### PR TITLE
Move files more generic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+archivematica-storage-service (0.3.0.rc10) UNRELEASED; urgency=low
+
+  * Add migrations and uninstall to debian packaging
+
+ -- Justin Simpson <jhs@inex>  Tue, 08 Apr 2014 16:25:34 -0700
+
 archivematica-storage-service (0.2.0) precise; urgency=low
 
   * updated to 0.2.2

--- a/debian/postinst
+++ b/debian/postinst
@@ -28,7 +28,9 @@ cd /usr/lib/archivematica/storage-service
 
 echo "configuring django database and static files"
 /usr/share/python/archivematica-storage-service/bin/python manage.py syncdb
+/usr/share/python/archivematica-storage-service/bin/python manage.py migrate
 /usr/share/python/archivematica-storage-service/bin/python manage.py collectstatic --noinput
+
 
 echo "updating directory permissions"
 chown -R archivematica:archivematica /var/archivematica/

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+#postrm 
+#run after the package is uninstalled
+
+#clean up storage service directories
+rm -rf /usr/share/python/archivematica-storage-service
+rm -rf /var/archivematica/storage*
+rm -r /var/archivematica/.storage-service
+rm -f /tmp/storage-service.log
+rm -f /etc/nginx/sites-enabled/storage
+rm -f /etc/nginx/sites-available/storage
+rm -f /etc/uwsgi/apps-enabled/storage.ini
+rm -f /etc/uwsgi/apps-available/storage.ini
+rm -rf /usr/lib/archivematica/storage*
+
+#DEBHELPER#
+

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ Django==1.5.4
 django-braces==1.0.0
 django-model-utils==1.3.1
 logutils==0.3.3
-South==0.8.1
+South==0.8.4
 django-tastypie==0.9.15
 django-extensions==1.1.1
 lxml==3.2.3

--- a/storage_service/administration/migrations/0001_initial.py
+++ b/storage_service/administration/migrations/0001_initial.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        pass
+
+    def backwards(self, orm):
+        pass
+
+    models = {
+        
+    }
+
+    complete_apps = ['administration']

--- a/storage_service/administration/migrations/0002_v0_2_2.py
+++ b/storage_service/administration/migrations/0002_v0_2_2.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Settings'
+        db.create_table(u'administration_settings', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),
+            ('value', self.gf('django.db.models.fields.TextField')(null=True, blank=True)),
+        ))
+        db.send_create_signal(u'administration', ['Settings'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Settings'
+        db.delete_table(u'administration_settings')
+
+
+    models = {
+        u'administration.settings': {
+            'Meta': {'object_name': 'Settings'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'value': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['administration']

--- a/storage_service/administration/migrations/0003_v0_3_0.py
+++ b/storage_service/administration/migrations/0003_v0_3_0.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName". 
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'administration.settings': {
+            'Meta': {'object_name': 'Settings'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'value': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['administration']
+    symmetrical = True

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -362,48 +362,59 @@ class PackageResource(ModelResource):
             mimetype='application/json')
 
     def extract_file_request(self, request, **kwargs):
+        """
+        Returns a single file from the Package, extracting if necessary.
+        """
         relative_path_to_file = request.GET.get('relative_path_to_file')
+        temp_dir = ''
 
         # Tastypie checks
         self.method_check(request, allowed=['get'])
         self.is_authenticated(request)
         self.throttle_check(request)
 
-        # Get AIP details
+        # Get Package details
         package = Package.objects.get(uuid=kwargs['uuid'])
-        if package.package_type not in Package.PACKAGE_TYPE_EXTRACTABLE:
-            # Can only extract files from AIPs
-            return http.HttpMethodNotAllowed()
+        full_path = package.full_path()
 
-        # create temp dir to extract to
-        temp_dir = tempfile.mkdtemp()
+        local_path = os.path.join(full_path, relative_path_to_file)
+        if os.path.exists(local_path):
+            # Local file exists - return that
+            extracted_file_path = local_path
+        elif package.package_type in Package.PACKAGE_TYPE_EXTRACTABLE:
+            # If file doesn't exist, try to extract it
 
-        filename, file_extension = os.path.splitext(package.full_path())
+            # Create temp dir to extract to
+            # TODO store this somewhere well known, so we don't clutter up
+            # filesystem with duplicates of files?
+            temp_dir = tempfile.mkdtemp()
 
-        # extract file from AIP
-        if file_extension == '.bz2':
-            command_data = [
-                'tar',
-                'xvjf',
-                package.full_path(),
-                '-C' + temp_dir,
-                relative_path_to_file
-            ]
-        else:
-            command_data = [
-                '7za',
-                'e',
-                '-o' + temp_dir,
-                package.full_path(),
-                relative_path_to_file
-            ]
+            filename, file_extension = os.path.splitext(full_path)
 
-        subprocess.call(command_data)
-        # send extracted file
-        if file_extension == '.bz2':
-            extracted_file_path = os.path.join(temp_dir, relative_path_to_file)
-        else:
-            extracted_file_path = os.path.join(temp_dir, os.path.basename(relative_path_to_file))
+            # extract file from Package
+            if file_extension == '.bz2':
+                command_data = [
+                    'tar',
+                    'xvjf',
+                    full_path,
+                    '-C' + temp_dir,
+                    relative_path_to_file
+                ]
+            else:
+                command_data = [
+                    '7za',
+                    'e',
+                    '-o' + temp_dir,
+                    full_path,
+                    relative_path_to_file
+                ]
+
+            subprocess.call(command_data)
+            # send extracted file
+            if file_extension == '.bz2':
+                extracted_file_path = os.path.join(temp_dir, relative_path_to_file)
+            else:
+                extracted_file_path = os.path.join(temp_dir, os.path.basename(relative_path_to_file))
 
         # If not found, return 404
         if not os.path.exists(extracted_file_path):
@@ -427,12 +438,17 @@ class PackageResource(ModelResource):
 
         response['Content-Length'] = os.path.getsize(extracted_file_path)
 
-        self.log_throttled_access(request)
+        # Delete temp dir if created
+        if os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir)
 
-        shutil.rmtree(temp_dir)
+        self.log_throttled_access(request)
         return response
 
     def download_request(self, request, **kwargs):
+        """
+        Returns the entire Package to be downloaded.
+        """
         # Tastypie checks
         self.method_check(request, allowed=['get'])
         self.is_authenticated(request)
@@ -441,7 +457,8 @@ class PackageResource(ModelResource):
         # Get AIP details
         package = Package.objects.get(uuid=kwargs['uuid'])
         if package.package_type not in Package.PACKAGE_TYPE_EXTRACTABLE:
-            # Can only extract files from AIPs
+            # Can only return packages that are a single file
+            # TODO Update to zip up a transfer before returning it?
             return http.HttpMethodNotAllowed()
 
         filename = os.path.basename(package.full_path())

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -1,3 +1,6 @@
+# This file contains the base models that individual versioned models
+# are based on. They shouldn't be directly used with Api objects.
+
 # stdlib, alphabetical
 import json
 import logging
@@ -53,6 +56,7 @@ class PipelineResource(ModelResource):
         authorization = Authorization()
         # authorization = DjangoAuthorization()
         # validation = CleanedDataFormValidation(form_class=PipelineForm)
+        resource_name = 'pipeline'
 
         fields = ['uuid', 'description']
         list_allowed_methods = ['get', 'post']
@@ -82,6 +86,7 @@ class SpaceResource(ModelResource):
         authorization = Authorization()
         # authorization = DjangoAuthorization()
         validation = CleanedDataFormValidation(form_class=SpaceForm)
+        resource_name = 'space'
 
         fields = ['access_protocol', 'last_verified', 'location_set', 'path',
             'size', 'used', 'uuid', 'verified']
@@ -140,6 +145,10 @@ class SpaceResource(ModelResource):
         obj.save()
         return bundle
 
+    def get_objects(self, space, path):
+        message = 'This method should be accessed via a versioned subclass'
+        raise NotImplementedError(message)
+
     def browse(self, request, **kwargs):
         """ Returns all of the entries in a space, optionally at a subpath.
 
@@ -157,7 +166,7 @@ class SpaceResource(ModelResource):
         space = Space.objects.get(uuid=kwargs['uuid'])
         path = os.path.join(space.path, path)
 
-        objects = space.browse(path)
+        objects = self.get_objects(space, path)
 
         self.log_throttled_access(request)
         return self.create_response(request, objects)
@@ -177,6 +186,7 @@ class LocationResource(ModelResource):
         authorization = Authorization()
         # authorization = DjangoAuthorization()
         # validation = CleanedDataFormValidation(form_class=LocationForm)
+        resource_name = 'location'
 
         fields = ['enabled', 'relative_path', 'purpose', 'quota', 'used', 'uuid']
         list_allowed_methods = ['get']
@@ -198,6 +208,13 @@ class LocationResource(ModelResource):
             url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/browse%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('browse'), name="browse"),
         ]
 
+    def decode_path(self, path):
+        return path
+
+    def get_objects(self, space, path):
+        message = 'This method should be accessed via a versioned subclass'
+        raise NotImplementedError(message)
+
     def browse(self, request, **kwargs):
         """ Returns all of the entries in a location, optionally at a subpath.
 
@@ -212,10 +229,11 @@ class LocationResource(ModelResource):
         self.is_authenticated(request)
         self.throttle_check(request)
         path = request.GET.get('path', '')
+        path = self.decode_path(path)
         location = Location.objects.get(uuid=kwargs['uuid'])
-        path = os.path.join(location.full_path(), path)
+        path = os.path.join(str(location.full_path()), path)
 
-        objects = location.space.browse(path)
+        objects = self.get_objects(location.space, path)
 
         self.log_throttled_access(request)
         return self.create_response(request, objects)
@@ -256,6 +274,7 @@ class PackageResource(ModelResource):
         authorization = Authorization()
         # authorization = DjangoAuthorization()
         # validation = CleanedDataFormValidation(form_class=PackageForm)
+        resource_name = 'package'
 
         fields = ['current_path', 'package_type', 'size', 'status', 'uuid']
         list_allowed_methods = ['get', 'post']

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -268,14 +268,17 @@ class PackageResource(ModelResource):
 
     class Meta:
         queryset = Package.objects.all()
-        resource_name = 'file'
         authentication = Authentication()
         # authentication = MultiAuthentication(
         #     BasicAuthentication, ApiKeyAuthentication())
         authorization = Authorization()
         # authorization = DjangoAuthorization()
         # validation = CleanedDataFormValidation(form_class=PackageForm)
-        resource_name = 'package'
+        #
+        # Note that this resource is exposed as 'file' to the API for
+        # compatibility because the resource itself was originally under
+        # that name.
+        resource_name = 'file'
 
         fields = ['current_path', 'package_type', 'size', 'status', 'uuid']
         list_allowed_methods = ['get', 'post']

--- a/storage_service/locations/api/urls.py
+++ b/storage_service/locations/api/urls.py
@@ -1,15 +1,21 @@
 from django.conf.urls import patterns, include, url
 from tastypie.api import Api
-from .resources import (LocationResource, SpaceResource, PackageResource,
-    PipelineResource)
+from locations.api import v1, v2
 
 v1_api = Api(api_name='v1')
-v1_api.register(SpaceResource())
-v1_api.register(LocationResource())
-v1_api.register(PackageResource())
-v1_api.register(PipelineResource())
+v1_api.register(v1.SpaceResource())
+v1_api.register(v1.LocationResource())
+v1_api.register(v1.PackageResource())
+v1_api.register(v1.PipelineResource())
 
+
+v2_api = Api(api_name='v2')
+v2_api.register(v2.SpaceResource())
+v2_api.register(v2.LocationResource())
+v2_api.register(v2.PackageResource())
+v2_api.register(v2.PipelineResource())
 
 urlpatterns = patterns('',
     (r'', include(v1_api.urls)),
+    (r'', include(v2_api.urls)),
 )

--- a/storage_service/locations/api/v1.py
+++ b/storage_service/locations/api/v1.py
@@ -1,0 +1,32 @@
+import locations.api.resources as resources
+
+from tastypie import fields
+
+
+class PipelineResource(resources.PipelineResource):
+    create_default_locations = fields.BooleanField(use_in=lambda x: False)
+    shared_path = fields.CharField(use_in=lambda x: False)
+
+
+class SpaceResource(resources.SpaceResource):
+    def get_objects(self, space, path):
+        return space.browse(path)
+
+
+class LocationResource(resources.LocationResource):
+    space = fields.ForeignKey(SpaceResource, 'space')
+    path = fields.CharField(attribute='full_path', readonly=True)
+    description = fields.CharField(attribute='get_description', readonly=True)
+    pipeline = fields.ToManyField(PipelineResource, 'pipeline')
+
+    def get_objects(self, space, path):
+        return space.browse(path)
+
+
+class PackageResource(resources.PackageResource):
+    origin_pipeline = fields.ForeignKey(PipelineResource, 'origin_pipeline')
+    origin_location = fields.ForeignKey(LocationResource, None, use_in=lambda x: False)
+    origin_path = fields.CharField(use_in=lambda x: False)
+    current_location = fields.ForeignKey(LocationResource, 'current_location')
+
+    current_full_path = fields.CharField(attribute='full_path', readonly=True)

--- a/storage_service/locations/api/v2.py
+++ b/storage_service/locations/api/v2.py
@@ -1,0 +1,45 @@
+import base64
+
+import locations.api.resources as resources
+
+from tastypie import fields
+
+
+class PipelineResource(resources.PipelineResource):
+    create_default_locations = fields.BooleanField(use_in=lambda x: False)
+    shared_path = fields.CharField(use_in=lambda x: False)
+
+
+class SpaceResource(resources.SpaceResource):
+    def get_objects(self, space, path):
+        objects = space.browse(path)
+        objects['entries'] = map(base64.b64encode, objects['entries'])
+        objects['directories'] = map(base64.b64encode, objects['directories'])
+
+        return objects
+
+
+class LocationResource(resources.LocationResource):
+    space = fields.ForeignKey(SpaceResource, 'space')
+    path = fields.CharField(attribute='full_path', readonly=True)
+    description = fields.CharField(attribute='get_description', readonly=True)
+    pipeline = fields.ToManyField(PipelineResource, 'pipeline')
+
+    def decode_path(self, path):
+        return str(base64.b64decode(path))
+
+    def get_objects(self, space, path):
+        objects = space.browse(path)
+        objects['entries'] = map(base64.b64encode, objects['entries'])
+        objects['directories'] = map(base64.b64encode, objects['directories'])
+
+        return objects
+
+
+class PackageResource(resources.PackageResource):
+    origin_pipeline = fields.ForeignKey(PipelineResource, 'origin_pipeline')
+    origin_location = fields.ForeignKey(LocationResource, None, use_in=lambda x: False)
+    origin_path = fields.CharField(use_in=lambda x: False)
+    current_location = fields.ForeignKey(LocationResource, 'current_location')
+
+    current_full_path = fields.CharField(attribute='full_path', readonly=True)

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -18,7 +18,7 @@ class PipelineForm(forms.ModelForm):
 class SpaceForm(forms.ModelForm):
     class Meta:
         model = Space
-        fields = ('access_protocol', 'size', 'path')
+        fields = ('access_protocol', 'size', 'path', 'staging_path')
 
     def __init__(self, *args, **kwargs):
         super(SpaceForm, self).__init__(*args, **kwargs)

--- a/storage_service/locations/migrations/0002_v0_2_2.py
+++ b/storage_service/locations/migrations/0002_v0_2_2.py
@@ -1,0 +1,269 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Pipeline'
+        db.create_table(u'locations_pipeline', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('uuid', self.gf('django.db.models.fields.CharField')(unique=True, max_length=36)),
+            ('description', self.gf('django.db.models.fields.CharField')(default=None, max_length=256, null=True, blank=True)),
+            ('enabled', self.gf('django.db.models.fields.BooleanField')(default=True)),
+        ))
+        db.send_create_signal(u'locations', ['Pipeline'])
+
+        # Adding model 'Package'
+        db.create_table(u'locations_package', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('uuid', self.gf('django.db.models.fields.CharField')(unique=True, max_length=36, blank=True)),
+            ('origin_pipeline', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['locations.Pipeline'], to_field='uuid')),
+            ('current_location', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['locations.Location'], to_field='uuid')),
+            ('current_path', self.gf('django.db.models.fields.TextField')()),
+            ('pointer_file_location', self.gf('django.db.models.fields.related.ForeignKey')(blank=True, related_name='+', to_field='uuid', null=True, to=orm['locations.Location'])),
+            ('pointer_file_path', self.gf('django.db.models.fields.TextField')(null=True, blank=True)),
+            ('size', self.gf('django.db.models.fields.IntegerField')(default=0)),
+            ('package_type', self.gf('django.db.models.fields.CharField')(max_length=8)),
+            ('status', self.gf('django.db.models.fields.CharField')(default='FAIL', max_length=8)),
+        ))
+        db.send_create_signal(u'locations', ['Package'])
+
+        # Adding model 'NFS'
+        db.create_table(u'locations_nfs', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('space', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['locations.Space'], to_field='uuid', unique=True)),
+            ('remote_name', self.gf('django.db.models.fields.CharField')(max_length=256)),
+            ('remote_path', self.gf('django.db.models.fields.TextField')()),
+            ('version', self.gf('django.db.models.fields.CharField')(default='nfs4', max_length=64)),
+            ('manually_mounted', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal(u'locations', ['NFS'])
+
+        # Adding model 'Event'
+        db.create_table(u'locations_event', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('package', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['locations.Package'], to_field='uuid')),
+            ('event_type', self.gf('django.db.models.fields.CharField')(max_length=8)),
+            ('event_reason', self.gf('django.db.models.fields.TextField')()),
+            ('pipeline', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['locations.Pipeline'], to_field='uuid')),
+            ('user_id', self.gf('django.db.models.fields.PositiveIntegerField')()),
+            ('user_email', self.gf('django.db.models.fields.EmailField')(max_length=254)),
+            ('status', self.gf('django.db.models.fields.CharField')(max_length=8)),
+            ('status_reason', self.gf('django.db.models.fields.TextField')(null=True, blank=True)),
+            ('admin_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'], null=True, blank=True)),
+            ('status_time', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),
+            ('store_data', self.gf('django.db.models.fields.TextField')(null=True, blank=True)),
+        ))
+        db.send_create_signal(u'locations', ['Event'])
+
+        # Adding model 'Location'
+        db.create_table(u'locations_location', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('uuid', self.gf('django.db.models.fields.CharField')(unique=True, max_length=36, blank=True)),
+            ('space', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['locations.Space'], to_field='uuid')),
+            ('purpose', self.gf('django.db.models.fields.CharField')(max_length=2)),
+            ('relative_path', self.gf('django.db.models.fields.TextField')()),
+            ('description', self.gf('django.db.models.fields.CharField')(default=None, max_length=256, null=True, blank=True)),
+            ('quota', self.gf('django.db.models.fields.BigIntegerField')(default=None, null=True, blank=True)),
+            ('used', self.gf('django.db.models.fields.BigIntegerField')(default=0)),
+            ('enabled', self.gf('django.db.models.fields.BooleanField')(default=True)),
+        ))
+        db.send_create_signal(u'locations', ['Location'])
+
+        # Adding model 'LocalFilesystem'
+        db.create_table(u'locations_localfilesystem', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('space', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['locations.Space'], to_field='uuid', unique=True)),
+        ))
+        db.send_create_signal(u'locations', ['LocalFilesystem'])
+
+        # Adding model 'LocationPipeline'
+        db.create_table(u'locations_locationpipeline', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('location', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['locations.Location'], to_field='uuid')),
+            ('pipeline', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['locations.Pipeline'], to_field='uuid')),
+        ))
+        db.send_create_signal(u'locations', ['LocationPipeline'])
+
+        # Adding model 'PipelineLocalFS'
+        db.create_table(u'locations_pipelinelocalfs', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('space', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['locations.Space'], to_field='uuid', unique=True)),
+            ('remote_user', self.gf('django.db.models.fields.CharField')(max_length=64)),
+            ('remote_name', self.gf('django.db.models.fields.CharField')(max_length=256)),
+        ))
+        db.send_create_signal(u'locations', ['PipelineLocalFS'])
+
+        # Adding model 'Space'
+        db.create_table(u'locations_space', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('uuid', self.gf('django.db.models.fields.CharField')(unique=True, max_length=36, blank=True)),
+            ('access_protocol', self.gf('django.db.models.fields.CharField')(max_length=8)),
+            ('size', self.gf('django.db.models.fields.BigIntegerField')(default=None, null=True, blank=True)),
+            ('used', self.gf('django.db.models.fields.BigIntegerField')(default=0)),
+            ('path', self.gf('django.db.models.fields.TextField')()),
+            ('verified', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('last_verified', self.gf('django.db.models.fields.DateTimeField')(default=None, null=True, blank=True)),
+        ))
+        db.send_create_signal(u'locations', ['Space'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Pipeline'
+        db.delete_table(u'locations_pipeline')
+
+        # Deleting model 'Package'
+        db.delete_table(u'locations_package')
+
+        # Deleting model 'NFS'
+        db.delete_table(u'locations_nfs')
+
+        # Deleting model 'Event'
+        db.delete_table(u'locations_event')
+
+        # Deleting model 'Location'
+        db.delete_table(u'locations_location')
+
+        # Deleting model 'LocalFilesystem'
+        db.delete_table(u'locations_localfilesystem')
+
+        # Deleting model 'LocationPipeline'
+        db.delete_table(u'locations_locationpipeline')
+
+        # Deleting model 'PipelineLocalFS'
+        db.delete_table(u'locations_pipelinelocalfs')
+
+        # Deleting model 'Space'
+        db.delete_table(u'locations_space')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'locations.event': {
+            'Meta': {'object_name': 'Event'},
+            'admin_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'event_reason': ('django.db.models.fields.TextField', [], {}),
+            'event_type': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Package']", 'to_field': "'uuid'"}),
+            'pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'status_reason': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'store_data': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'user_email': ('django.db.models.fields.EmailField', [], {'max_length': '254'}),
+            'user_id': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        u'locations.localfilesystem': {
+            'Meta': {'object_name': 'LocalFilesystem'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
+        u'locations.location': {
+            'Meta': {'object_name': 'Location'},
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pipeline': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['locations.Pipeline']", 'null': 'True', 'through': u"orm['locations.LocationPipeline']", 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'quota': ('django.db.models.fields.BigIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'relative_path': ('django.db.models.fields.TextField', [], {}),
+            'space': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'"}),
+            'used': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.locationpipeline': {
+            'Meta': {'object_name': 'LocationPipeline'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Location']", 'to_field': "'uuid'"}),
+            'pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"})
+        },
+        u'locations.nfs': {
+            'Meta': {'object_name': 'NFS'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'manually_mounted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'remote_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'remote_path': ('django.db.models.fields.TextField', [], {}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'default': "'nfs4'", 'max_length': '64'})
+        },
+        u'locations.package': {
+            'Meta': {'object_name': 'Package'},
+            'current_location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Location']", 'to_field': "'uuid'"}),
+            'current_path': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'origin_pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"}),
+            'package_type': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'pointer_file_location': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'to_field': "'uuid'", 'null': 'True', 'to': u"orm['locations.Location']"}),
+            'pointer_file_path': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'size': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'FAIL'", 'max_length': '8'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.pipeline': {
+            'Meta': {'object_name': 'Pipeline'},
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36'})
+        },
+        u'locations.pipelinelocalfs': {
+            'Meta': {'object_name': 'PipelineLocalFS'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'remote_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'remote_user': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
+        u'locations.space': {
+            'Meta': {'object_name': 'Space'},
+            'access_protocol': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_verified': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.TextField', [], {}),
+            'size': ('django.db.models.fields.BigIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'used': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'}),
+            'verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['locations']

--- a/storage_service/locations/migrations/0003_v0_3_0.py
+++ b/storage_service/locations/migrations/0003_v0_3_0.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName". 
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'locations.event': {
+            'Meta': {'object_name': 'Event'},
+            'admin_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'event_reason': ('django.db.models.fields.TextField', [], {}),
+            'event_type': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Package']", 'to_field': "'uuid'"}),
+            'pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'status_reason': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'store_data': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'user_email': ('django.db.models.fields.EmailField', [], {'max_length': '254'}),
+            'user_id': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        u'locations.localfilesystem': {
+            'Meta': {'object_name': 'LocalFilesystem'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
+        u'locations.location': {
+            'Meta': {'object_name': 'Location'},
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pipeline': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['locations.Pipeline']", 'null': 'True', 'through': u"orm['locations.LocationPipeline']", 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'quota': ('django.db.models.fields.BigIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'relative_path': ('django.db.models.fields.TextField', [], {}),
+            'space': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'"}),
+            'used': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.locationpipeline': {
+            'Meta': {'object_name': 'LocationPipeline'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Location']", 'to_field': "'uuid'"}),
+            'pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"})
+        },
+        u'locations.nfs': {
+            'Meta': {'object_name': 'NFS'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'manually_mounted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'remote_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'remote_path': ('django.db.models.fields.TextField', [], {}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'default': "'nfs4'", 'max_length': '64'})
+        },
+        u'locations.package': {
+            'Meta': {'object_name': 'Package'},
+            'current_location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Location']", 'to_field': "'uuid'"}),
+            'current_path': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'origin_pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"}),
+            'package_type': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'pointer_file_location': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'to_field': "'uuid'", 'null': 'True', 'to': u"orm['locations.Location']"}),
+            'pointer_file_path': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'size': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'FAIL'", 'max_length': '8'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.pipeline': {
+            'Meta': {'object_name': 'Pipeline'},
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36'})
+        },
+        u'locations.pipelinelocalfs': {
+            'Meta': {'object_name': 'PipelineLocalFS'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'remote_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'remote_user': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
+        u'locations.space': {
+            'Meta': {'object_name': 'Space'},
+            'access_protocol': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_verified': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.TextField', [], {}),
+            'size': ('django.db.models.fields.BigIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'used': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'}),
+            'verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['locations']
+    symmetrical = True

--- a/storage_service/locations/migrations/0004_v0_4_0.py
+++ b/storage_service/locations/migrations/0004_v0_4_0.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Space.staging_path'
+        db.add_column(u'locations_space', 'staging_path',
+                      self.gf('django.db.models.fields.TextField')(default='/var/archivematica/storage_service/'),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Space.staging_path'
+        db.delete_column(u'locations_space', 'staging_path')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'locations.event': {
+            'Meta': {'object_name': 'Event'},
+            'admin_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'event_reason': ('django.db.models.fields.TextField', [], {}),
+            'event_type': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Package']", 'to_field': "'uuid'"}),
+            'pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'status_reason': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'store_data': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'user_email': ('django.db.models.fields.EmailField', [], {'max_length': '254'}),
+            'user_id': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        u'locations.localfilesystem': {
+            'Meta': {'object_name': 'LocalFilesystem'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
+        u'locations.location': {
+            'Meta': {'object_name': 'Location'},
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pipeline': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['locations.Pipeline']", 'null': 'True', 'through': u"orm['locations.LocationPipeline']", 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'quota': ('django.db.models.fields.BigIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'relative_path': ('django.db.models.fields.TextField', [], {}),
+            'space': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'"}),
+            'used': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.locationpipeline': {
+            'Meta': {'object_name': 'LocationPipeline'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Location']", 'to_field': "'uuid'"}),
+            'pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"})
+        },
+        u'locations.nfs': {
+            'Meta': {'object_name': 'NFS'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'manually_mounted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'remote_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'remote_path': ('django.db.models.fields.TextField', [], {}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'default': "'nfs4'", 'max_length': '64'})
+        },
+        u'locations.package': {
+            'Meta': {'object_name': 'Package'},
+            'current_location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Location']", 'to_field': "'uuid'"}),
+            'current_path': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'origin_pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"}),
+            'package_type': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'pointer_file_location': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'to_field': "'uuid'", 'null': 'True', 'to': u"orm['locations.Location']"}),
+            'pointer_file_path': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'size': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'FAIL'", 'max_length': '8'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.pipeline': {
+            'Meta': {'object_name': 'Pipeline'},
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36'})
+        },
+        u'locations.pipelinelocalfs': {
+            'Meta': {'object_name': 'PipelineLocalFS'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'remote_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'remote_user': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
+        u'locations.space': {
+            'Meta': {'object_name': 'Space'},
+            'access_protocol': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_verified': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.TextField', [], {}),
+            'size': ('django.db.models.fields.BigIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'staging_path': ('django.db.models.fields.TextField', [], {}),
+            'used': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'}),
+            'verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['locations']

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -172,15 +172,150 @@ class Space(models.Model):
             entries = []
         return {'directories': directories, 'entries': entries}
 
+    def move_to_storage_service(self, source_path, destination_path,
+                                destination_space, *args, **kwargs):
+        """ Move source_path to destination_path in the staging area of destination_space.
+
+        If source_path is not an absolute path, it is assumed to be relative to
+        Space.path.
+
+        destination_path must be relative and destination_space.staging_path
+        MUST be locally accessible to the storage service.
+
+        This is implemented by the child protocol spaces.
+        """
+        logging.debug('TO: src: {}'.format(source_path))
+        logging.debug('TO: dst: {}'.format(destination_path))
+        logging.debug('TO: staging: {}'.format(destination_space.staging_path))
+        # TODO move the path mangling to here?
+        # TODO enforce source_path is inside self.path
+        try:
+            self.get_child_space().move_to_storage_service(
+                source_path, destination_path, destination_space, *args, **kwargs)
+        except AttributeError:
+            raise NotImplementedError('{} space has not implemented move_to_storage_service'.format(self.get_access_protocol_display()))
+
+    def post_move_to_storage_service(self, *args, **kwargs):
+        """ Hook for any actions that need to be taken after moving to the storage service. """
+        try:
+            self.get_child_space().post_move_to_storage_service(*args, **kwargs)
+        except AttributeError:
+            # This is optional for the child class to implement
+            pass
+
+    def move_from_storage_service(self, source_path, destination_path,
+                                  *args, **kwargs):
+        """ Move source_path in this Space's staging area to destination_path in this Space.
+
+        That is, moves self.staging_path/source_path to self.path/destination_path.
+
+        If destination_path is not an absolute path, it is assumed to be
+        relative to Space.path.
+
+        source_path must be relative to self.staging_path.
+
+        This is implemented by the child protocol spaces.
+        """
+        logging.debug('FROM: src: {}'.format(source_path))
+        logging.debug('FROM: dst: {}'.format(destination_path))
+        # TODO move the path mangling to here?
+        # TODO enforce destination_path is inside self.path
+        try:
+            self.get_child_space().move_from_storage_service(
+                source_path, destination_path, *args, **kwargs)
+        except AttributeError:
+            raise NotImplementedError('{} space has not implemented move_from_storage_service'.format(self.get_access_protocol_display()))
+
+    def post_move_from_storage_service(self, *args, **kwargs):
+        """ Hook for any actions that need to be taken after moving from the storage service to the final destination. """
+        try:
+            self.get_child_space().post_move_from_storage_service(*args, **kwargs)
+        except AttributeError:
+            # This is optional for the child class to implement
+            pass
+
+    # HELPER FUNCTIONS
+
+    def _move_locally(self, source_path, destination_path, mode=None):
+        """ Moves a file from source_path to destination_path on the local filesystem. """
+        logging.info("Moving from {} to {}".format(source_path, destination_path))
+
+        # Create directories
+        self._create_local_directory(destination_path, mode)
+
+        # Move the file
+        os.rename(source_path, destination_path)
+
+    def _move_rsync(self, source, destination):
+        """ Moves a file from source to destination using rsync.
+
+        All directories leading to destination must exist.
+        Space._create_local_directory may be useful.
+        """
+        # Create directories
+        logging.info("Rsyncing from {} to {}".format(source, destination))
+
+        # Rsync file over
+        # TODO Do this asyncronously, with restarting failed attempts
+        command = ['rsync', '--chmod=ugo+rw,ugo-x', source, destination]
+        logging.info("rsync command: {}".format(command))
+        try:
+            subprocess.check_call(command)
+        except subprocess.CalledProcessError as e:
+            logging.warning("Rsync failed: {}".format(e))
+            raise
+
+    def _create_local_directory(self, path, mode=None):
+        """ Creates a local directory at 'path' with 'mode' (default 755). """
+        if mode is None:
+            mode = (stat.S_IRUSR + stat.S_IWUSR + stat.S_IXUSR +
+                    stat.S_IRGRP +                stat.S_IXGRP +
+                    stat.S_IROTH +                stat.S_IXOTH)
+        try:
+            os.makedirs(os.path.dirname(path), mode)
+        except os.error as e:
+            # If the leaf node already exists, that's fine
+            if e.errno != errno.EEXIST:
+                logging.warning("Could not create storage directory: {}".format(e))
+                raise
+
+        # os.makedirs may ignore the mode when creating directories, so force
+        # the permissions here. Some spaces (eg CIFS) doesn't allow chmod, so
+        # wrap it in a try-catch and ignore the failure.
+        try:
+            os.chmod(os.path.dirname(path), mode)
+        except os.error as e:
+            logging.warning(e)
+
 
 class LocalFilesystem(models.Model):
     """ Spaces found in the local filesystem of the storage service."""
     space = models.OneToOneField('Space', to_field='uuid')
-    # Does not currently need any other information - delete?
 
-    def save(self, *args, **kwargs):
-        self.verify()
-        super(LocalFilesystem, self).save(*args, **kwargs)
+    class Meta:
+        verbose_name = "Local Filesystem"
+
+    def move_to_storage_service(self, src_path, dest_path, dest_space):
+        """ Moves src_path to dest_space.staging_path/dest_path. """
+        source_path = os.path.join(self.space.path, src_path)
+        # dest_path must be relative
+        if os.path.isabs(dest_path):
+            dest_path = dest_path.lstrip(os.sep)
+            # os.path.join(*dest_path.split(os.sep)[1:]) # Strips up to first os.sep
+        destination_path = os.path.join(dest_space.staging_path, dest_path)
+        # Archivematica expects the file to still be on disk even after stored
+        self.space._create_local_directory(destination_path)
+        return self.space._move_rsync(source_path, destination_path)
+
+    def move_from_storage_service(self, src_path, dest_path):
+        """ Moves self.staging_path/src_path to dest_path. """
+        # src_path must be relative
+        if os.path.isabs(src_path):
+            src_path = src_path.lstrip(os.sep)
+            # os.path.join(*src_path.split(os.sep)[1:]) # Strips up to first os.sep
+        source_path = os.path.join(self.space.staging_path, src_path)
+        destination_path = os.path.join(self.space.path, dest_path)
+        return self.space._move_locally(source_path, destination_path)
 
     def verify(self):
         """ Verify that the space is accessible to the storage service. """
@@ -203,8 +338,41 @@ class NFS(models.Model):
         help_text="Type of the filesystem, i.e. nfs, or nfs4. \
         Should match a command in `mount`.")
     # https://help.ubuntu.com/community/NFSv4Howto
-
     manually_mounted = models.BooleanField(default=False)
+
+    class Meta:
+        verbose_name = "Network File System (NFS)"
+
+    def move_to_storage_service(self, src_path, dest_path, dest_space):
+        """ Moves src_path to dest_space.staging_path/dest_path. """
+        source_path = os.path.join(self.space.path, src_path)
+        # dest_path must be relative
+        if os.path.isabs(dest_path):
+            dest_path = dest_path.lstrip(os.sep)
+            # os.path.join(*dest_path.split(os.sep)[1:]) # Strips up to first os.sep
+        destination_path = os.path.join(dest_space.staging_path, dest_path)
+        self.space._create_local_directory(destination_path)
+        return self.space._move_rsync(source_path, destination_path)
+
+    def post_move_to_storage_service(self, *args, **kwargs):
+        # TODO delete original file?
+        pass
+
+    def move_from_storage_service(self, src_path, dest_path):
+        """ Moves self.staging_path/src_path to dest_path. """
+        # src_path must be relative
+        if os.path.isabs(src_path):
+            src_path = src_path.lstrip(os.sep)
+            # os.path.join(*src_path.split(os.sep)[1:]) # Strips up to first os.sep
+        source_path = os.path.join(self.space.staging_path, src_path)
+        destination_path = os.path.join(self.space.path, dest_path)
+        # TODO optimization - check if the staging path and destination path are on the same device and use os.rename/self.space._move_locally if so
+        self.space._create_local_directory(destination_path)
+        return self.space._move_rsync(source_path, destination_path)
+
+    def post_move_from_storage_service(self, staging_file):
+        # Remove the staging file, since rsync leaves it behind
+        os.remove(staging_file)
 
     def save(self, *args, **kwargs):
         self.verify()
@@ -240,24 +408,105 @@ class PipelineLocalFS(models.Model):
         help_text="Name or IP of the remote machine.")
     # Space.path is the path on the remote machine
 
+    class Meta:
+        verbose_name = "Pipeline Local FS"
+
+    def move_to_storage_service(self, src_path, dest_path, dest_space):
+        """ Moves src_path to dest_space.staging_path/dest_path. """
+        # if dest_space == self:
+        #     # If moving within same space, don't bring to storage service
+        #     # FIXME dest_path is relative, and intended for staging_path, need
+        #     # real destination path - memoize something and retrieve it in
+        #     # move_from_storage_service?  Move to self.space.path/dest_path?
+        #     command = 'mkdir -p "{dest_dir}" && mv "{src_path}" "{dest_path}"'.format(
+        #         dest_dir=os.path.dirname(dest_path),
+        #         src_user=self.remote_user, src_host=self.remote_name,
+        #         src_path=src_path, dest_path=dest_path,
+        #         )
+        #     ssh_command = ["ssh", self.remote_user+"@"+self.remote_name, command]
+        #     logging.info("ssh+mv command: {}".format(ssh_command))
+        #     try:
+        #         subprocess.check_call(ssh_command)
+        #     except subprocess.CalledProcessError as e:
+        #         logging.warning("ssh+mv failed: {}".format(e))
+        #         raise
+        # else:
+        source_path = "{user}@{host}:{path}".format(
+            user=self.remote_user,
+            host=self.remote_name,
+            path=os.path.join(self.space.path, src_path))
+        # dest_path must be relative
+        if os.path.isabs(dest_path):
+            dest_path = dest_path.lstrip(os.sep)
+            # os.path.join(*dest_path.split(os.sep)[1:]) # Strips up to first os.sep
+        destination_path = os.path.join(dest_space.staging_path, dest_path)
+        self.space._create_local_directory(destination_path)
+        return self.space._move_rsync(source_path, destination_path)
+
+    def post_move_to_storage_service(self, *args, **kwargs):
+        # TODO delete original file?
+        pass
+
+    def move_from_storage_service(self, src_path, dest_path):
+        """ Moves self.staging_path/src_path to dest_path. """
+        # src_path must be relative
+        if os.path.isabs(src_path):
+            src_path = src_path.lstrip(os.sep)
+            # os.path.join(*src_path.split(os.sep)[1:]) # Strips up to first os.sep
+        source_path = os.path.join(self.space.staging_path, src_path)
+        destination_path = os.path.join(self.space.path, dest_path)
+
+        # Need to make sure destination exists
+        command = 'mkdir -p {}'.format(os.path.dirname(destination_path))
+        ssh_command = ["ssh", self.remote_user+"@"+self.remote_name, command]
+        logging.info("ssh+mkdir command: {}".format(ssh_command))
+        try:
+            subprocess.check_call(ssh_command)
+        except subprocess.CalledProcessError as e:
+            logging.warning("ssh+mkdir failed: {}".format(e))
+            raise
+
+        # Prepend user and host to destination
+        destination_path = "{user}@{host}:{path}".format(
+            user=self.remote_user,
+            host=self.remote_name,
+            path=destination_path)
+
+        # Move file
+        return self.space._move_rsync(source_path, destination_path)
+
+    def post_move_from_storage_service(self, *args, **kwargs):
+        # TODO delete staging file?
+        pass
+
 
 # To add a new storage space the following places must be updated:
 #  locations/models.py (this file)
 #   Add constant for storage protocol
 #   Add constant to ACCESS_PROTOCOL_CHOICES
 #   Add class for protocol-specific fields using template below
-#   Add to Package.store_aip(), using existing categories if possible
-#  locations/forms.py
 #   Add to Space.browse, using existing categories if possible
+#  locations/forms.py
 #   Add ModelForm for new class
 #  common/constants.py
-#   Add entry to protocol with fields that should be added to GET resource
-#     requests, the Model and ModelForm
+#   Add entry to protocol
+#    'model' is the model object
+#    'form' is the ModelForm for creating the space
+#    'fields' is a whitelist of fields to display to the user
 
 # class Example(models.Model):
 #     space = models.OneToOneField('Space', to_field='uuid')
 #
-
+#     class Meta:
+#         verbose_name = "Example Space"
+#
+#     def move_to_storage_service(self, src_path, dest_path, dest_space):
+#         """ Moves src_path to dest_space.staging_path/dest_path. """
+#         pass
+#
+#     def move_from_storage_service(self, src_path, dest_path):
+#         """ Moves self.staging_path/src_path to dest_path. """
+#         pass
 
 ########################## LOCATIONS ##########################
 
@@ -458,34 +707,22 @@ class Package(models.Model):
         self.status = Package.PENDING
         self.save()
 
-        # Create destination for pointer file
-
-        # Call different protocols depending on what Space we're moving it to
-        # and from
         src_space = self.origin_location.space
-        if src_space.access_protocol in Space.mounted_locally and dest_space.access_protocol in Space.mounted_locally:
-            logging.info("Moving AIP from locally mounted storage to locally mounted storage.")
-            # Move pointer file
-            self._store_aip_local_to_local(pointer_file_src, pointer_file_dst)
-            # Move AIP
-            self._store_aip_local_to_local(source_path, destination_path)
-        elif src_space.access_protocol in Space.ssh_only_access and dest_space.access_protocol in Space.mounted_locally:
-            logging.info("Moving AIP from SSH-only access storage to locally mounted storage.")
-            # Move pointer file
-            self._store_aip_ssh_only_to_local(pointer_file_src, pointer_file_dst)
-            # Move AIP
-            self._store_aip_ssh_only_to_local(source_path, destination_path)
-        elif src_space.access_protocol in Space.ssh_only_access and dest_space.access_protocol in Space.ssh_only_access:
-            logging.info("Moving AIP from SSH-only access storage to SSH-only access storage.")
-            # Move pointer file
-            self._store_aip_ssh_only_to_local(pointer_file_src, pointer_file_dst)
-            # Move AIP
-            self._store_aip_ssh_only_to_ssh_only(source_path, destination_path)
-        else:
-            # Not supported: Space.mounted_locally to Space.ssh_only_access
-            logging.warning("Transfering package from {} to {} not supported".format(src_space.access_protocol, dest_space.access_protocol))
-            return
 
+        # Move pointer file
+        pointer_file_name = 'pointer-'+self.uuid+'.xml'
+        src_space.move_to_storage_service(pointer_file_src, pointer_file_name, self.pointer_file_location.space)
+        self.pointer_file_location.space.move_from_storage_service(pointer_file_name, pointer_file_dst)
+
+        # Move AIP
+        src_space.move_to_storage_service(
+            source_path=os.path.join(self.origin_location.relative_path, self.origin_path),
+            destination_path=self.current_path,  # This should include Location.path
+            destination_space=dest_space)
+        dest_space.move_from_storage_service(
+            source_path=self.current_path,  # This should include Location.path
+            destination_path=os.path.join(location.relative_path, self.current_path),
+            )
         # Save new space/location usage, package status
         dest_space.used += self.size
         dest_space.save()
@@ -505,78 +742,6 @@ class Package(models.Model):
         with open(pointer_file_dst, 'w') as f:
             f.write(etree.tostring(root, pretty_print=True))
 
-    def _store_aip_local_to_local(self, source_path, destination_path):
-        """ Stores AIPs to locations accessible locally to the storage service.
-
-        AIP is stored at:
-        destination_location/uuid/split/into/chunks/destination_path. """
-        # Create directories
-        logging.info("rsyncing from {} to {}".format(source_path, destination_path))
-        try:
-            mode = (stat.S_IRUSR + stat.S_IWUSR + stat.S_IXUSR +
-                    stat.S_IRGRP +                stat.S_IXGRP +
-                    stat.S_IROTH +                stat.S_IXOTH)
-            os.makedirs(os.path.dirname(destination_path), mode)
-        except os.error as e:
-            if e.errno != errno.EEXIST:
-                logging.warning("Could not create storage directory: {}".format(e))
-                raise
-        try:
-            # Mode not getting set correctly in os.makedirs
-            os.chmod(os.path.dirname(destination_path), mode)
-        except os.error as e:
-            logging.warning(e)
-
-        # Rsync file over
-        # TODO use Gearman to do this asyncronously
-        command = ['rsync', '--chmod=u+rw,go-rwx', source_path, destination_path]
-        logging.info("rsync command: {}".format(command))
-        try:
-            subprocess.check_call(command)
-        except Exception as e:
-            logging.warning("Rsync failed: {}".format(e))
-            raise
-
-    def _store_aip_ssh_only_to_local(self, source_path, destination_path):
-        """ Stores an AIP from a location SSH-accessible to one accessible locally.
-
-        AIP is stored at:
-        destination_location/uuid/split/into/chunks/destination_path. """
-        # Local to local uses rsync, so pass it a source_path that includes
-        # user@host:path
-        # Get correct protocol-specific model, and then the correct object
-        protocol_space = self.origin_location.space.get_child_space()
-        user = protocol_space.remote_user
-        host = protocol_space.remote_name
-        full_source_path = "{user}@{host}:{path}".format(user=user, host=host,
-            path=source_path)
-        self._store_aip_local_to_local(full_source_path, destination_path)
-
-    def _store_aip_ssh_only_to_ssh_only(self, source_path, destination_path):
-        """ Stores AIPs from and to a location only accessible via SSH.
-
-        AIP is stored at:
-        destination_location/uuid/split/into/chunks/destination_path. """
-        # Get correct protocol-specific model, and then the correct object
-        src_protocol_space = self.origin_location.space.get_child_space()
-        dst_protocol_space = self.current_location.space.get_child_space()
-        src_user = src_protocol_space.remote_user
-        src_host = src_protocol_space.remote_name
-        dst_user = dst_protocol_space.remote_user
-        dst_host = dst_protocol_space.remote_name
-
-        command = 'mkdir -p {dst_dir} && rsync {src_user}@{src_host}:{src_path} {dst_path}'.format(
-            dst_dir=os.path.dirname(destination_path),
-            src_user=src_user, src_host=src_host,
-            src_path=source_path, dst_path=destination_path,
-            )
-        ssh_command = ["ssh", dst_user+"@"+dst_host, command]
-        logging.info("ssh+rsync command: {}".format(ssh_command))
-        try:
-            subprocess.check_call(ssh_command)
-        except Exception as e:
-            logging.warning("ssh+sync failed: {}".format(e))
-            raise
 
     def delete_from_storage(self):
         """ Deletes the package from filesystem and updates metadata.

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -257,7 +257,7 @@ class Space(models.Model):
 
         # Rsync file over
         # TODO Do this asyncronously, with restarting failed attempts
-        command = ['rsync', '--chmod=ugo+rw,ugo-x', source, destination]
+        command = ['rsync', '--chmod=ugo+rw', '-r', source, destination]
         logging.info("rsync command: {}".format(command))
         try:
             subprocess.check_call(command)

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -238,6 +238,11 @@ class Space(models.Model):
 
     def _move_locally(self, source_path, destination_path, mode=None):
         """ Moves a file from source_path to destination_path on the local filesystem. """
+        # FIXME this does not work properly when moving folders troubleshoot
+        # and fix before using.
+        # When copying from folder/. to folder2/. it failed because the folder
+        # already existed.  Copying folder/ or folder to folder/ or folder also
+        # has errors.  Should uses shutil.move()
         logging.info("Moving from {} to {}".format(source_path, destination_path))
 
         # Create directories
@@ -315,7 +320,8 @@ class LocalFilesystem(models.Model):
             # os.path.join(*src_path.split(os.sep)[1:]) # Strips up to first os.sep
         source_path = os.path.join(self.space.staging_path, src_path)
         destination_path = os.path.join(self.space.path, dest_path)
-        return self.space._move_locally(source_path, destination_path)
+        self.space._create_local_directory(destination_path)
+        return self.space._move_rsync(source_path, destination_path)
 
     def verify(self):
         """ Verify that the space is accessible to the storage service. """

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -345,12 +345,14 @@ class Package(models.Model):
     size = models.IntegerField(default=0)
 
     AIP = "AIP"
+    AIC = "AIC"
     SIP = "SIP"
     DIP = "DIP"
     TRANSFER = "transfer"
     FILE = 'file'
     PACKAGE_TYPE_CHOICES = (
         (AIP, 'AIP'),
+        (AIC, 'AIC'),
         (SIP, 'SIP'),
         (DIP, 'DIP'),
         (TRANSFER, 'Transfer'),
@@ -376,6 +378,9 @@ class Package(models.Model):
         default=FAIL,
         help_text="Status of the package in the storage service.")
 
+    PACKAGE_TYPE_DELETABLE = (AIP, AIC)
+    PACKAGE_TYPE_EXTRACTABLE = (AIP, AIC)
+
     class Meta:
         verbose_name = "Package"
 
@@ -397,7 +402,7 @@ class Package(models.Model):
         """ Return the full path of the AIP's pointer file, None if not an AIP.
 
         Includes the space, location and package paths joined."""
-        if self.package_type != self.AIP:
+        if self.package_type not in (self.AIP, self.AIC):
             return None
         else:
             return os.path.join(self.pointer_file_location.full_path(),

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -127,6 +127,8 @@ class Space(models.Model):
         if self.access_protocol in self.mounted_locally:
             # Sorted list of all entries in directory, excluding hidden files
             # This may need magic for encoding/decoding, but doesn't seem to
+            if isinstance(path, unicode):
+                path = str(path)
             entries = [name for name in os.listdir(path) if name[0] != '.']
             entries = sorted(entries, key=lambda s: s.lower())
             directories = []

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -86,6 +86,8 @@ class Space(models.Model):
         help_text="Amount used in bytes")
     path = models.TextField(validators=[validate_space_path],
         help_text="Absolute path to the space on the storage service machine.")
+    staging_path=models.TextField(validators=[validate_space_path],
+        help_text="Absolute path to a staging area.  Must be UNIX filesystem compatible, preferably on the same filesystem as the path.")
     verified = models.BooleanField(default=False,
        help_text="Whether or not the space has been verified to be accessible.")
     last_verified = models.DateTimeField(default=None, null=True, blank=True,

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -226,10 +226,14 @@ class Space(models.Model):
         except AttributeError:
             raise NotImplementedError('{} space has not implemented move_from_storage_service'.format(self.get_access_protocol_display()))
 
-    def post_move_from_storage_service(self, *args, **kwargs):
+    def post_move_from_storage_service(self, staging_path=None, destination_path=None, package=None, *args, **kwargs):
         """ Hook for any actions that need to be taken after moving from the storage service to the final destination. """
         try:
-            self.get_child_space().post_move_from_storage_service(*args, **kwargs)
+            self.get_child_space().post_move_from_storage_service(
+                staging_path=staging_path,
+                destination_path=destination_path,
+                package=package,
+                *args, **kwargs)
         except AttributeError:
             # This is optional for the child class to implement
             pass
@@ -376,9 +380,9 @@ class NFS(models.Model):
         self.space._create_local_directory(destination_path)
         return self.space._move_rsync(source_path, destination_path)
 
-    def post_move_from_storage_service(self, staging_file):
-        # Remove the staging file, since rsync leaves it behind
-        os.remove(staging_file)
+    def post_move_from_storage_service(self, staging_path, destination_path, package):
+        # TODO Remove the staging file, since rsync leaves it behind
+        pass
 
     def save(self, *args, **kwargs):
         self.verify()
@@ -481,8 +485,8 @@ class PipelineLocalFS(models.Model):
         # Move file
         return self.space._move_rsync(source_path, destination_path)
 
-    def post_move_from_storage_service(self, *args, **kwargs):
-        # TODO delete staging file?
+    def post_move_from_storage_service(self, staging_path, destination_path, package):
+        # TODO Remove the staging file, since rsync leaves it behind
         pass
 
 

--- a/storage_service/static/js/file-explorer.js
+++ b/storage_service/static/js/file-explorer.js
@@ -199,6 +199,10 @@
           var child = entry.children[index]
             , allowDisplay = true;
 
+          // names are base64-encoded from the server; needs to be
+          // decoded for human reading
+          child.attributes.name = Base64.decode(child.attributes.name);
+
           if (self.entryDisplayFilter) {
             allowDisplay = self.entryDisplayFilter(child);
           }

--- a/storage_service/static/js/vendor/base64.js
+++ b/storage_service/static/js/vendor/base64.js
@@ -1,0 +1,216 @@
+/*
+Copyright (c) 2008 Fred Palmer fred.palmer_at_gmail.com
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+function StringBuffer()
+{ 
+    this.buffer = []; 
+} 
+
+StringBuffer.prototype.append = function append(string)
+{ 
+    this.buffer.push(string); 
+    return this; 
+}; 
+
+StringBuffer.prototype.toString = function toString()
+{ 
+    return this.buffer.join(""); 
+}; 
+
+var Base64 =
+{
+    codex : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+
+    encode : function (input)
+    {
+        var output = new StringBuffer();
+
+        var enumerator = new Utf8EncodeEnumerator(input);
+        while (enumerator.moveNext())
+        {
+            var chr1 = enumerator.current;
+
+            enumerator.moveNext();
+            var chr2 = enumerator.current;
+
+            enumerator.moveNext();
+            var chr3 = enumerator.current;
+
+            var enc1 = chr1 >> 2;
+            var enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+            var enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+            var enc4 = chr3 & 63;
+
+            if (isNaN(chr2))
+            {
+                enc3 = enc4 = 64;
+            }
+            else if (isNaN(chr3))
+            {
+                enc4 = 64;
+            }
+
+            output.append(this.codex.charAt(enc1) + this.codex.charAt(enc2) + this.codex.charAt(enc3) + this.codex.charAt(enc4));
+        }
+
+        return output.toString();
+    },
+
+    decode : function (input)
+    {
+        var output = new StringBuffer();
+
+        var enumerator = new Base64DecodeEnumerator(input);
+        while (enumerator.moveNext())
+        {
+            var charCode = enumerator.current;
+
+            if (charCode < 128)
+                output.append(String.fromCharCode(charCode));
+            else if ((charCode > 191) && (charCode < 224))
+            {
+                enumerator.moveNext();
+                var charCode2 = enumerator.current;
+
+                output.append(String.fromCharCode(((charCode & 31) << 6) | (charCode2 & 63)));
+            }
+            else
+            {
+                enumerator.moveNext();
+                var charCode2 = enumerator.current;
+
+                enumerator.moveNext();
+                var charCode3 = enumerator.current;
+
+                output.append(String.fromCharCode(((charCode & 15) << 12) | ((charCode2 & 63) << 6) | (charCode3 & 63)));
+            }
+        }
+
+        return output.toString();
+    }
+}
+
+
+function Utf8EncodeEnumerator(input)
+{
+    this._input = input;
+    this._index = -1;
+    this._buffer = [];
+}
+
+Utf8EncodeEnumerator.prototype =
+{
+    current: Number.NaN,
+
+    moveNext: function()
+    {
+        if (this._buffer.length > 0)
+        {
+            this.current = this._buffer.shift();
+            return true;
+        }
+        else if (this._index >= (this._input.length - 1))
+        {
+            this.current = Number.NaN;
+            return false;
+        }
+        else
+        {
+            var charCode = this._input.charCodeAt(++this._index);
+
+            // "\r\n" -> "\n"
+            //
+            if ((charCode == 13) && (this._input.charCodeAt(this._index + 1) == 10))
+            {
+                charCode = 10;
+                this._index += 2;
+            }
+
+            if (charCode < 128)
+            {
+                this.current = charCode;
+            }
+            else if ((charCode > 127) && (charCode < 2048))
+            {
+                this.current = (charCode >> 6) | 192;
+                this._buffer.push((charCode & 63) | 128);
+            }
+            else
+            {
+                this.current = (charCode >> 12) | 224;
+                this._buffer.push(((charCode >> 6) & 63) | 128);
+                this._buffer.push((charCode & 63) | 128);
+            }
+
+            return true;
+        }
+    }
+}
+
+function Base64DecodeEnumerator(input)
+{
+    this._input = input;
+    this._index = -1;
+    this._buffer = [];
+}
+
+Base64DecodeEnumerator.prototype =
+{
+    current: 64,
+
+    moveNext: function()
+    {
+        if (this._buffer.length > 0)
+        {
+            this.current = this._buffer.shift();
+            return true;
+        }
+        else if (this._index >= (this._input.length - 1))
+        {
+            this.current = 64;
+            return false;
+        }
+        else
+        {
+            var enc1 = Base64.codex.indexOf(this._input.charAt(++this._index));
+            var enc2 = Base64.codex.indexOf(this._input.charAt(++this._index));
+            var enc3 = Base64.codex.indexOf(this._input.charAt(++this._index));
+            var enc4 = Base64.codex.indexOf(this._input.charAt(++this._index));
+
+            var chr1 = (enc1 << 2) | (enc2 >> 4);
+            var chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+            var chr3 = ((enc3 & 3) << 6) | enc4;
+
+            this.current = chr1;
+
+            if (enc3 != 64)
+                this._buffer.push(chr2);
+
+            if (enc4 != 64)
+                this._buffer.push(chr3);
+
+            return true;
+        }
+    }
+};

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -196,7 +196,7 @@ DJANGO_APPS = (
 )
 
 THIRD_PARTY_APPS = (
-    # 'south',  # DB migration helper
+    'south',  # DB migration helper
     'tastypie',  # REST framework
 )
 

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -43,7 +43,9 @@ def startup():
     logging.basicConfig(level=logging.INFO)
     logging.info("Running startup")
     space, space_created = locations_models.Space.objects.get_or_create(
-        access_protocol=locations_models.Space.LOCAL_FILESYSTEM, path='/')
+        access_protocol=locations_models.Space.LOCAL_FILESYSTEM,
+        path=os.sep,
+        staging_path=os.path.join(os.sep, 'var', 'archivematica', 'storage_service'))
     if space_created:
         local_fs = locations_models.LocalFilesystem(space=space)
         local_fs.save()
@@ -66,6 +68,9 @@ def startup():
     except OSError as e:
         if e.errno != errno.EEXIST:
             logging.error("Internal storage location {} not accessible.".format(internal_use.full_path()))
-    utils.set_setting('default_transfer_source', [transfer_source.uuid])
-    utils.set_setting('default_aip_storage', [aip_storage.uuid])
+    if not utils.get_setting('default_transfer_source'):
+        utils.set_setting('default_transfer_source', [transfer_source.uuid])
+    if not utils.get_setting('default_aip_storage'):
+        utils.set_setting('default_aip_storage', [aip_storage.uuid])
+
 startup()

--- a/storage_service/templates/locations/location_form.html
+++ b/storage_service/templates/locations/location_form.html
@@ -31,6 +31,7 @@
   <script type="text/javascript" src="{{ STATIC_URL }}js/file-explorer.js"></script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/directory_picker.js"></script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/single_directory_picker.js"></script>
+  <script type="text/javascript" src="{{ STATIC_URL }}js/vendor/base64.js"></script>
 
   <script>
     $(document).ready(function() {

--- a/storage_service/templates/locations/location_form.html
+++ b/storage_service/templates/locations/location_form.html
@@ -42,7 +42,7 @@
         'id_relative_path',
         'id_relative_path_browse',
         'directory_picker',
-        '/api/v1/space/{{ space.uuid }}/browse/'
+        '/api/v2/space/{{ space.uuid }}/browse/'
       );
     });
   </script>

--- a/storage_service/templates/locations/space_detail.html
+++ b/storage_service/templates/locations/space_detail.html
@@ -8,6 +8,7 @@
   <dl>
     <dt>Access Protocol</dt> <dd>{{ space.get_access_protocol_display }}</dd>
     <dt>Path</dt> <dd>{{ space.path }}</dd>
+    <dt>Staging Path</dt> <dd>{{ space.staging_path}}</dd>
     <dt>Usage</dt> <dd>{{ space.used|filesizeformat }} / {{ space.size|filesizeformat }}</dd>
     <dt>Last Verified</dt> <dd>{{ space.last_verified }}</dd>
     {% for k, v in space.child.items %}


### PR DESCRIPTION
Rather than every Space knowing how to move to every other Space, they only need to know how to move to and from a staging area in the storage service.  The staging area must be locally accessible to the storage service (ie with tools like mv and os.rename), and is configured for each Space.

Each space implements functions to move files/folders to and from the storage service. Moving to the storage service from the original location deposits them in a staging area associated with the destination Space.  Moving from the storage service to the final destination moves the file from the destination Space's staging area to the destination path.

Also added support for moving folders, not just files.  Rsync uses -r, and extract files looks for the file on disk before trying to extract it from a Package.

No Archivematica changes needed.
