### PR TITLE
Fix dealing with Unicode paths in v2 API

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -1,3 +1,6 @@
+# This file contains the base models that individual versioned models
+# are based on. They shouldn't be directly used with Api objects.
+
 # stdlib, alphabetical
 import json
 import logging
@@ -53,6 +56,7 @@ class PipelineResource(ModelResource):
         authorization = Authorization()
         # authorization = DjangoAuthorization()
         # validation = CleanedDataFormValidation(form_class=PipelineForm)
+        resource_name = 'pipeline'
 
         fields = ['uuid', 'description']
         list_allowed_methods = ['get', 'post']
@@ -82,6 +86,7 @@ class SpaceResource(ModelResource):
         authorization = Authorization()
         # authorization = DjangoAuthorization()
         validation = CleanedDataFormValidation(form_class=SpaceForm)
+        resource_name = 'space'
 
         fields = ['access_protocol', 'last_verified', 'location_set', 'path',
             'size', 'used', 'uuid', 'verified']
@@ -140,6 +145,10 @@ class SpaceResource(ModelResource):
         obj.save()
         return bundle
 
+    def get_objects(self, space, path):
+        message = 'This method should be accessed via a versioned subclass'
+        raise NotImplementedError(message)
+
     def browse(self, request, **kwargs):
         """ Returns all of the entries in a space, optionally at a subpath.
 
@@ -157,7 +166,7 @@ class SpaceResource(ModelResource):
         space = Space.objects.get(uuid=kwargs['uuid'])
         path = os.path.join(space.path, path)
 
-        objects = space.browse(path)
+        objects = self.get_objects(space, path)
 
         self.log_throttled_access(request)
         return self.create_response(request, objects)
@@ -177,6 +186,7 @@ class LocationResource(ModelResource):
         authorization = Authorization()
         # authorization = DjangoAuthorization()
         # validation = CleanedDataFormValidation(form_class=LocationForm)
+        resource_name = 'location'
 
         fields = ['enabled', 'relative_path', 'purpose', 'quota', 'used', 'uuid']
         list_allowed_methods = ['get']
@@ -198,6 +208,13 @@ class LocationResource(ModelResource):
             url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/browse%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('browse'), name="browse"),
         ]
 
+    def decode_path(self, path):
+        return path
+
+    def get_objects(self, space, path):
+        message = 'This method should be accessed via a versioned subclass'
+        raise NotImplementedError(message)
+
     def browse(self, request, **kwargs):
         """ Returns all of the entries in a location, optionally at a subpath.
 
@@ -212,10 +229,11 @@ class LocationResource(ModelResource):
         self.is_authenticated(request)
         self.throttle_check(request)
         path = request.GET.get('path', '')
+        path = self.decode_path(path)
         location = Location.objects.get(uuid=kwargs['uuid'])
-        path = os.path.join(location.full_path(), path)
+        path = os.path.join(str(location.full_path()), path)
 
-        objects = location.space.browse(path)
+        objects = self.get_objects(location.space, path)
 
         self.log_throttled_access(request)
         return self.create_response(request, objects)
@@ -256,6 +274,7 @@ class PackageResource(ModelResource):
         authorization = Authorization()
         # authorization = DjangoAuthorization()
         # validation = CleanedDataFormValidation(form_class=PackageForm)
+        resource_name = 'package'
 
         fields = ['current_path', 'package_type', 'size', 'status', 'uuid']
         list_allowed_methods = ['get', 'post']

--- a/storage_service/locations/api/urls.py
+++ b/storage_service/locations/api/urls.py
@@ -1,15 +1,21 @@
 from django.conf.urls import patterns, include, url
 from tastypie.api import Api
-from .resources import (LocationResource, SpaceResource, PackageResource,
-    PipelineResource)
+from locations.api import v1, v2
 
 v1_api = Api(api_name='v1')
-v1_api.register(SpaceResource())
-v1_api.register(LocationResource())
-v1_api.register(PackageResource())
-v1_api.register(PipelineResource())
+v1_api.register(v1.SpaceResource())
+v1_api.register(v1.LocationResource())
+v1_api.register(v1.PackageResource())
+v1_api.register(v1.PipelineResource())
 
+
+v2_api = Api(api_name='v2')
+v2_api.register(v2.SpaceResource())
+v2_api.register(v2.LocationResource())
+v2_api.register(v2.PackageResource())
+v2_api.register(v2.PipelineResource())
 
 urlpatterns = patterns('',
     (r'', include(v1_api.urls)),
+    (r'', include(v2_api.urls)),
 )

--- a/storage_service/locations/api/v1.py
+++ b/storage_service/locations/api/v1.py
@@ -1,0 +1,32 @@
+import locations.api.resources as resources
+
+from tastypie import fields
+
+
+class PipelineResource(resources.PipelineResource):
+    create_default_locations = fields.BooleanField(use_in=lambda x: False)
+    shared_path = fields.CharField(use_in=lambda x: False)
+
+
+class SpaceResource(resources.SpaceResource):
+    def get_objects(self, space, path):
+        return space.browse(path)
+
+
+class LocationResource(resources.LocationResource):
+    space = fields.ForeignKey(SpaceResource, 'space')
+    path = fields.CharField(attribute='full_path', readonly=True)
+    description = fields.CharField(attribute='get_description', readonly=True)
+    pipeline = fields.ToManyField(PipelineResource, 'pipeline')
+
+    def get_objects(self, space, path):
+        return space.browse(path)
+
+
+class PackageResource(resources.PackageResource):
+    origin_pipeline = fields.ForeignKey(PipelineResource, 'origin_pipeline')
+    origin_location = fields.ForeignKey(LocationResource, None, use_in=lambda x: False)
+    origin_path = fields.CharField(use_in=lambda x: False)
+    current_location = fields.ForeignKey(LocationResource, 'current_location')
+
+    current_full_path = fields.CharField(attribute='full_path', readonly=True)

--- a/storage_service/locations/api/v2.py
+++ b/storage_service/locations/api/v2.py
@@ -1,0 +1,45 @@
+import base64
+
+import locations.api.resources as resources
+
+from tastypie import fields
+
+
+class PipelineResource(resources.PipelineResource):
+    create_default_locations = fields.BooleanField(use_in=lambda x: False)
+    shared_path = fields.CharField(use_in=lambda x: False)
+
+
+class SpaceResource(resources.SpaceResource):
+    def get_objects(self, space, path):
+        objects = space.browse(path)
+        objects['entries'] = map(base64.b64encode, objects['entries'])
+        objects['directories'] = map(base64.b64encode, objects['directories'])
+
+        return objects
+
+
+class LocationResource(resources.LocationResource):
+    space = fields.ForeignKey(SpaceResource, 'space')
+    path = fields.CharField(attribute='full_path', readonly=True)
+    description = fields.CharField(attribute='get_description', readonly=True)
+    pipeline = fields.ToManyField(PipelineResource, 'pipeline')
+
+    def decode_path(self, path):
+        return str(base64.b64decode(path))
+
+    def get_objects(self, space, path):
+        objects = space.browse(path)
+        objects['entries'] = map(base64.b64encode, objects['entries'])
+        objects['directories'] = map(base64.b64encode, objects['directories'])
+
+        return objects
+
+
+class PackageResource(resources.PackageResource):
+    origin_pipeline = fields.ForeignKey(PipelineResource, 'origin_pipeline')
+    origin_location = fields.ForeignKey(LocationResource, None, use_in=lambda x: False)
+    origin_path = fields.CharField(use_in=lambda x: False)
+    current_location = fields.ForeignKey(LocationResource, 'current_location')
+
+    current_full_path = fields.CharField(attribute='full_path', readonly=True)

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -127,6 +127,8 @@ class Space(models.Model):
         if self.access_protocol in self.mounted_locally:
             # Sorted list of all entries in directory, excluding hidden files
             # This may need magic for encoding/decoding, but doesn't seem to
+            if isinstance(path, unicode):
+                path = str(path)
             entries = [name for name in os.listdir(path) if name[0] != '.']
             entries = sorted(entries, key=lambda s: s.lower())
             directories = []

--- a/storage_service/static/js/file-explorer.js
+++ b/storage_service/static/js/file-explorer.js
@@ -199,6 +199,10 @@
           var child = entry.children[index]
             , allowDisplay = true;
 
+          // names are base64-encoded from the server; needs to be
+          // decoded for human reading
+          child.attributes.name = Base64.decode(child.attributes.name);
+
           if (self.entryDisplayFilter) {
             allowDisplay = self.entryDisplayFilter(child);
           }

--- a/storage_service/static/js/vendor/base64.js
+++ b/storage_service/static/js/vendor/base64.js
@@ -1,0 +1,216 @@
+/*
+Copyright (c) 2008 Fred Palmer fred.palmer_at_gmail.com
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+function StringBuffer()
+{ 
+    this.buffer = []; 
+} 
+
+StringBuffer.prototype.append = function append(string)
+{ 
+    this.buffer.push(string); 
+    return this; 
+}; 
+
+StringBuffer.prototype.toString = function toString()
+{ 
+    return this.buffer.join(""); 
+}; 
+
+var Base64 =
+{
+    codex : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+
+    encode : function (input)
+    {
+        var output = new StringBuffer();
+
+        var enumerator = new Utf8EncodeEnumerator(input);
+        while (enumerator.moveNext())
+        {
+            var chr1 = enumerator.current;
+
+            enumerator.moveNext();
+            var chr2 = enumerator.current;
+
+            enumerator.moveNext();
+            var chr3 = enumerator.current;
+
+            var enc1 = chr1 >> 2;
+            var enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+            var enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+            var enc4 = chr3 & 63;
+
+            if (isNaN(chr2))
+            {
+                enc3 = enc4 = 64;
+            }
+            else if (isNaN(chr3))
+            {
+                enc4 = 64;
+            }
+
+            output.append(this.codex.charAt(enc1) + this.codex.charAt(enc2) + this.codex.charAt(enc3) + this.codex.charAt(enc4));
+        }
+
+        return output.toString();
+    },
+
+    decode : function (input)
+    {
+        var output = new StringBuffer();
+
+        var enumerator = new Base64DecodeEnumerator(input);
+        while (enumerator.moveNext())
+        {
+            var charCode = enumerator.current;
+
+            if (charCode < 128)
+                output.append(String.fromCharCode(charCode));
+            else if ((charCode > 191) && (charCode < 224))
+            {
+                enumerator.moveNext();
+                var charCode2 = enumerator.current;
+
+                output.append(String.fromCharCode(((charCode & 31) << 6) | (charCode2 & 63)));
+            }
+            else
+            {
+                enumerator.moveNext();
+                var charCode2 = enumerator.current;
+
+                enumerator.moveNext();
+                var charCode3 = enumerator.current;
+
+                output.append(String.fromCharCode(((charCode & 15) << 12) | ((charCode2 & 63) << 6) | (charCode3 & 63)));
+            }
+        }
+
+        return output.toString();
+    }
+}
+
+
+function Utf8EncodeEnumerator(input)
+{
+    this._input = input;
+    this._index = -1;
+    this._buffer = [];
+}
+
+Utf8EncodeEnumerator.prototype =
+{
+    current: Number.NaN,
+
+    moveNext: function()
+    {
+        if (this._buffer.length > 0)
+        {
+            this.current = this._buffer.shift();
+            return true;
+        }
+        else if (this._index >= (this._input.length - 1))
+        {
+            this.current = Number.NaN;
+            return false;
+        }
+        else
+        {
+            var charCode = this._input.charCodeAt(++this._index);
+
+            // "\r\n" -> "\n"
+            //
+            if ((charCode == 13) && (this._input.charCodeAt(this._index + 1) == 10))
+            {
+                charCode = 10;
+                this._index += 2;
+            }
+
+            if (charCode < 128)
+            {
+                this.current = charCode;
+            }
+            else if ((charCode > 127) && (charCode < 2048))
+            {
+                this.current = (charCode >> 6) | 192;
+                this._buffer.push((charCode & 63) | 128);
+            }
+            else
+            {
+                this.current = (charCode >> 12) | 224;
+                this._buffer.push(((charCode >> 6) & 63) | 128);
+                this._buffer.push((charCode & 63) | 128);
+            }
+
+            return true;
+        }
+    }
+}
+
+function Base64DecodeEnumerator(input)
+{
+    this._input = input;
+    this._index = -1;
+    this._buffer = [];
+}
+
+Base64DecodeEnumerator.prototype =
+{
+    current: 64,
+
+    moveNext: function()
+    {
+        if (this._buffer.length > 0)
+        {
+            this.current = this._buffer.shift();
+            return true;
+        }
+        else if (this._index >= (this._input.length - 1))
+        {
+            this.current = 64;
+            return false;
+        }
+        else
+        {
+            var enc1 = Base64.codex.indexOf(this._input.charAt(++this._index));
+            var enc2 = Base64.codex.indexOf(this._input.charAt(++this._index));
+            var enc3 = Base64.codex.indexOf(this._input.charAt(++this._index));
+            var enc4 = Base64.codex.indexOf(this._input.charAt(++this._index));
+
+            var chr1 = (enc1 << 2) | (enc2 >> 4);
+            var chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+            var chr3 = ((enc3 & 3) << 6) | enc4;
+
+            this.current = chr1;
+
+            if (enc3 != 64)
+                this._buffer.push(chr2);
+
+            if (enc4 != 64)
+                this._buffer.push(chr3);
+
+            return true;
+        }
+    }
+};

--- a/storage_service/templates/locations/location_form.html
+++ b/storage_service/templates/locations/location_form.html
@@ -31,6 +31,7 @@
   <script type="text/javascript" src="{{ STATIC_URL }}js/file-explorer.js"></script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/directory_picker.js"></script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/single_directory_picker.js"></script>
+  <script type="text/javascript" src="{{ STATIC_URL }}js/vendor/base64.js"></script>
 
   <script>
     $(document).ready(function() {

--- a/storage_service/templates/locations/location_form.html
+++ b/storage_service/templates/locations/location_form.html
@@ -42,7 +42,7 @@
         'id_relative_path',
         'id_relative_path_browse',
         'directory_picker',
-        '/api/v1/space/{{ space.uuid }}/browse/'
+        '/api/v2/space/{{ space.uuid }}/browse/'
       );
     });
   </script>


### PR DESCRIPTION
This adds a new API revision, v2, which attempts to deal with the many problems we've had dealing with Unicode paths.

Paths are basically bytestrings to the OS, and we've caused ourselves a lot of grief by trying to treat them as sets of characters instead of bytes. v2 of the API sidesteps this by treating all paths as sets of arbitrary bytes, and communicates them to/from outside services in base64-encoded strings.

The tastypie resources are now separated out into base classes and versioned classes, which inherit from the base resources.

This will get squashed down a bit on merge.
