### PR TITLE
Add FEDORA API

### DIFF
--- a/debian/archivematica-storage-service.install
+++ b/debian/archivematica-storage-service.install
@@ -5,7 +5,7 @@ install/storage etc/nginx/sites-available/
 install/.storage-service var/archivematica/
 install/make_key.py var/archivematica/storage-service/
 
-#lib/* var/archivematica/storage-service/lib/
+lib/* var/archivematica/storage-service/lib/
 
 storage_service/static/* /var/archivematica/storage-service/static/
 storage_service/templates/* /var/archivematica/storage-service/templates/

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -415,7 +415,7 @@ class DepositResource(ModelResource):
 
     def sword_deposit(self, request, **kwargs):
         self.log_throttled_access(request)
-        return sword_views.deposit(request, kwargs['uuid'])
+        return sword_views.deposit_edit(request, kwargs['uuid'])
 
     def sword_deposit_media(self, request, **kwargs):
         self.log_throttled_access(request)

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -169,6 +169,7 @@ class SpaceResource(ModelResource):
     def prepend_urls(self):
         return [
             url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/browse%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('browse'), name="browse"),
+            url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/sword%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('sword_service_document'), name="sword_service_document"),
         ]
 
     # Is there a better place to add protocol-specific space info?
@@ -231,6 +232,10 @@ class SpaceResource(ModelResource):
         objects = self.get_objects(space, path)
 
         return self.create_response(request, objects)
+
+    def sword_service_document(self, request, **kwargs):
+        self.log_throttled_access(request)
+        return sword_views.service_document(request, kwargs['uuid'])
 
 
 class LocationResource(ModelResource):

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -405,6 +405,7 @@ class DepositResource(ModelResource):
         return [
             url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/sword%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('sword_deposit'), name="sword_deposit"),
             url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/sword/media%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('sword_deposit_media'), name="sword_deposit_media"),
+            url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/sword/state%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('sword_deposit_state'), name="sword_deposit_state")
         ]
 
     def sword_deposit(self, request, **kwargs):
@@ -415,6 +416,9 @@ class DepositResource(ModelResource):
         self.log_throttled_access(request)
         return sword.deposit_media(request, kwargs['uuid'])
 
+    def sword_deposit_state(self, request, **kwargs):
+        self.log_throttled_access(request)
+        return sword.deposit_state(request, kwargs['uuid'])
 
 class PackageResource(ModelResource):
     """ Resource for managing Packages.

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -234,6 +234,9 @@ class SpaceResource(ModelResource):
         return self.create_response(request, objects)
 
     def sword_collection(self, request, **kwargs):
+        space = Space.objects.get(uuid=kwargs['uuid'])
+        if space.access_protocol != Space.SWORD_SERVER:
+            return http.HttpBadRequest('This is not a SWORD server space.')
         self.log_throttled_access(request)
         return sword_views.collection(request, kwargs['uuid'])
 
@@ -379,20 +382,23 @@ class LocationResource(ModelResource):
         return self.create_response(request, response)
 
     def sword_deposit(self, request, **kwargs):
-        if self.location.purpose != Location.SWORD_DEPOSIT:
-            return http.HttpBadRequest
+        location = Location.objects.get(uuid=kwargs['uuid'])
+        if location.purpose != Location.SWORD_DEPOSIT:
+            return http.HttpBadRequest('This is not a SWORD deposit location.')
         self.log_throttled_access(request)
         return sword_views.deposit_edit(request, kwargs['uuid'])
 
     def sword_deposit_media(self, request, **kwargs):
-        if self.location.purpose != Location.SWORD_DEPOSIT:
-            return http.HttpBadRequest
+        location = Location.objects.get(uuid=kwargs['uuid'])
+        if location.purpose != Location.SWORD_DEPOSIT:
+            return http.HttpBadRequest('This is not a SWORD deposit location.')
         self.log_throttled_access(request)
         return sword_views.deposit_media(request, kwargs['uuid'])
 
     def sword_deposit_state(self, request, **kwargs):
-        if self.location.purpose != Location.SWORD_DEPOSIT:
-            return http.HttpBadRequest
+        location = Location.objects.get(uuid=kwargs['uuid'])
+        if location.purpose != Location.SWORD_DEPOSIT:
+            return http.HttpBadRequest('This is not a SWORD deposit location.')
         self.log_throttled_access(request)
         return sword_views.deposit_state(request, kwargs['uuid'])
 

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -27,6 +27,7 @@ from tastypie.utils import trailing_slash
 
 # This project, alphabetical
 from common import utils
+from locations.api import sword
 
 from ..models import (Event, Package, Location, Space, Pipeline, StorageException)
 from ..forms import LocationForm, SpaceForm
@@ -266,6 +267,7 @@ class LocationResource(ModelResource):
     def prepend_urls(self):
         return [
             url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/browse%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('browse'), name="browse"),
+            url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/sword/collection%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('sword_collection'), name="sword_collection")
         ]
 
     def decode_path(self, path):
@@ -368,6 +370,10 @@ class LocationResource(ModelResource):
         response = {'error': None,
                     'message': 'Files moved successfully'}
         return self.create_response(request, response)
+
+    def sword_collection(self, request, **kwargs):
+        self.log_throttled_access(request)
+        return sword.collection(request, kwargs['uuid'])
 
 
 class PackageResource(ModelResource):

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -379,14 +379,20 @@ class LocationResource(ModelResource):
         return self.create_response(request, response)
 
     def sword_deposit(self, request, **kwargs):
+        if self.location.purpose != Location.SWORD_DEPOSIT:
+            return http.HttpBadRequest
         self.log_throttled_access(request)
         return sword_views.deposit_edit(request, kwargs['uuid'])
 
     def sword_deposit_media(self, request, **kwargs):
+        if self.location.purpose != Location.SWORD_DEPOSIT:
+            return http.HttpBadRequest
         self.log_throttled_access(request)
         return sword_views.deposit_media(request, kwargs['uuid'])
 
     def sword_deposit_state(self, request, **kwargs):
+        if self.location.purpose != Location.SWORD_DEPOSIT:
+            return http.HttpBadRequest
         self.log_throttled_access(request)
         return sword_views.deposit_state(request, kwargs['uuid'])
 

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -27,7 +27,7 @@ from tastypie.utils import trailing_slash
 
 # This project, alphabetical
 from common import utils
-from locations.api import sword
+from locations.api.sword import views as sword_views
 
 from ..models import (Event, Package, Location, Space, Pipeline, Deposit, StorageException)
 from ..forms import LocationForm, SpaceForm
@@ -373,7 +373,7 @@ class LocationResource(ModelResource):
 
     def sword_collection(self, request, **kwargs):
         self.log_throttled_access(request)
-        return sword.collection(request, kwargs['uuid'])
+        return sword_views.collection(request, kwargs['uuid'])
 
 
 class DepositResource(ModelResource):
@@ -410,15 +410,15 @@ class DepositResource(ModelResource):
 
     def sword_deposit(self, request, **kwargs):
         self.log_throttled_access(request)
-        return sword.deposit(request, kwargs['uuid'])
+        return sword_views.deposit(request, kwargs['uuid'])
 
     def sword_deposit_media(self, request, **kwargs):
         self.log_throttled_access(request)
-        return sword.deposit_media(request, kwargs['uuid'])
+        return sword_views.deposit_media(request, kwargs['uuid'])
 
     def sword_deposit_state(self, request, **kwargs):
         self.log_throttled_access(request)
-        return sword.deposit_state(request, kwargs['uuid'])
+        return sword_views.deposit_state(request, kwargs['uuid'])
 
 class PackageResource(ModelResource):
     """ Resource for managing Packages.

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -29,7 +29,7 @@ from tastypie.utils import trailing_slash
 from common import utils
 from locations.api import sword
 
-from ..models import (Event, Package, Location, Space, Pipeline, StorageException)
+from ..models import (Event, Package, Location, Space, Pipeline, Deposit, StorageException)
 from ..forms import LocationForm, SpaceForm
 from ..constants import PROTOCOL
 from locations import signals
@@ -374,6 +374,46 @@ class LocationResource(ModelResource):
     def sword_collection(self, request, **kwargs):
         self.log_throttled_access(request)
         return sword.collection(request, kwargs['uuid'])
+
+
+class DepositResource(ModelResource):
+    location = fields.ForeignKey(LocationResource, 'location')
+    path = fields.CharField(attribute='full_path', readonly=True)
+    name = fields.CharField(attribute='name', readonly=True)
+
+    class Meta:
+        queryset = Deposit.objects.all()
+        authentication = Authentication()
+        # authentication = MultiAuthentication(
+        #     BasicAuthentication, ApiKeyAuthentication())
+        authorization = Authorization()
+        # authorization = DjangoAuthorization()
+        # validation = CleanedDataFormValidation(form_class=LocationForm)
+
+        fields = ['path', 'name', 'uuid']
+        list_allowed_methods = ['get']
+        detail_allowed_methods = ['get']
+        detail_uri_name = 'uuid'
+        always_return_data = True
+        filtering = {
+            'path': ALL,
+            'location': ALL_WITH_RELATIONS,
+            'uuid': ALL,
+        }
+
+    def prepend_urls(self):
+        return [
+            url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/sword%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('sword_deposit'), name="sword_deposit"),
+            url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/sword/media%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('sword_deposit_media'), name="sword_deposit_media"),
+        ]
+
+    def sword_deposit(self, request, **kwargs):
+        self.log_throttled_access(request)
+        return sword.deposit(request, kwargs['uuid'])
+
+    def sword_deposit_media(self, request, **kwargs):
+        self.log_throttled_access(request)
+        return sword.deposit_media(request, kwargs['uuid'])
 
 
 class PackageResource(ModelResource):

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -377,7 +377,7 @@ class LocationResource(ModelResource):
 
     def sword_collection(self, request, **kwargs):
         location = get_object_or_None(Location, uuid=kwargs['uuid'])
-        if location and (location.purpose != Location.SWORD_DEPOSIT or location.space.access_protocol != Space.SWORD_SERVER):
+        if location and (location.purpose != Location.SWORD_DEPOSIT or location.space.access_protocol != Space.FEDORA):
             return http.HttpBadRequest('This is not a SWORD server space.')
         self.log_throttled_access(request)
         return sword_views.collection(request, location or kwargs['uuid'])

--- a/storage_service/locations/api/sword.py
+++ b/storage_service/locations/api/sword.py
@@ -1,0 +1,634 @@
+# stdlib, alphabetical
+import datetime
+from lxml import etree as etree
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+
+# Core Django, alphabetical
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.urlresolvers import reverse
+from django.db import transaction
+from django.http import HttpResponse
+from django.shortcuts import render
+from django.template.loader import render_to_string
+
+# This project, alphabetical
+from ..models import Deposit
+from ..models import Location
+
+def _deposit_storage_path(uuid):
+    try:
+        transfer = models.Transfer.objects.get(uuid=uuid)
+        return transfer.currentlocation
+    except ObjectDoesNotExist:
+        return None
+
+def _deposit_storage_path_root(location_uuid):
+    location = Location.objects.get(uuid=location_uuid)
+    return location.full_path()
+
+def _create_deposit_directory_and_db_entry(deposit_specification):
+    deposit_uuid = uuid.uuid4().__str__()
+
+    if 'name' in deposit_specification:
+        deposit_name = deposit_specification['name']
+    else:
+        deposit_name = 'Untitled'
+
+    deposit_path = os.path.join(
+        _deposit_storage_path_root(deposit_specification['location_uuid']),
+        deposit_name
+    )
+
+    # TODO deposit_path = helpers.pad_destination_filepath_if_it_already_exists(deposit_path)
+    os.mkdir(deposit_path)
+    os.chmod(deposit_path, 02770) # drwxrws---
+
+    if os.path.exists(deposit_path):
+        location = Location.objects.get(uuid=deposit_specification['location_uuid'])
+        deposit = Deposit.objects.create(name=deposit_name, path=deposit_name,
+            location=location)
+
+        # TODO
+        if 'sourceofacquisition' in deposit_specification:
+            deposit.source = deposit_specification['sourceofacquisition']
+
+        deposit.save()
+        return deposit.uuid
+
+def _deposit_list(location_uuid):
+    location = Location.objects.get(uuid=location_uuid)
+
+    deposit_list = []
+    deposits = Deposit.objects.filter(location=location)
+    for deposit in deposits:
+        deposit_list.append(deposit.uuid)
+    return deposit_list
+
+def _sword_error_response(request, error_details):
+    error_details['request'] = request
+    error_details['update_time'] = datetime.datetime.now().__str__()
+    error_details['user_agent'] = request.META['HTTP_USER_AGENT']
+    error_xml = render_to_string('locations/api/sword/error.xml', error_details)
+    return HttpResponse(error_xml, status=error_details['status'])
+
+def _write_file_from_request_body(request, file_path):
+    bytes_written = 0
+    new_file = open(file_path, 'ab')
+    chunk = request.read()
+    if chunk != None:
+        new_file.write(chunk)
+        bytes_written += len(chunk)
+        chunk = request.read()
+    new_file.close()
+    return bytes_written
+
+def _get_file_md5_checksum(filepath):
+    raw_result = subprocess.Popen(["md5sum", filepath],stdout=subprocess.PIPE).communicate()[0]
+    return raw_result[0:32]
+
+def _handle_upload_request_with_potential_md5_checksum(request, file_path, success_status_code):
+    temp_filepath = _write_request_body_to_temp_file(request)
+    if 'HTTP_CONTENT_MD5' in request.META:
+        md5sum = _get_file_md5_checksum(temp_filepath)
+        if request.META['HTTP_CONTENT_MD5'] != md5sum:
+            os.remove(temp_filepath)
+            bad_request = 'MD5 checksum of uploaded file ({uploaded_md5sum}) does not match checksum provided in header ({header_md5sum}).'.format(uploaded_md5sum=md5sum, header_md5sum=request.META['HTTP_CONTENT_MD5'])
+            return _sword_error_response(request, {
+                'summary': bad_request,
+                'status': 400
+            })
+        else:
+            shutil.copyfile(temp_filepath, file_path)
+            os.remove(temp_filepath)
+            return HttpResponse(status=success_status_code)
+    else:
+        shutil.copyfile(temp_filepath, file_path)
+        os.remove(temp_filepath)
+        return HttpResponse(status=success_status_code)
+
+def _parse_filename_from_content_disposition(header):
+    filename = header.split('filename=')[1]
+    if filename[0] == '"' or filename[0] == "'":
+            filename = filename[1:-1]
+    return filename
+
+def _handle_upload_request(request, uuid, replace_file=False):
+    error = None
+    bad_request = None
+
+    if 'HTTP_CONTENT_DISPOSITION' in request.META:
+        filename = _parse_filename_from_content_disposition(request.META['HTTP_CONTENT_DISPOSITION']) 
+
+        if filename != '':
+            file_path = os.path.join(_deposit_storage_path(uuid), filename)
+
+            if replace_file:
+                # if doing a file replace, the file being replaced must exist
+                if os.path.exists(file_path):
+                    return _handle_upload_request_with_potential_md5_checksum(
+                        request,
+                        file_path,
+                        204
+                    )
+                else:
+                    bad_request = 'File does not exist.'
+            else:
+                # if adding a file, the file must not already exist
+                if os.path.exists(file_path):
+                    bad_request = 'File already exists.'
+                else:
+                    return _handle_upload_request_with_potential_md5_checksum(
+                        request,
+                        file_path,
+                        201
+                    )
+        else:
+            bad_request = 'No filename found in Content-disposition header.'
+    else:
+        bad_request = 'Content-disposition must be set in request header.'
+
+    if bad_request != None:
+        error = {
+            'summary': bad_request,
+            'status': 400
+        }
+
+    if error != None:
+        return _sword_error_response(request, error)
+
+def _write_request_body_to_temp_file(request):
+    filehandle, temp_filepath = tempfile.mkstemp()
+    _write_file_from_request_body(request, temp_filepath)
+    return temp_filepath
+
+def _fetch_content(transfer_uuid, object_content_urls):
+    # write resources to temp file
+    temp_dir = tempfile.mkdtemp()
+    os.chmod(temp_dir, 02770) # drwxrws---
+
+    # create job record to associate tasks with the transfer
+    now = datetime.datetime.now()
+    job_uuid = uuid.uuid4().__str__()
+    job = models.Job()
+    job.jobuuid = job_uuid
+    job.sipuuid = transfer_uuid
+    job.createdtime = now.__str__()
+    job.createdtimedec = int(now.strftime("%s"))
+    job.hidden = True
+    job.save()
+
+    for resource_url in object_content_urls:
+        # create task record so progress can be tracked
+        task_uuid = uuid.uuid4().__str__()
+        arguments = '"{resource_url}" "{transfer_path}"'.format(resource_url=resource_url, transfer_path=_deposit_storage_path(transfer_uuid))
+
+        """
+        # create task record so time can be tracked by the MCP client
+        # ...Django doesn't like putting 0 in datetime fields
+        # TODO: put in arguments, etc. and use proper sanitization
+        sql = "INSERT INTO Tasks (taskUUID, jobUUID, startTime) VALUES ('%s', '%s', 0)" % (task_uuid, job_uuid)
+        #sql = "INSERT INTO Tasks (taskUUID, jobUUID, startTime) VALUES ('" + task_uuid + "', '" + job_uuid + "', 0)"
+        databaseInterface.runSQL(sql)
+        _flush_transaction() # refresh ORM after manual SQL
+
+        command = '/usr/lib/archivematica/MCPClient/clientScripts/fetchFedoraCommonsObjectContent.py ' + arguments
+        exitCode, stdOut, stdError = executeOrRun("command", command)
+
+        # record task completion time
+        task = models.Task.objects.get(taskuuid=task_uuid)
+        task.exitcode = exitCode
+        task.endtime = datetime.datetime.now().__str__() # TODO: endtime seems weird... Django time zone issue?
+        task.save()
+        """
+
+    # delete temp dir
+    shutil.rmtree(temp_dir)
+
+# respond with SWORD 2.0 deposit receipt XML
+def _deposit_receipt_response(request, transfer_uuid, status_code):
+    """
+    media_iri = request.build_absolute_uri(
+        reverse('components.api.views_sword.transfer_files', args=[transfer_uuid])
+    )
+
+    edit_iri = request.build_absolute_uri(
+        reverse('components.api.views_sword.transfer', args=[transfer_uuid])
+    )
+
+    state_iri = request.build_absolute_uri(
+        reverse('components.api.views_sword.transfer_state', args=[transfer_uuid])
+    )
+    """
+
+    receipt_xml = render_to_string('locations/api/sword/deposit_receipt.xml', locals())
+
+    response = HttpResponse(receipt_xml, mimetype='text/xml', status=status_code)
+    response['Location'] = transfer_uuid
+    return response
+
+def _deposit_has_been_submitted_for_processing(deposit_uuid):
+    try:
+        deposit = models.Deposit.objects.get(uuid=deposit_uuid)
+        if deposit.status != 'complete':
+            return True
+        return False
+    except:
+        return False
+
+"""
+Example GET of service document:
+
+  curl -v http://127.0.0.1/api/v2/sword
+"""
+def service_document(request):
+    transfer_collectiion_url = request.build_absolute_uri(
+        reverse('components.api.views_sword.transfer_collection')
+    )
+
+    service_document_xml = render_to_string('api/sword/service_document.xml', locals())
+    response = HttpResponse(service_document_xml)
+    response['Content-Type'] = 'application/atomserv+xml'
+    return response
+
+"""
+Example GET of collection deposit list:
+
+  curl -v http://localhost:8000/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/collection/
+
+Example POST creation of deposit:
+
+  curl -v -H "In-Progress: true" --data-binary @mets.xml --request POST http://localhost:8000/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/collection/
+"""
+# TODO: add authentication
+# TODO: error if deposit is finalized, but has no files?
+def collection(request, location_uuid):
+    error = None
+    bad_request = None
+
+    if request.method == 'GET':
+        # return list of transfers as ATOM feed
+        feed = {
+            'title': 'Transfers',
+            #'url': request.build_absolute_uri(reverse('components.api.views_sword.transfer_collection'))
+        }
+
+        entries = []
+
+        entries = [{
+            'title': 'Hey',
+            'url': 'http://www.google.com'
+        }]
+        for uuid in _deposit_list(location_uuid):
+            deposit = Deposit.objects.get(uuid=uuid)
+            entries.append({
+                'title': deposit.name,
+                'url': 'http://www.google.com/',
+                #'url': request.build_absolute_uri(reverse('components.api.views_sword.transfer', args=[uuid]))
+            })
+
+        collection_xml = render_to_string('locations/api/sword/collection.xml', locals())
+        response = HttpResponse(collection_xml)
+        response['Content-Type'] = 'application/atom+xml;type=feed'
+        return response
+    elif request.method == 'POST':
+        # is the deposit still in progress?
+        if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'true':
+            # process creation request, if criteria met
+            if request.body != '':
+                try:
+                    temp_filepath = _write_request_body_to_temp_file(request)
+
+                    # parse XML
+                    try:
+                        tree = etree.parse(temp_filepath)
+                        root = tree.getroot()
+                        transfer_name = root.get('LABEL')
+
+                        if transfer_name == None:
+                            bad_request = 'No deposit name found in XML.'
+                        else:
+                            # assemble deposit specification
+                            transfer_specification = {'location_uuid': location_uuid}
+                            transfer_specification['name'] = transfer_name
+                            if 'HTTP_ON_BEHALF_OF' in request.META:
+                                # TODO: should get this from author header
+                                transfer_specification['sourceofacquisition'] = request.META['HTTP_ON_BEHALF_OF']
+
+                            location_path = _deposit_storage_path_root(location_uuid)
+                            if not os.path.isdir(location_path):
+                                error = {
+                                    'summary': 'Location path (%s) does not exist: contact an administrator.' % (location_path),
+                                    'status': 500
+                                }
+                            else:
+                                transfer_uuid = _create_deposit_directory_and_db_entry(transfer_specification)
+
+                                if transfer_uuid != None:
+                                    # parse XML for content URLs
+                                    object_content_urls = []
+
+                                    elements = root.iterfind("{http://www.loc.gov/METS/}fileSec/"
+                                        + "{http://www.loc.gov/METS/}fileGrp[@ID='DATASTREAMS']/"
+                                        + "{http://www.loc.gov/METS/}fileGrp[@ID='OBJ']/"
+                                        + "{http://www.loc.gov/METS/}file/"
+                                        + "{http://www.loc.gov/METS/}FLocat"
+                                    )
+
+                                    for element in elements:
+                                        object_content_urls.append(element.get('{http://www.w3.org/1999/xlink}href'))
+
+                                    # create thread so content URLs can be downloaded asynchronously
+                                    thread = threading.Thread(target=_fetch_content, args=(transfer_uuid, object_content_urls))
+                                    thread.start()
+
+                                    return _deposit_receipt_response(request, transfer_uuid, 201)
+                                else:
+                                    error = {
+                                        'summary': 'Could not create deposit: contact an administrator.',
+                                        'status': 500
+                                    }
+                    except etree.XMLSyntaxError as e:
+                        error = {
+                            'summary': 'Error parsing XML ({error_message}).'.format(error_message=str(e)),
+                            'status': 412
+                        }
+                except Exception as e:
+                    bad_request = str(e)
+            else:
+                error = {
+                    'summary': 'A request body must be sent when creating a transfer.',
+                    'status': 412
+                }
+        else:
+            # TODO: way to do one-step transfer creation by setting In-Progress to false
+            error = {
+                'summary': 'The In-Progress header must be set to true when creating a transfer.',
+                'status': 412
+            }
+    else:
+        error = {
+            'summary': 'This endpoint only responds to the GET and POST HTTP methods.',
+            'status': 405
+        }
+
+    if bad_request != None:
+        error = {
+            'summary': bad_request,
+            'status': 400
+        }
+
+    if error != None:
+        return _sword_error_response(request, error)
+
+"""
+TODO: decouple deposits and locations for shorter URLs
+
+Example POST finalization of transfer:
+
+  curl -v -H "In-Progress: false" --request http://127.0.0.1/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/deposit/5bdf83cd-5858-4152-90e2-c2426e90e7c0/
+
+Example DELETE if transfer:
+
+  curl -v -XDELETE http://127.0.0.1/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/deposit/5bdf83cd-5858-4152-90e2-c2426e90e7c0/
+"""
+# TODO: add authentication
+def deposit(request, uuid):
+    error = None
+    bad_request = None
+
+    if request.method == 'GET':
+        # details about a deposit
+        return HttpResponse('Feed XML of files for deposit' + uuid)
+    elif request.method == 'POST':
+        # is the deposit ready to be processed?
+        if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'false':
+            # TODO: check that related tasks are complete before copying
+            # ...task row must exist and task endtime must be equal to or greater than start time
+            try:
+                if _deposit_has_been_submitted_for_processing(uuid):
+                    error = {
+                        'summary': 'This deposit has already been submitted for processing.',
+                        'status': 400
+                    }
+                else:
+                    deposit = models.Deposit.objects.get(uuid=uuid)
+
+                    if len(os.listdir(deposit.full_path())) > 0:
+                        """
+                        TODO: replace this will call to dashboard API
+                        helpers.copy_to_start_transfer(transfer.currentlocation, 'standard', {'uuid': uuid})
+
+                        # wait for watch directory to determine a transfer is awaiting
+                        # approval then attempt to approve it
+                        time.sleep(5)
+                        approve_transfer_via_mcp(
+                            os.path.basename(transfer.currentlocation),
+                            'standard',
+                        1
+                        ) # TODO: replace hardcoded user ID
+                        """
+                        pass
+
+                        return _deposit_receipt_response(request, uuid, 200)
+                    else:
+                        bad_request = 'This deposit contains no files.'
+
+            except ObjectDoesNotExist:
+                error = {
+                    'summary': 'This deposit could not be found.',
+                    'status': 404
+                }
+        else:
+            bad_request = 'The In-Progress header must be set to false when starting deposit processing.'
+    elif request.method == 'PUT':
+        # update deposit
+        return HttpResponse(status=204) # No content
+    elif request.method == 'DELETE':
+        # delete deposit files
+        deposit_path = _deposit_storage_path(uuid)
+        shutil.rmtree(transfer_path)
+
+        # delete entry in Transfers table (and task?)
+        transfer = models.Transfer.objects.get(uuid=uuid)
+        transfer.delete()
+        return HttpResponse(status=204) # No content
+    else:
+        error = {
+            'summary': 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.',
+            'status': 405
+        }
+
+    if bad_request != None:
+        error = {
+            'summary': bad_request,
+            'status': 400
+        }
+
+    if error != None:
+                return _sword_error_response(request, error)
+
+"""
+Example GET of files list:
+
+  curl -v http://127.0.0.1/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
+
+Example POST of file:
+
+  curl -v -H "Content-Disposition: attachment; filename=joke.jpg" --request POST \
+    --data-binary "@joke.jpg" \
+    http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
+
+Example DELETE of all files:
+
+  curl -v -XDELETE \
+      "http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
+
+Example DELETE of file:
+
+  curl -v -XDELETE \
+    "http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media?filename=thing.jpg"
+"""
+# TODO: implement Content-MD5 header so we can verify file upload was successful
+# TODO: better Content-Disposition header parsing
+# TODO: add authentication
+def transfer_files(request, uuid):
+    if _deposit_has_been_submitted_for_processing(uuid):
+        return _sword_error_response(request, {
+            'summary': 'This transfer is already being processed by Archivematica.',
+            'status': 400
+        })
+
+    error = None
+
+    if request.method == 'GET':
+        transfer_path = _deposit_storage_path(uuid)
+        if transfer_path == None:
+            error = {
+                'summary': 'This transfer does not exist.',
+                'status': 404
+            }
+        else:
+            if os.path.exists(transfer_path):
+                return helpers.json_response(os.listdir(transfer_path))
+            else:
+                error = {
+                    'summary': 'This transfer path does not exist.',
+                    'status': 404
+                }
+    elif request.method == 'PUT':
+        # replace a file in the transfer
+        return _handle_upload_request(request, uuid, True)
+    elif request.method == 'POST':
+        # add a file to the transfer
+        return _handle_upload_request(request, uuid)
+    elif request.method == 'DELETE':
+        filename = request.GET.get('filename', '')
+        if filename != '':
+            transfer_path = _deposit_storage_path(uuid)
+            file_path = os.path.join(transfer_path, filename) 
+            if os.path.exists(file_path):
+                os.remove(file_path)
+                return HttpResponse(status=204) # No content
+            else:
+                error = {
+                    'summary': 'The transfer path does not exist.',
+                    'status': 404
+                }
+        else:
+            # delete all files in transfer
+            if _deposit_has_been_submitted_for_processing(uuid):
+                error = {
+                    'summary': 'This transfer is already being processed by Archivematica.',
+                    'status': 400
+                }
+            else:
+                transfer = models.Transfer.objects.get(uuid=uuid)
+
+                for filename in os.listdir(transfer.currentlocation):
+                    filepath = os.path.join(transfer.currentlocation, filename)
+                    if os.path.isfile(filepath):
+                        os.remove(filepath)
+                    elif os.path.isdir(filepath):
+                        shutil.rmtree(filepath)
+
+                return HttpResponse(status=204) # No content
+    else:
+        error = {
+            'summary': 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.',
+            'status': 405
+        }
+
+    if error != None:
+                return _sword_error_response(request, error)
+
+"""
+Example GET of state:
+
+  curl -v http://127.0.0.1/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/state
+"""
+# TODO: add authentication
+def transfer_state(request, uuid):
+    # TODO: add check if UUID is valid, 404 otherwise
+
+    error = None
+
+    if request.method == 'GET':
+        # In order to determine the transfer status we need to check
+        # for three possibilities:
+        #
+        # 1) The transfer involved no asynchronous depositing. There
+        #    should be no row in the Jobs table for this transfer.
+        #
+        # 2) The transfer involved asynchronous depositing, but the
+        #    depositing is incomplete. There should be a row in the
+        #    Jobs table, but the end time should be blank.
+        #
+        # 3) The transfer involved asynchronous depositing and is
+        #    complete. There should be a row in the Jobs table with
+        #    an end time.
+
+        # get transfer creation job, if any
+        job = None
+        try:
+            # get job corresponding to transfer
+            job = models.Job.objects.filter(sipuuid=uuid, hidden=True)[0]
+
+            task = None
+            if job != None:
+                try:
+                    task = models.Task.objects.filter(job=job)[0]
+                except:
+                    pass
+
+            if task != None:
+                task_state = 'Processing'
+
+            if task.endtime != None:
+                if task.exitcode == 1:
+                    task_state = 'Failed'
+                else:
+                    task_state = 'Complete'
+        except:
+            task_state = 'Complete'
+
+        state_term = task_state.lower()
+        state_description = 'Deposit initiation: ' + task_state
+
+        response = HttpResponse(render_to_string('api/sword/state.xml', locals()))
+        response['Content-Type'] = 'application/atom+xml;type=feed'
+        return response
+    else:
+        error = {
+            'summary': 'This endpoint only responds to the GET HTTP method.',
+            'status': 405
+        }
+
+    if error != None:
+                return _sword_error_response(request, error)

--- a/storage_service/locations/api/sword.py
+++ b/storage_service/locations/api/sword.py
@@ -202,19 +202,20 @@ def _fetch_content(deposit_uuid, object_content_urls):
 
 # respond with SWORD 2.0 deposit receipt XML
 def _deposit_receipt_response(request, deposit_uuid, status_code):
+    deposit = Deposit.objects.get(uuid=deposit_uuid)
+
+    # TODO: fix minor issues with template
     media_iri = request.build_absolute_uri(
-       reverse('sword_deposit_media', kwargs={'api_name': 'v1',
-           'resource_name': 'deposit', 'uuid': deposit_uuid}))
+        reverse('sword_deposit_media', kwargs={'api_name': 'v1',
+            'resource_name': 'deposit', 'uuid': deposit_uuid}))
 
     edit_iri = request.build_absolute_uri(
         reverse('sword_deposit', kwargs={'api_name': 'v1',
-                   'resource_name': 'deposit', 'uuid': deposit_uuid}))
+            'resource_name': 'deposit', 'uuid': deposit_uuid}))
 
-    """
     state_iri = request.build_absolute_uri(
-        reverse('components.api.views_sword.transfer_state', args=[transfer_uuid])
-    )
-    """
+        reverse('sword_deposit_state', kwargs={'api_name': 'v1',
+            'resource_name': 'deposit', 'uuid': deposit_uuid}))
 
     receipt_xml = render_to_string('locations/api/sword/deposit_receipt.xml', locals())
 

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -57,6 +57,15 @@ def write_request_body_to_temp_file(request):
     write_file_from_request_body(request, temp_filepath)
     return temp_filepath
 
+# recursive
+def pad_destination_filepath_if_it_already_exists(filepath, original=None, attempt=0):
+    if original == None:
+        original = filepath
+    attempt = attempt + 1
+    if os.path.exists(filepath):
+        return pad_destination_filepath_if_it_already_exists(original + '_' + str(attempt), original, attempt)
+    return filepath
+
 def download_resource(url, destination_path):
     response = urllib2.urlopen(url)
     filename = _filename_from_response(response)

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -11,17 +11,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from locations.models import Deposit
 from locations.models import Location
 
-def deposit_storage_path(uuid):
-    try:
-        deposit = Deposit.objects.get(uuid=uuid)
-        return deposit.full_path()
-    except ObjectDoesNotExist:
-        return None
-
-def deposit_location_path(location_uuid):
-    location = Location.objects.get(uuid=location_uuid)
-    return location.full_path()
-
 def deposit_list(location_uuid):
     location = Location.objects.get(uuid=location_uuid)
 

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -7,15 +7,21 @@ import urllib2
 # Core Django, alphabetical
 from django.core.exceptions import ObjectDoesNotExist
 
-# This project, alphabetical
-from locations.models import Deposit
-from locations.models import Location
+# External dependencies, alphabetical
+from annoying.functions import get_object_or_None
 
-def deposit_list(location_uuid):
-    location = Location.objects.get(uuid=location_uuid)
+# This project, alphabetical
+from locations.models import Location
+from locations.models import Space
+
+def get_deposit(uuid):
+    return get_object_or_None(Location, uuid=uuid)
+
+def deposit_list(space_uuid):
+    space = Space.objects.get(uuid=space_uuid)
 
     deposit_list = []
-    deposits = Deposit.objects.filter(location=location)
+    deposits = Location.objects.filter(space=space)
     for deposit in deposits:
         deposit_list.append(deposit.uuid)
     return deposit_list

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -21,6 +21,7 @@ def deposit_list(space_uuid):
     space = Space.objects.get(uuid=space_uuid)
 
     deposit_list = []
+    # TODO: add purpose spec to filter
     deposits = Location.objects.filter(space=space)
     for deposit in deposits:
         deposit_list.append(deposit.uuid)

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -1,5 +1,7 @@
 # stdlib, alphabetical
+import base64
 import json
+import logging
 import os
 from multiprocessing import Process
 import shutil
@@ -22,6 +24,10 @@ from locations.models import Location
 from locations.models import LocationDownloadTask
 from locations.models import Space
 from locations.models import SwordServer
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(filename="/tmp/storage_service.log",
+    level=logging.INFO)
 
 """
 Shortcut to retrieve deposit data
@@ -115,8 +121,11 @@ filename (using the filename at the end of the URL otherwise)
 Returns filename of downloaded resource
 """
 def download_resource(url, destination_path):
-    response = urllib2.urlopen(url)
-
+    logging.info('downloading url: ' + url)
+    request = urllib2.Request(url)
+    base64string = base64.encodestring('%s:%s' % ('fedoraAdmin', 'islandora')).replace('\n', '')
+    request.add_header("Authorization", "Basic %s" % base64string)   
+    response = urllib2.urlopen(request)
     info = response.info()
     if 'content-disposition' in info:
         filename = parse_filename_from_content_disposition(info['content-disposition'])

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -1,33 +1,57 @@
 # stdlib, alphabetical
+import json
 import os
+from multiprocessing import Process
+import shutil
 import subprocess
 import tempfile
+import time
+import urllib
 import urllib2
 
 # Core Django, alphabetical
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils import timezone
 
 # External dependencies, alphabetical
 from annoying.functions import get_object_or_None
+import requests
 
 # This project, alphabetical
 from locations.models import Location
+from locations.models import LocationDownloadTask
 from locations.models import Space
+from locations.models import SwordServer
 
+"""
+Shortcut to retrieve deposit data
+
+Returns deposit model object or None
+"""
 def get_deposit(uuid):
     return get_object_or_None(Location, uuid=uuid)
 
+"""
+Retrieve list of deposits
+TODO: filter out completed ones?
+
+Returns list containing deposit UUIDs
+"""
 def deposit_list(space_uuid):
     space = Space.objects.get(uuid=space_uuid)
 
     deposit_list = []
-    # TODO: add purpose spec to filter
     deposits = Location.objects.filter(space=space)
     for deposit in deposits:
         if deposit.purpose == Location.SWORD_DEPOSIT:
             deposit_list.append(deposit.uuid)
     return deposit_list
 
+"""
+Write HTTP request's body content to a file
+
+Return the number of bytes successfully written
+"""
 def write_file_from_request_body(request, file_path):
     bytes_written = 0
     new_file = open(file_path, 'ab')
@@ -39,22 +63,42 @@ def write_file_from_request_body(request, file_path):
     new_file.close()
     return bytes_written
 
+"""
+Write HTTP request's body content to a temp file
+
+Return the temp file's path
+"""
+def write_request_body_to_temp_file(request):
+    filehandle, temp_filepath = tempfile.mkstemp()
+    write_file_from_request_body(request, temp_filepath)
+    return temp_filepath
+
+"""
+Get the MD5 checksum for a file
+
+Return MD5 checksum
+"""
 def get_file_md5_checksum(filepath):
     raw_result = subprocess.Popen(["md5sum", filepath],stdout=subprocess.PIPE).communicate()[0]
     return raw_result[0:32]
 
+"""
+Parse a filename from HTTP Content-Disposition data
+
+Return filename
+"""
 def parse_filename_from_content_disposition(header):
     filename = header.split('filename=')[1]
     if filename[0] == '"' or filename[0] == "'":
         filename = filename[1:-1]
     return filename
 
-def write_request_body_to_temp_file(request):
-    filehandle, temp_filepath = tempfile.mkstemp()
-    write_file_from_request_body(request, temp_filepath)
-    return temp_filepath
+"""
+Pad a filename numerically, preserving the file extension, if it's a duplicate
+of an existing file. This function is recursive.
 
-# recursive
+Returns padded (if necessary) file path
+"""
 def pad_destination_filepath_if_it_already_exists(filepath, original=None, attempt=0):
     if original == None:
         original = filepath
@@ -63,25 +107,200 @@ def pad_destination_filepath_if_it_already_exists(filepath, original=None, attem
         return pad_destination_filepath_if_it_already_exists(original + '_' + str(attempt), original, attempt)
     return filepath
 
+"""
+Download a URL resource to a destination directory, using the response's
+Content-Disposition header, if available, to determine the destination
+filename (using the filename at the end of the URL otherwise)
+
+Returns filename of downloaded resource
+"""
 def download_resource(url, destination_path):
     response = urllib2.urlopen(url)
-    filename = _filename_from_response(response)
 
-    if filename == None:
+    info = response.info()
+    if 'content-disposition' in info:
+        filename = parse_filename_from_content_disposition(info['content-disposition'])
+    else:
         filename = os.path.basename(url)
 
     filepath = os.path.join(destination_path, filename)
-    buffer = 16 * 1024
+    buffer_size = 16 * 1024
     with open(filepath, 'wb') as fp:
         while True:
-            chunk = response.read(buffer)
+            chunk = response.read(buffer_size)
             if not chunk: break
             fp.write(chunk)
     return filename
 
-def _filename_from_response(response):
-    info = response.info()
-    if 'content-disposition' in info:
-        return parse_filename_from_content_disposition(info['content-disposition'])
+"""
+Return deposit status, indicating whether any incomplete or failed batch
+downloads exist.
+"""
+def deposit_downloading_status(deposit_uuid):
+    deposit = get_deposit(deposit_uuid)
+    tasks = LocationDownloadTask.objects.filter(location=deposit)
+    if len(tasks) > 0:
+        # check each task for completion and failure
+        complete = True
+        failed = False
+
+        for task in tasks:
+            if task.downloading_status() != 'complete':
+                complete = False
+                if task.downloading_status() == 'failed':
+                    failed = True
+        if failed:
+            return 'failed'
+        else:
+            if complete:
+                return 'complete'
+            else:
+                return 'incomplete'
     else:
-        return None
+        return 'complete'
+
+"""
+Spawn an asynchrnous batch download
+"""
+def spawn_download_task(deposit_uuid, object_content_urls):
+    p = Process(target=_fetch_content, args=(deposit_uuid, object_content_urls))
+    p.start()
+
+"""
+Download a number of files, keeping track of progress and success using a
+database record. After downloading, finalize deposit if requested.
+"""
+def _fetch_content(deposit_uuid, object_content_urls):
+    # add download task to keep track of progress
+    deposit = get_deposit(deposit_uuid)
+    task = LocationDownloadTask(location=deposit)
+    task.downloads_attempted = len(object_content_urls)
+    task.downloads_completed = 0
+    task.save()
+
+    # download the files
+    temp_dir = tempfile.mkdtemp()
+
+    completed = 0
+    for url in object_content_urls:
+        try:
+            filename = download_resource(url, temp_dir)
+            shutil.move(os.path.join(temp_dir, filename),
+                os.path.join(deposit.full_path(), filename))
+            completed += 1
+        except:
+            pass
+
+    # remove temp dir
+    shutil.rmtree(temp_dir)
+
+    # record the number of successful downloads and completion time
+    task.downloads_completed = completed
+    task.download_completion_time = timezone.now()
+    task.save()
+
+    # if the deposit is ready for finalization and this is the last batch
+    # download to complete, then finalize
+    if deposit.ready_for_finalization and deposit_downloading_status(deposit_uuid) == 'complete':
+        finalize_if_not_empty(deposit_uuid)
+
+"""
+Approve a deposit for processing and mark is as completed
+
+Returns True if completed successfully, False if not
+"""
+def finalize_if_not_empty(deposit_uuid):
+    deposit = get_deposit(deposit_uuid)
+    if len(os.listdir(deposit.full_path())) > 0:
+        # get sword server so we can access pipeline information
+        sword_server = SwordServer.objects.get(space=deposit.space)
+        result = activate_transfer_and_request_approval_from_pipeline(deposit, sword_server)
+        #result['deposit_uuid'] = deposit_uuid
+
+        if 'error' in result:
+            return _sword_error_response(request, 500, result['message'])
+
+        # mark deposit as complete and return deposit receipt
+        deposit.deposit_completion_time = timezone.now()
+        deposit.save()
+
+        return True
+    else:
+        return False
+
+"""
+Handle requesting the approval of a transfer from a pipeline via a REST call.
+
+This function returns a dict representation of the results, either returning
+the JSON returned by the request to the pipeline (converted to a dict) or
+a dict indicating a pipeline authentication issue.
+
+The dict representation is of the form:
+
+{
+    'error': <True|False>,
+    'message': <description of success or failure>
+}
+"""
+def activate_transfer_and_request_approval_from_pipeline(deposit, sword_server):
+    # make sure pipeline API access is configured
+    for property in ['remote_name', 'api_username', 'api_key']:
+        if getattr(sword_server.pipeline, property)=='':
+            property_description = property.replace('_', ' ')
+            # TODO: fix this
+            return _sword_error_response(request, 500, 'Pipeline {property} not set.'.format(property=property_description))
+
+    # TODO: add error if more than one location is returned
+    processing_location = Location.objects.get(
+        pipeline=sword_server.pipeline,
+        purpose=Location.CURRENTLY_PROCESSING)
+
+    destination_path = os.path.join(
+        processing_location.full_path(),
+        'watchedDirectories/activeTransfers/standardTransfer',
+        os.path.basename(deposit.full_path()))
+
+    # move to standard transfers directory
+    destination_path = pad_destination_filepath_if_it_already_exists(destination_path)
+    shutil.move(deposit.full_path(), destination_path)
+
+    params = {
+        'username': pipeline.api_username,
+        'api_key': pipeline.api_key
+    }
+    url = 'http://' + pipeline.remote_name + '/api/transfer/unapproved/'
+    while True:
+        response = requests.get(url, params=params)
+        if response.status_code == 200:
+            results = response.json()
+        else:
+            raise Exception("Dashboard returned {}: {}".format(response.status_code, response.text))
+
+        directories = [result['directory'] for result in results['results'] if result['type'] == 'standard']
+        if deposit.current_path in directories:
+            break
+        time.sleep(5)
+
+    # make request to pipeline's transfer approval API
+    data = urllib.urlencode({
+        'username': sword_server.pipeline.api_username,
+        'api_key': sword_server.pipeline.api_key,
+        'directory': os.path.basename(destination_path),
+        'type': 'standard'
+    })
+
+    pipeline_endpoint_url = 'http://' + sword_server.pipeline.remote_name + '/api/transfer/approve/'
+    approve_request = urllib2.Request(pipeline_endpoint_url, data)
+
+    try:
+        approve_response = urllib2.urlopen(approve_request)
+    except:
+        # move back to deposit directory
+        shutil.move(destination_path, deposit.full_path())
+        return {
+            'error': True,
+            'message': 'Request to pipeline ' + sword_server.pipeline.uuid + ' transfer approval API failed: check credentials and REST API IP whitelist.'
+        } #_sword_error_response(request, 500, 'Request to pipeline transfer approval API failed: check credentials and REST API IP whitelist.')
+
+    result = json.loads(approve_response.read())
+    return result

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -121,11 +121,14 @@ filename (using the filename at the end of the URL otherwise)
 
 Returns filename of downloaded resource
 """
-def download_resource(url, destination_path, filename=None):
+def download_resource(url, destination_path, filename=None, username=None, password=None):
     logging.info('downloading url: ' + url)
     request = urllib2.Request(url)
-    base64string = base64.encodestring('%s:%s' % ('fedoraAdmin', 'islandora')).replace('\n', '')
-    request.add_header("Authorization", "Basic %s" % base64string)   
+
+    if username != None and password != None:
+        base64string = base64.encodestring('%s:%s' % (username, password)).replace('\n', '')
+        request.add_header("Authorization", "Basic %s" % base64string)   
+
     response = urllib2.urlopen(request)
     info = response.info()
     if filename == None:
@@ -212,7 +215,14 @@ def _fetch_content(deposit_uuid, objects):
             task_file.url = item['url']
             task_file.save()
 
-            download_resource(item['url'], temp_dir, filename)
+            download_resource(
+                item['url'],
+                temp_dir,
+                filename,
+                deposit.space.fedora_user,
+                deposit.space.fedora_password
+            )
+
             shutil.move(os.path.join(temp_dir, filename),
                 os.path.join(deposit.full_path(), filename))
 

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -24,7 +24,8 @@ def deposit_list(space_uuid):
     # TODO: add purpose spec to filter
     deposits = Location.objects.filter(space=space)
     for deposit in deposits:
-        deposit_list.append(deposit.uuid)
+        if deposit.purpose == Location.SWORD_DEPOSIT:
+            deposit_list.append(deposit.uuid)
     return deposit_list
 
 def write_file_from_request_body(request, file_path):

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -223,8 +223,16 @@ def _fetch_content(deposit_uuid, objects):
                 deposit.space.fedora_password
             )
 
-            shutil.move(os.path.join(temp_dir, filename),
-                os.path.join(deposit.full_path(), filename))
+            temp_filename = os.path.join(temp_dir, filename)
+
+            if item['checksum'] is not None and item['checksum'] != get_file_md5_checksum(temp_filename):
+                os.unlink(temp_filename)
+                raise Exception("Incorrect checksum")
+
+            shutil.move(
+                temp_filename,
+                os.path.join(deposit.full_path(), filename)
+            )
 
             # mark download task file record complete or failed
             task_file.completed = True

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -202,31 +202,46 @@ def _fetch_content(deposit_uuid, object_content_urls):
     # if the deposit is ready for finalization and this is the last batch
     # download to complete, then finalize
     if deposit.ready_for_finalization and deposit_downloading_status(deposit_uuid) == 'complete':
-        finalize_if_not_empty(deposit_uuid)
+        _finalize_if_not_empty(deposit_uuid)
 
 """
-Approve a deposit for processing and mark is as completed
+Spawn an asynchronous finalization
+"""
+def spawn_finalization(deposit_uuid):
+    p = Process(target=_finalize_if_not_empty, args=(deposit_uuid, ))
+    p.start()
+
+"""
+Approve a deposit for processing and mark is as completed or finalization failed
 
 Returns True if completed successfully, False if not
 """
-def finalize_if_not_empty(deposit_uuid):
+def _finalize_if_not_empty(deposit_uuid):
     deposit = get_deposit(deposit_uuid)
-    if len(os.listdir(deposit.full_path())) > 0:
-        # get sword server so we can access pipeline information
-        sword_server = SwordServer.objects.get(space=deposit.space)
-        result = activate_transfer_and_request_approval_from_pipeline(deposit, sword_server)
-        #result['deposit_uuid'] = deposit_uuid
+    completed = False
+    
+    # don't finalize if still downloading
+    if deposit_downloading_status(deposit_uuid) == 'complete':
+        if len(os.listdir(deposit.full_path())) > 0:
+            # get sword server so we can access pipeline information
+            sword_server = SwordServer.objects.get(space=deposit.space)
+            result = activate_transfer_and_request_approval_from_pipeline(deposit, sword_server)
+            #result['deposit_uuid'] = deposit_uuid
 
-        if 'error' in result:
-            return _sword_error_response(request, 500, result['message'])
+            if 'error' in result:
+                return _sword_error_response(request, 500, result['message'])
 
-        # mark deposit as complete and return deposit receipt
+            completed = True
+
+    if completed:
+        # mark deposit as complete
         deposit.deposit_completion_time = timezone.now()
-        deposit.save()
-
-        return True
     else:
-        return False
+        # make finalization as having failed
+        deposit.finalization_attempt_failed = True
+    deposit.save()
+
+    return completed
 
 """
 Handle requesting the approval of a transfer from a pipeline via a REST call.

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -1,0 +1,81 @@
+# stdlib, alphabetical
+import os
+import subprocess
+import tempfile
+import urllib2
+
+# Core Django, alphabetical
+from django.core.exceptions import ObjectDoesNotExist
+
+# This project, alphabetical
+from locations.models import Deposit
+from locations.models import Location
+
+def deposit_storage_path(uuid):
+    try:
+        deposit = Deposit.objects.get(uuid=uuid)
+        return deposit.full_path()
+    except ObjectDoesNotExist:
+        return None
+
+def deposit_location_path(location_uuid):
+    location = Location.objects.get(uuid=location_uuid)
+    return location.full_path()
+
+def deposit_list(location_uuid):
+    location = Location.objects.get(uuid=location_uuid)
+
+    deposit_list = []
+    deposits = Deposit.objects.filter(location=location)
+    for deposit in deposits:
+        deposit_list.append(deposit.uuid)
+    return deposit_list
+
+def write_file_from_request_body(request, file_path):
+    bytes_written = 0
+    new_file = open(file_path, 'ab')
+    chunk = request.read()
+    if chunk != None:
+        new_file.write(chunk)
+        bytes_written += len(chunk)
+        chunk = request.read()
+    new_file.close()
+    return bytes_written
+
+def get_file_md5_checksum(filepath):
+    raw_result = subprocess.Popen(["md5sum", filepath],stdout=subprocess.PIPE).communicate()[0]
+    return raw_result[0:32]
+
+def parse_filename_from_content_disposition(header):
+    filename = header.split('filename=')[1]
+    if filename[0] == '"' or filename[0] == "'":
+        filename = filename[1:-1]
+    return filename
+
+def write_request_body_to_temp_file(request):
+    filehandle, temp_filepath = tempfile.mkstemp()
+    write_file_from_request_body(request, temp_filepath)
+    return temp_filepath
+
+def download_resource(url, destination_path):
+    response = urllib2.urlopen(url)
+    filename = _filename_from_response(response)
+
+    if filename == None:
+        filename = os.path.basename(url)
+
+    filepath = os.path.join(destination_path, filename)
+    buffer = 16 * 1024
+    with open(filepath, 'wb') as fp:
+        while True:
+            chunk = response.read(buffer)
+            if not chunk: break
+            fp.write(chunk)
+    return filename
+
+def _filename_from_response(response):
+    info = response.info()
+    if 'content-disposition' in info:
+        return parse_filename_from_content_disposition(info['content-disposition'])
+    else:
+        return None

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -226,7 +226,6 @@ def _finalize_if_not_empty(deposit_uuid):
             # get sword server so we can access pipeline information
             sword_server = SwordServer.objects.get(space=deposit.space)
             result = activate_transfer_and_request_approval_from_pipeline(deposit, sword_server)
-            #result['deposit_uuid'] = deposit_uuid
 
             if 'error' in result:
                 return _sword_error_response(request, 500, result['message'])

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -157,7 +157,7 @@ def _create_deposit_directory_and_db_entry(deposit_specification):
         deposit_name
     )
 
-    # TODO deposit_path = helpers.pad_destination_filepath_if_it_already_exists(deposit_path)
+    deposit_path = helpers.pad_destination_filepath_if_it_already_exists(deposit_path)
     os.mkdir(deposit_path)
     os.chmod(deposit_path, 02770) # drwxrws---
 

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -22,8 +22,8 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 
 # This project, alphabetical
-from ..models import Deposit
-from ..models import Location
+from locations.models import Deposit
+from locations.models import Location
 
 def _deposit_storage_path(uuid):
     try:

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -363,20 +363,8 @@ Returns deposit receipt response or error response
 """
 def _finalize_or_mark_for_finalization(request, deposit_uuid):
     if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'false':
-        if helpers.deposit_downloading_status(deposit_uuid) == 'complete':
-            completed = helpers.finalize_if_not_empty(deposit_uuid)
-            if completed:
-                return _deposit_receipt_response(request, deposit_uuid, 200)
-            else:
-                return _sword_error_response(request, 400, 'This deposit contains no files.')
-        else:
-            # Indicate that the deposit is ready for finalization (after all batch
-            # downloads have completed
-            deposit = helpers.get_deposit(deposit_uuid)
-            deposit.ready_for_finalization = True
-            deposit.save()
-
-            return _deposit_receipt_response(request, uuid, 203) # change to 200
+        helpers.spawn_finalization(deposit_uuid)
+        return _deposit_receipt_response(request, deposit_uuid, 200)
     else:
         return _sword_error_response(request, 400, 'The In-Progress header must be set to false when starting deposit processing.')
 
@@ -451,8 +439,14 @@ def deposit_state(request, uuid):
         return _sword_error_response(request, 404, 'Deposit location {uuid} does not exist.'.format(uuid=uuid))
 
     if request.method == 'GET':
-        state_term = helpers.deposit_downloading_status(uuid)
-        state_description = 'Deposit initiation: ' + helpers.deposit_downloading_status(uuid)
+        status = helpers.deposit_downloading_status(uuid)
+        state_term = status
+        state_description = 'Deposit initiation: ' + status
+
+        # if deposit hasn't been finalized and last finalization attempt
+        # failed, note failed finalization
+        if deposit.finalization_attempt_failed and deposit.deposit_completion_time==None:
+            state_description += ' (last finalization attempt failed)'
 
         response = HttpResponse(render_to_string('locations/api/sword/state.xml', locals()))
         response['Content-Type'] = 'application/atom+xml;type=feed'

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -75,6 +75,11 @@ Example POST creation of deposit, finalizing the deposit and auto-approving it:
   curl -v -H "In-Progress: false" --data-binary @mets.xml --request POST http://localhost:8000/api/v1/location/c0bee7c8-3e9b-41e3-8600-ee9b2c475da2/sword/collection/?approval_pipeline=41b57f04-9738-43d8-b80e-3fad88c75abc
 """
 def collection(request, location_uuid):
+    location = get_object_or_None(Location, uuid=location_uuid)
+    if location == None:
+        error = _error(404, 'Location {uuid} does not exist.'.format(uuid=location_uuid))
+        return _sword_error_response(request, error)
+
     error = None
 
     if request.method == 'GET':
@@ -246,6 +251,10 @@ Example DELETE of deposit:
 def deposit_edit(request, uuid):
     deposit = get_object_or_None(Deposit, uuid=uuid)
 
+    if deposit == None:
+        error = _error(404, 'Deposit {uuid} does not exist.'.format(uuid=uuid))
+        return _sword_error_response(request, error)
+
     if deposit.has_been_submitted_for_processing():
         return _sword_error_response(request, {
             'summary': 'This deposit has already been submitted for processing.',
@@ -364,6 +373,10 @@ Example DELETE of file:
 def deposit_media(request, uuid):
     deposit = get_object_or_None(Deposit, uuid=uuid)
 
+    if deposit == None:
+        error = _error(404, 'Deposit {uuid} does not exist.'.format(uuid=uuid))
+        return _sword_error_response(request, error)
+
     if deposit.has_been_submitted_for_processing():
         return _sword_error_response(request, {
             'summary': 'This deposit has already been submitted for processing.',
@@ -475,7 +488,11 @@ Example GET of state:
   curl -v http://localhost:8000/api/v1/deposit/96606387-cc70-4b09-b422-a7220606488d/sword/state/
 """
 def deposit_state(request, uuid):
-    # TODO: add check if UUID is valid, 404 otherwise
+    deposit = get_object_or_None(Deposit, uuid=uuid)
+
+    if deposit == None:
+        error = _error(404, 'Deposit {uuid} does not exist.'.format(uuid=uuid))
+        return _sword_error_response(request, error)
 
     error = None
 

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -104,6 +104,7 @@ def collection(request, space_uuid):
         response = HttpResponse(collection_xml)
         response['Content-Type'] = 'application/atom+xml;type=feed'
         return response
+
     elif request.method == 'POST':
         # has the In-Progress header been set?
         if 'HTTP_IN_PROGRESS' in request.META:
@@ -276,9 +277,18 @@ def _parse_name_and_content_urls_from_mets_file(filepath):
     for element in elements:
        url = element.get('{http://www.w3.org/1999/xlink}href')
        filename = element.get('{http://www.w3.org/1999/xlink}title')
+
+       # only MD5 checksums currently supported
+       checksumtype = element.get('CHECKSUMTYPE')
+       checksum = element.get('CHECKSUM')
+
+       if checksum is not None and checksumtype != 'MD5':
+           raise Exception('If using CHECKSUM attribute, CHECKSUMTYPE attribute value must be set to MD5 in XML')
+
        objects.append({
            'filename': filename,
-           'url': url
+           'url': url,
+           'checksum': checksum
        })
        logging.info('found url in mets: ' + url)
 

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -25,7 +25,64 @@ from locations.models import Location
 from locations.models import Pipeline
 from locations.models import Space
 from locations.models import SwordServer
+from locations.models import LocationDownloadTask
 import helpers
+
+def deposit_downloading_status(deposit_uuid):
+    deposit = helpers.get_deposit(deposit_uuid)
+    tasks = LocationDownloadTask.objects.filter(location=deposit)
+    if len(tasks) > 0:
+        # check each task for completion and failure
+        complete = True
+        failed = False
+
+        for task in tasks:
+            if task.downloading_status() != 'complete':
+                complete = False
+                if task.downloading_status() == 'failed':
+                    failed = True
+        if failed:
+            return 'failed'
+        else:
+            if complete:
+                return 'complete'
+            else:
+                return 'incomplete'
+    else:
+        return 'complete'
+
+def spawn_download_task(deposit_uuid, object_content_urls):
+    p = Process(target=_fetch_content, args=(deposit_uuid, object_content_urls))
+    p.start()
+
+def _fetch_content(deposit_uuid, object_content_urls):
+    # add download task to keep track of progress
+    deposit = helpers.get_deposit(deposit_uuid)
+    task = LocationDownloadTask(location=deposit)
+    task.downloads_attempted = len(object_content_urls)
+    task.downloads_completed = 0
+    task.save()
+
+    # download the files
+    temp_dir = tempfile.mkdtemp()
+
+    completed = 0
+    for url in object_content_urls:
+        try:
+            filename = helpers.download_resource(url, temp_dir)
+            shutil.move(os.path.join(temp_dir, filename),
+                os.path.join(deposit.full_path(), filename))
+            completed += 1
+        except:
+            pass
+
+    # remove temp dir
+    shutil.rmtree(temp_dir)
+
+    # record the number of successful downloads and completion time
+    task.downloads_completed = completed
+    task.download_completion_time = timezone.now()
+    task.save()
 
 """
 Example GET of service document:
@@ -134,8 +191,7 @@ def collection(request, space_uuid):
                                 if deposit_uuid != None:
                                     if request.META['HTTP_IN_PROGRESS'] == 'true':
                                         # create subprocess so content URLs can be downloaded asynchronously
-                                        p = Process(target=_fetch_content, args=(deposit_uuid, mets_data['object_content_urls']))
-                                        p.start()
+                                        spawn_download_task(deposit_uuid, mets_data['object_content_urls'])
                                         return _deposit_receipt_response(request, deposit_uuid, 201)
                                     else:
                                         # fetch content synchronously then finalize transfer
@@ -256,34 +312,6 @@ def _create_deposit_directory_and_db_entry(deposit_specification):
         deposit.save()
         return deposit.uuid
 
-def _fetch_content(deposit_uuid, object_content_urls):
-    # update deposit with number of files that need to be downloaded
-    deposit = helpers.get_deposit(deposit_uuid)
-    deposit.downloads_attempted = len(object_content_urls)
-    deposit.downloads_completed = 0
-    deposit.save()
-
-    # download the files
-    temp_dir = tempfile.mkdtemp()
-
-    completed = 0
-    for url in object_content_urls:
-        try:
-            filename = helpers.download_resource(url, temp_dir)
-            completed += 1
-        except:
-            pass
-        shutil.move(os.path.join(temp_dir, filename),
-            os.path.join(deposit.full_path(), filename))
-
-    # remove temp dir
-    shutil.rmtree(temp_dir)
-
-    # record the number of successful downloads and completion time
-    deposit.downloads_completed = completed
-    deposit.download_completion_time = timezone.now()
-    deposit.save()
-
 """
 Example POST finalization of deposit:
 
@@ -319,7 +347,7 @@ def deposit_edit(request, uuid):
     elif request.method == 'POST':
         # is the deposit ready to be processed?
         if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'false':
-            if deposit.downloading_status() == 'complete':
+            if deposit_downloading_status(uuid) == 'complete':
                 if len(os.listdir(deposit.full_path())) > 0:
                     # get sword server so we can access pipeline information
                     sword_server = SwordServer.objects.get(space=deposit.space)
@@ -537,8 +565,8 @@ def deposit_state(request, uuid):
         return _sword_error_response(request, 404, 'Deposit location {uuid} does not exist.'.format(uuid=uuid))
 
     if request.method == 'GET':
-        state_term = deposit.downloading_status()
-        state_description = 'Deposit initiation: ' + deposit.downloading_status()
+        state_term = deposit_downloading_status(uuid)
+        state_description = 'Deposit initiation: ' + deposit_downloading_status(uuid)
 
         response = HttpResponse(render_to_string('locations/api/sword/state.xml', locals()))
         response['Content-Type'] = 'application/atom+xml;type=feed'

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -310,7 +310,9 @@ def deposit_edit(request, uuid):
                     try:
                         approve_response = urllib2.urlopen(approve_request)
                     except:
-                        return _sword_error_response(request, 500, 'Request to pipeline transfer approval API failed: check credentials.')
+                        # move back to deposit directory
+                        shutil.move(destination_path, deposit.full_path())
+                        return _sword_error_response(request, 500, 'Request to pipeline transfer approval API failed: check credentials and REST API IP whitelist.')
 
                     result = json.loads(approve_response.read())
                     if 'error' in result:

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -251,8 +251,19 @@ def deposit_edit(request, uuid):
         return _sword_error_response(request, 400, 'This deposit has already been submitted for processing.')
 
     if request.method == 'GET':
-        # details about a deposit
-        return HttpResponse('Feed XML of files for deposit' + uuid)
+        deposit = helpers.get_deposit(uuid)
+        edit_iri = request.build_absolute_uri(
+            reverse(
+                'sword_deposit',
+                kwargs={'api_name': 'v1', 'resource_name': 'location', 'uuid': deposit.uuid}))
+
+        entry = {
+            'title': deposit.description,
+            'url': edit_iri
+        }
+        response = HttpResponse(render_to_string('locations/api/sword/entry.xml', locals()))
+        response['Content-Type'] = 'application/atom+xml'
+        return response
     elif request.method == 'POST':
         # is the deposit ready to be processed?
         if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'false':

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -143,7 +143,6 @@ def collection(request, space_uuid):
                     else:
                         return _sword_error_response(request, 400, 'source_location is set, but relative_path_to_files is not.')
                 else:
-                    # TODO: consider removing this?
                     result = deposit_from_location_relative_path(source_location, relative_path_to_files, space.uuid)
                     if 'error' in result and result['error'] != None:
                         return _sword_error_response(request, 500, result['message'])

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -225,8 +225,6 @@ def _fetch_content(deposit_uuid, object_content_urls):
     deposit.save()
 
 """
-TODO: decouple deposits and locations for shorter URLs
-
 Example POST finalization of deposit:
 
   curl -v -H "In-Progress: false" --request POST http://127.0.0.1:8000/api/v1/deposit/149cc29d-6472-4bcf-bee8-f8223bf60580/sword/
@@ -464,7 +462,6 @@ Example GET of state:
 
   curl -v http://localhost:8000/api/v1/deposit/96606387-cc70-4b09-b422-a7220606488d/sword/state/
 """
-# TODO: add authentication
 def deposit_state(request, uuid):
     # TODO: add check if UUID is valid, 404 otherwise
 
@@ -554,9 +551,7 @@ def _error(status, summary):
 # TODO: is this right?
 def _deposit_has_been_submitted_for_processing(deposit_uuid):
     try:
-        deposit = models.Deposit.objects.get(uuid=deposit_uuid)
-        if deposit.status != 'complete':
-            return True
-        return False
-    except:
+        deposit = Deposit.objects.get(uuid=deposit_uuid)
+        return deposit.deposit_completion_time != None
+    except ObjectDoesNotExist:
         return False

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -29,7 +29,7 @@ import helpers
 """
 Example GET of service document:
 
-  curl -v http://127.0.0.1:8000/api/v1/space/969959bc-5f20-4c6f-9e9b-fcc4e19d6cd5/sword/
+  curl -v http://127.0.0.1:8000/api/v1/sword/
 """
 def service_document(request):
     spaces = Space.objects.filter(access_protocol='SWORD_S')

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -29,6 +29,11 @@ from locations.models import SwordServer
 from locations.models import LocationDownloadTask
 import helpers
 
+"""
+Return deposit status, indicating whether any incomplete or failed batch
+downloads exist.
+"""
+# TODO: move to helpers
 def deposit_downloading_status(deposit_uuid):
     deposit = helpers.get_deposit(deposit_uuid)
     tasks = LocationDownloadTask.objects.filter(location=deposit)
@@ -52,10 +57,19 @@ def deposit_downloading_status(deposit_uuid):
     else:
         return 'complete'
 
+"""
+Spawn an asynchrnous batch download
+"""
+# TODO: move to helpers
 def spawn_download_task(deposit_uuid, object_content_urls):
     p = Process(target=_fetch_content, args=(deposit_uuid, object_content_urls))
     p.start()
 
+"""
+Download a number of files, keeping track of progress and success using a
+database record. After downloading, finalize deposit if requested.
+"""
+# TODO: move to helpers
 def _fetch_content(deposit_uuid, object_content_urls):
     # add download task to keep track of progress
     deposit = helpers.get_deposit(deposit_uuid)
@@ -84,6 +98,11 @@ def _fetch_content(deposit_uuid, object_content_urls):
     task.downloads_completed = completed
     task.download_completion_time = timezone.now()
     task.save()
+
+    # if the deposit is ready for finalization and this is the last batch
+    # download to complete, then finalize
+    if deposit.ready_for_finalization and deposit_downloading_status(deposit_uuid) == 'complete':
+        _finalize_if_not_empty(deposit_uuid)
 
 """
 Example GET of service document:
@@ -187,7 +206,8 @@ def collection(request, space_uuid):
                                 deposit_uuid = _create_deposit_directory_and_db_entry(deposit_specification)
 
                                 if deposit_uuid != None:
-                                    _handle_batch_download_depending_on_whether_request_specifies_finalization(deposit_uuid, request, mets_data)
+                                    _spawn_batch_download_and_flag_finalization_if_requested(deposit_uuid, request, mets_data)
+
                                     if request.META['HTTP_IN_PROGRESS'] == 'true':
                                         return _deposit_receipt_response(request, deposit_uuid, 201)
                                     else:
@@ -250,15 +270,23 @@ def deposit_from_location_relative_path(source_location, relative_path_to_files,
     result['deposit_uuid'] = deposit_uuid
     return result
 
-# If HTTP_IN_PROGRESS is set to true, spawn async batch download
-# Once async finalization is implemented, this function will be redundant
-def _handle_batch_download_depending_on_whether_request_specifies_finalization(deposit_uuid, request, mets_data):
-    if request.META['HTTP_IN_PROGRESS'] == 'true':
-        # create subprocess so content URLs can be downloaded asynchronously
-        spawn_download_task(deposit_uuid, mets_data['object_content_urls'])
-    else:
-        # fetch content synchronously then finalize transfer
-        _fetch_content(deposit_uuid, mets_data['object_content_urls'])
+"""
+Rename this function...
+
+Spawn a batch download, optionally setting finalization beforehand.
+
+If HTTP_IN_PROGRESS is set to true, spawn async batch download
+"""
+def _spawn_batch_download_and_flag_finalization_if_requested(deposit_uuid, request, mets_data):
+    if request.META['HTTP_IN_PROGRESS'] == 'false':
+        # Indicate that the deposit is ready for finalization (after all batch
+        # downloads have completed)
+        deposit = helpers.get_deposit(deposit_uuid)
+        deposit.ready_for_finalization = True
+        deposit.save()
+
+    # create subprocess so content URLs can be downloaded asynchronously
+    spawn_download_task(deposit_uuid, mets_data['object_content_urls'])
 
 # returns None if didn't parse correctly
 def _parse_name_and_content_urls_from_request_body(request):
@@ -294,19 +322,25 @@ def _parse_name_and_content_urls_from_mets_file(filepath):
         'object_content_urls': object_content_urls
     }
 
+"""
+Create a new deposit location from a specification, optionally copying
+files to it from a source path.
+"""
 def _create_deposit_directory_and_db_entry(deposit_specification):
+    # Formulate deposit name using specification
     if 'name' in deposit_specification:
         deposit_name = deposit_specification['name']
     else:
         deposit_name = 'Untitled'
 
+    # Formulate deposit path using space path and deposit name
     space = Space.objects.get(uuid=deposit_specification['space_uuid']) 
-
     deposit_path = os.path.join(
         space.path,
         deposit_name
     )
 
+    # Pad deposit path, if it already exists, and either copy source data to it or just create it
     deposit_path = helpers.pad_destination_filepath_if_it_already_exists(deposit_path)
     if 'source_path' in deposit_specification and deposit_specification['source_path'] != '':
         shutil.copytree(deposit_specification['source_path'], deposit_path)
@@ -314,6 +348,7 @@ def _create_deposit_directory_and_db_entry(deposit_specification):
         os.mkdir(deposit_path)
         os.chmod(deposit_path, 02770) # drwxrws---
 
+    # Create SWORD deposit location using deposit name and path
     if os.path.exists(deposit_path):
         deposit = Location.objects.create(description=deposit_name, relative_path=os.path.basename(deposit_path),
             space=space, purpose=Location.SWORD_DEPOSIT)
@@ -358,35 +393,20 @@ def deposit_edit(request, uuid):
         response['Content-Type'] = 'application/atom+xml'
         return response
     elif request.method == 'POST':
+        # If METS XML has been sent to indicate a list of files needing downloading, handle it
         if request.body != '':
             mets_data = _parse_name_and_content_urls_from_request_body(request)
             if mets_data != None:
-                _handle_batch_download_depending_on_whether_request_specifies_finalization(uuid, request, mets_data)
+                _spawn_batch_download_and_flag_finalization_if_requested(uuid, request, mets_data)
+                return _deposit_receipt_response(request, uuid, 200)
             else:
                 return _sword_error_response(request, 412, 'Error parsing XML ({error_message}).'.format(error_message=str(e)))
-
-        # is the deposit ready to be processed?
-        if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'false':
-            if deposit_downloading_status(uuid) == 'complete':
-                if len(os.listdir(deposit.full_path())) > 0:
-                    # get sword server so we can access pipeline information
-                    sword_server = SwordServer.objects.get(space=deposit.space)
-                    result = _activate_transfer_and_request_approval_from_pipeline(deposit, sword_server)
-                    #result['deposit_uuid'] = deposit_uuid
-
-                    if 'error' in result:
-                        return _sword_error_response(request, 500, result['message'])
-
-                    # mark deposit as complete and return deposit receipt
-                    deposit.deposit_completion_time = timezone.now()
-                    deposit.save()
-                    return _deposit_receipt_response(request, uuid, 200)
-                else:
-                    return _sword_error_response(request, 400, 'This deposit contains no files.')
-            else:
-                return _sword_error_response(request, 400, 'Deposit is not complete or has failed.')
         else:
-            return _sword_error_response(request, 400, 'The In-Progress header must be set to false when starting deposit processing.')
+            # Attempt to finalize (if requested), otherwise just return deposit receipt
+            if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'false':
+                return _finalize_or_mark_for_finalization(request, uuid)
+            else:
+                return _deposit_receipt_response(request, uuid, 200)
     elif request.method == 'PUT':
         # TODO: implement update deposit
         return HttpResponse(status=204) # No content
@@ -401,6 +421,48 @@ def deposit_edit(request, uuid):
         return HttpResponse(status=204) # No content
     else:
         return _sword_error_response(request, 405, 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.')
+
+#
+#
+#  return True if completed successfully
+#
+def _finalize_if_not_empty(deposit_uuid):
+    deposit = helpers.get_deposit(deposit_uuid)
+    if len(os.listdir(deposit.full_path())) > 0:
+        # get sword server so we can access pipeline information
+        sword_server = SwordServer.objects.get(space=deposit.space)
+        result = _activate_transfer_and_request_approval_from_pipeline(deposit, sword_server)
+        #result['deposit_uuid'] = deposit_uuid
+
+        if 'error' in result:
+            return _sword_error_response(request, 500, result['message'])
+
+        # mark deposit as complete and return deposit receipt
+        deposit.deposit_completion_time = timezone.now()
+        deposit.save()
+
+        return True
+    else:
+        return False
+
+def _finalize_or_mark_for_finalization(request, deposit_uuid):
+    if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'false':
+        if deposit_downloading_status(deposit_uuid) == 'complete':
+            completed = _finalize_if_not_empty(deposit_uuid)
+            if completed:
+                return _deposit_receipt_response(request, deposit_uuid, 200)
+            else:
+                return _sword_error_response(request, 400, 'This deposit contains no files.')
+        else:
+            # Indicate that the deposit is ready for finalization (after all batch
+            # downloads have completed
+            deposit = helpers.get_deposit(deposit_uuid)
+            deposit.ready_for_finalization = True
+            deposit.save()
+
+            return _deposit_receipt_response(request, uuid, 203) # change to 200
+    else:
+        return _sword_error_response(request, 400, 'The In-Progress header must be set to false when starting deposit processing.')
 
 """
 Handle requesting the approval of a transfer from a pipeline via a REST call.

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -478,7 +478,7 @@ def _deposit_receipt_response(request, deposit_uuid, status_code):
     receipt_xml = render_to_string('locations/api/sword/deposit_receipt.xml', locals())
 
     response = HttpResponse(receipt_xml, mimetype='text/xml', status=status_code)
-    response['Location'] = deposit_uuid
+    response['Location'] = '/api/v1/location/' + deposit_uuid + '/sword/'
     return response
 
 def _sword_error_response_render(request, error_details):

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -85,7 +85,7 @@ def collection(request, space_uuid):
         entries = []
 
         for uuid in helpers.deposit_list(space_uuid):
-            deposit = Location.objects.get(uuid=uuid)
+            deposit = helpers.get_deposit(uuid)
 
             edit_iri = request.build_absolute_uri(
                 reverse('sword_deposit', kwargs={'api_name': 'v1',
@@ -195,7 +195,7 @@ def _create_deposit_directory_and_db_entry(deposit_specification):
 
     if os.path.exists(deposit_path):
         deposit = Location.objects.create(description=deposit_name, relative_path=deposit_name,
-            space=space)
+            space=space, purpose=Location.SWORD_DEPOSIT)
 
         # TODO: implement this
         if 'sourceofacquisition' in deposit_specification:
@@ -206,7 +206,7 @@ def _create_deposit_directory_and_db_entry(deposit_specification):
 
 def _fetch_content(deposit_uuid, object_content_urls):
     # update deposit with number of files that need to be downloaded
-    deposit = Location.objects.get(uuid=deposit_uuid)
+    deposit = helpers.get_deposit(deposit_uuid)
     deposit.downloads_attempted = len(object_content_urls)
     deposit.downloads_completed = 0
     deposit.save()
@@ -322,7 +322,7 @@ def deposit_edit(request, uuid):
         shutil.rmtree(deposit.full_path())
 
         # delete deposit
-        deposit = Location.objects.get(uuid=uuid)
+        deposit = helpers.get_deposit(uuid)
         deposit.delete()
 
         return HttpResponse(status=204) # No content

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -1,5 +1,6 @@
 # stdlib, alphabetical
 import datetime
+import logging
 from lxml import etree as etree
 import os
 import shutil
@@ -21,6 +22,12 @@ from locations.models import Pipeline
 from locations.models import Space
 from locations.models import SwordServer
 import helpers
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(filename="/tmp/storage_service.log",
+    level=logging.INFO)
+
+logging.info('starting sword service')
 
 """
 Example GET of service document:
@@ -216,13 +223,18 @@ From a request's body, parse deposit name and control URLs from METS XML
 Returns None if parsing fails
 """
 def _parse_name_and_content_urls_from_request_body(request):
+    logging.info('getting name and content from request: ' + request.read())
     temp_filepath = helpers.write_request_body_to_temp_file(request)
+    logging.info ('temp file path: ' + temp_filepath)
 
     # parse name and content URLs out of XML
     try:
         mets_data = _parse_name_and_content_urls_from_mets_file(temp_filepath)
+        os.unlink(temp_filepath)
+        logging.info (mets_data)
         return mets_data
     except etree.XMLSyntaxError as e:
+        os.unlink(temp_filepath)
         return None
 
 """
@@ -234,6 +246,7 @@ def _parse_name_and_content_urls_from_mets_file(filepath):
     tree = etree.parse(filepath)
     root = tree.getroot()
     deposit_name = root.get('LABEL')
+    logging.info('found deposit name in mets: ' + deposit_name)
 
     # parse XML for content URLs
     object_content_urls = []
@@ -246,7 +259,9 @@ def _parse_name_and_content_urls_from_mets_file(filepath):
     )
 
     for element in elements:
-       object_content_urls.append(element.get('{http://www.w3.org/1999/xlink}href'))
+       new_url = element.get('{http://www.w3.org/1999/xlink}href')
+       object_content_urls.append(new_url)
+       logging.info('found url in mets: ' + new_url)
 
     return {
         'deposit_name': deposit_name,

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -35,7 +35,7 @@ Example GET of service document:
 def service_document(request, space_uuid):
     space = get_object_or_None(Space, uuid=space_uuid)
     if space == None:
-        return _sword_error_response(404, 'Space {uuid} does not exist.'.format(uuid=space_uuid))
+        return _sword_error_response(request, 404, 'Space {uuid} does not exist.'.format(uuid=space_uuid))
 
     locations = Location.objects.filter(space=space)
 
@@ -77,7 +77,7 @@ def collection(request, location_uuid):
     location = get_object_or_None(Location, uuid=location_uuid)
 
     if location == None:
-        return _sword_error_response(404, 'Location {uuid} does not exist.'.format(uuid=location_uuid))
+        return _sword_error_response(request, 404, 'Location {uuid} does not exist.'.format(uuid=location_uuid))
 
     if request.method == 'GET':
         # return list of deposits as ATOM feed
@@ -121,7 +121,7 @@ def collection(request, location_uuid):
                         mets_data = _parse_name_and_content_urls_from_mets_file(temp_filepath)
 
                         if mets_data['deposit_name'] == None:
-                            return _sword_error_response(400, 'No deposit name found in XML.')
+                            return _sword_error_response(request, 400, 'No deposit name found in XML.')
                         else:
                             # assemble deposit specification
                             deposit_specification = {'location_uuid': location_uuid}
@@ -131,7 +131,7 @@ def collection(request, location_uuid):
                                 deposit_specification['sourceofacquisition'] = request.META['HTTP_ON_BEHALF_OF']
 
                             if not os.path.isdir(location.full_path()):
-                                return  _sword_error_response(500, 'Location path (%s) does not exist: contact an administrator.' % (location.full_path()))
+                                return  _sword_error_response(request, 500, 'Location path (%s) does not exist: contact an administrator.' % (location.full_path()))
                             else:
                                 deposit_uuid = _create_deposit_directory_and_db_entry(deposit_specification)
 
@@ -146,20 +146,20 @@ def collection(request, location_uuid):
                                         _fetch_content(deposit_uuid, mets_data['object_content_urls'])
                                         return deposit_edit(request, deposit_uuid)
                                 else:
-                                    return _sword_error_response(500, 'Could not create deposit: contact an administrator.')
+                                    return _sword_error_response(request, 500, 'Could not create deposit: contact an administrator.')
                     except etree.XMLSyntaxError as e:
-                        return _sword_error_response(412, 'Error parsing XML ({error_message}).'.format(error_message=str(e)))
+                        return _sword_error_response(request, 412, 'Error parsing XML ({error_message}).'.format(error_message=str(e)))
                 except Exception as e:
                     import sys
                     exc_type, exc_obj, exc_tb = sys.exc_info()
                     fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
-                    return _sword_error_response(400, 'Contact administration: ' + str(exc_type) + ' ' + str(fname) + ' ' + str(exc_tb.tb_lineno))
+                    return _sword_error_response(request, 400, 'Contact administration: ' + str(exc_type) + ' ' + str(fname) + ' ' + str(exc_tb.tb_lineno))
             else:
-                return _sword_error_response(412, 'A request body must be sent when creating a deposit.')
+                return _sword_error_response(request, 412, 'A request body must be sent when creating a deposit.')
         else:
-            return _sword_error_response(412, 'The In-Progress header must be set to either true or false when creating a deposit.')
+            return _sword_error_response(request, 412, 'The In-Progress header must be set to either true or false when creating a deposit.')
     else:
-        return _sword_error_response(405, 'This endpoint only responds to the GET and POST HTTP methods.')
+        return _sword_error_response(request, 405, 'This endpoint only responds to the GET and POST HTTP methods.')
 
 def _parse_name_and_content_urls_from_mets_file(filepath):
     tree = etree.parse(filepath)
@@ -254,10 +254,10 @@ def deposit_edit(request, uuid):
     deposit = get_object_or_None(Deposit, uuid=uuid)
 
     if deposit == None:
-        return _sword_error_response(404, 'Deposit {uuid} does not exist.'.format(uuid=uuid))
+        return _sword_error_response(request, 404, 'Deposit {uuid} does not exist.'.format(uuid=uuid))
 
     if deposit.has_been_submitted_for_processing():
-        return _sword_error_response(400, 'This deposit has already been submitted for processing.')
+        return _sword_error_response(request, 400, 'This deposit has already been submitted for processing.')
 
     if request.method == 'GET':
         # details about a deposit
@@ -266,62 +266,64 @@ def deposit_edit(request, uuid):
         # is the deposit ready to be processed?
         if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'false':
             deposit = Deposit.objects.get(uuid=uuid)
+            if _deposit_state_summary(deposit) == 'Complete':
+                if len(os.listdir(deposit.full_path())) > 0:
+                    # optionally auto-approve
+                    approval_pipeline = request.GET.get('approval_pipeline', '')
 
-            if len(os.listdir(deposit.full_path())) > 0:
-                # optionally auto-approve
-                approval_pipeline = request.GET.get('approval_pipeline', '')
+                    # if auto-approve is being used, test configuration
+                    if approval_pipeline != '':
+                        try:
+                            pipeline = Pipeline.objects.get(uuid=approval_pipeline)
+                        except ObjectDoesNotExist:
+                            return _sword_error_response(request, 400, 'Pipeline {uuid} does not exist.'.format(uuid=approval_pipeline))
 
-                # if auto-approve is being used, test configuration
-                if approval_pipeline != '':
-                    try:
-                        pipeline = Pipeline.objects.get(uuid=approval_pipeline)
-                    except ObjectDoesNotExist:
-                        return _sword_error_response(400, 'Pipeline {uuid} does not exist.'.format(uuid=approval_pipeline))
+                        # make sure pipeline API access is configured
+                        for property in ['remote_name', 'api_username', 'api_key']:
+                            if getattr(pipeline, property)=='':
+                                property_description = property.replace('_', ' ')
+                                return _sword_error_response(request, 500, 'Pipeline {property} not set.'.format(property=property_description))
 
-                    # make sure pipeline API access is configured
-                    for property in ['remote_name', 'api_username', 'api_key']:
-                        if getattr(pipeline, property)=='':
-                            property_description = property.replace('_', ' ')
-                            return _sword_error_response(500, 'Pipeline {property} not set.'.format(property=property_description))
+                    # TODO... how to get appropriate destination path?
+                    destination_path = '/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/standardTransfer/' + os.path.basename(deposit.full_path())
 
-                # TODO... how to get appropriate destination path?
-                destination_path = '/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/standardTransfer/' + os.path.basename(deposit.full_path())
+                    # move to standard transfers directory
+                    destination_path = helpers.pad_destination_filepath_if_it_already_exists(destination_path)
+                    shutil.move(deposit.full_path(), destination_path)
 
-                # move to standard transfers directory
-                destination_path = helpers.pad_destination_filepath_if_it_already_exists(destination_path)
-                shutil.move(deposit.full_path(), destination_path)
+                    # handle auto-approval
+                    if approval_pipeline != '':
+                        # wait to make sure the MCP responds to the directory being in the watch directory
+                        time.sleep(2)
 
-                # handle auto-approval
-                if approval_pipeline != '':
-                    # wait to make sure the MCP responds to the directory being in the watch directory
-                    time.sleep(2)
+                        # make request to pipeline's transfer approval API
+                        data = urllib.urlencode({
+                            'username': pipeline.api_username,
+                            'api_key': pipeline.api_key,
+                            'directory': os.path.basename(destination_path),
+                            'type': 'standard' # TODO: make this customizable via a URL param
+                        })
+                        approve_request = urllib2.Request('http://' + pipeline.remote_name + '/api/transfer/approve/', data)
 
-                    # make request to pipeline's transfer approval API
-                    data = urllib.urlencode({
-                        'username': pipeline.api_username,
-                        'api_key': pipeline.api_key,
-                        'directory': os.path.basename(destination_path),
-                        'type': 'standard' # TODO: make this customizable via a URL param
-                    })
-                    approve_request = urllib2.Request('http://' + pipeline.remote_name + '/api/transfer/approve/', data)
+                        try:
+                            approve_response = urllib2.urlopen(approve_request)
+                        except:
+                            return _sword_error_response(request, 500, 'Request to pipeline transfer approval API failed: check credentials.')
 
-                    try:
-                        approve_response = urllib2.urlopen(approve_request)
-                    except:
-                        return _sword_error_response(500, 'Request to pipeline transfer approval API failed: check credentials.')
+                        result = json.loads(approve_response.read())
+                        if 'error' in result:
+                            return _sword_error_response(request, 500, result['message'])
 
-                    result = json.loads(approve_response.read())
-                    if 'error' in result:
-                        return _sword_error_response(500, result['message'])
-
-                # mark deposit as complete and return deposit receipt
-                deposit.deposit_completion_time = timezone.now()
-                deposit.save()
-                return _deposit_receipt_response(request, uuid, 200)
+                    # mark deposit as complete and return deposit receipt
+                    deposit.deposit_completion_time = timezone.now()
+                    deposit.save()
+                    return _deposit_receipt_response(request, uuid, 200)
+                else:
+                    return _sword_error_response(request, 400, 'This deposit contains no files.')
             else:
-                return _sword_error_response(400, 'This deposit contains no files.')
+                return _sword_error_response(request, 400, 'Deposit is not complete or has failed.')
         else:
-            return _sword_error_response(400, 'The In-Progress header must be set to false when starting deposit processing.')
+            return _sword_error_response(request, 400, 'The In-Progress header must be set to false when starting deposit processing.')
     elif request.method == 'PUT':
         # TODO: implement update deposit
         return HttpResponse(status=204) # No content
@@ -335,7 +337,7 @@ def deposit_edit(request, uuid):
 
         return HttpResponse(status=204) # No content
     else:
-        return _sword_error_response(405, 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.')
+        return _sword_error_response(request, 405, 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.')
 
 """
 Example GET of files list:
@@ -362,10 +364,10 @@ def deposit_media(request, uuid):
     deposit = get_object_or_None(Deposit, uuid=uuid)
 
     if deposit == None:
-        return _sword_error_response(404, 'Deposit {uuid} does not exist.'.format(uuid=uuid))
+        return _sword_error_response(request, 404, 'Deposit {uuid} does not exist.'.format(uuid=uuid))
 
     if deposit.has_been_submitted_for_processing():
-        return _sword_error_response(400, 'This deposit has already been submitted for processing.')
+        return _sword_error_response(request, 400, 'This deposit has already been submitted for processing.')
 
     if request.method == 'GET':
         return HttpResponse(str(os.listdir(deposit.full_path())))
@@ -383,7 +385,7 @@ def deposit_media(request, uuid):
                 os.remove(file_path)
                 return HttpResponse(status=204) # No content
             else:
-                return _sword_error_response(404, 'The path to this file (%s) does not exist.' % (file_path))
+                return _sword_error_response(request, 404, 'The path to this file (%s) does not exist.' % (file_path))
         else:
             deposit = Deposit.objects.get(uuid=uuid)
 
@@ -396,7 +398,7 @@ def deposit_media(request, uuid):
 
             return HttpResponse(status=204) # No content
     else:
-        return _sword_error_response(405, 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.')
+        return _sword_error_response(request, 405, 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.')
 
 def _handle_upload_request(request, deposit, replace_file=False):
     if 'HTTP_CONTENT_DISPOSITION' in request.META:
@@ -414,11 +416,11 @@ def _handle_upload_request(request, deposit, replace_file=False):
                         204
                     )
                 else:
-                    return _sword_error_response(400, 'File does not exist.')
+                    return _sword_error_response(request, 400, 'File does not exist.')
             else:
                 # if adding a file, the file must not already exist
                 if os.path.exists(file_path):
-                    return _sword_error_response(400, 'File already exists.')
+                    return _sword_error_response(request, 400, 'File already exists.')
                 else:
                     return _handle_upload_request_with_potential_md5_checksum(
                         request,
@@ -426,9 +428,9 @@ def _handle_upload_request(request, deposit, replace_file=False):
                         201
                     )
         else:
-            return _sword_error_response(400, 'No filename found in Content-disposition header.')
+            return _sword_error_response(request, 400, 'No filename found in Content-disposition header.')
     else:
-        return _sword_error_response(400, 'Content-disposition must be set in request header.')
+        return _sword_error_response(request, 400, 'Content-disposition must be set in request header.')
 
 def _handle_upload_request_with_potential_md5_checksum(request, file_path, success_status_code):
     temp_filepath = helpers.write_request_body_to_temp_file(request)
@@ -436,7 +438,7 @@ def _handle_upload_request_with_potential_md5_checksum(request, file_path, succe
         md5sum = helpers.get_file_md5_checksum(temp_filepath)
         if request.META['HTTP_CONTENT_MD5'] != md5sum:
             os.remove(temp_filepath)
-            return _sword_error_response(400, 'MD5 checksum of uploaded file ({uploaded_md5sum}) does not match ' + 'checksum provided in header ({header_md5sum}).'.format(
+            return _sword_error_response(request, 400, 'MD5 checksum of uploaded file ({uploaded_md5sum}) does not match ' + 'checksum provided in header ({header_md5sum}).'.format(
                 uploaded_md5sum=md5sum, header_md5sum=request.META['HTTP_CONTENT_MD5']))
         else:
             shutil.copyfile(temp_filepath, file_path)
@@ -456,49 +458,54 @@ def deposit_state(request, uuid):
     deposit = get_object_or_None(Deposit, uuid=uuid)
 
     if deposit == None:
-        return _sword_error_response('This deposit has already been submitted for processing.'(404, 'Deposit {uuid} does not exist.'.format(uuid=uuid)))
+        return _sword_error_response(request, 404, 'Deposit {uuid} does not exist.'.format(uuid=uuid))
 
     if request.method == 'GET':
-        """
-        In order to determine the deposit status we need to check
-        for three possibilities:
-        
-        1) The deposit involved no asynchronous depositing. The
-           downloads_attempted DB row column should be 0.
-       
-        2) The deposit involved asynchronous depositing, but
-           the depositing is incomplete. downloads_attempted is
-           greater than 0, but download_completion_time is not
-           set.
-      
-        3) The deposit involved asynchronous depositing and
-           completed successfully. download_completion_time is set.
-           downloads_attempted is equal to downloads_completed.
-      
-        4) The deposit involved asynchronous depositing and
-           completed unsuccessfully. download_completion_time is set.
-           downloads_attempted isn't equal to downloads_completed.
-        """
-        deposit = Deposit.objects.get(uuid=uuid)
-        if deposit.downloads_attempted == 0:
-            task_state = 'Complete'
-        else:
-           if deposit.download_completion_time == None:
-               task_state = 'Incomplete'
-           else:
-               if deposit.downloads_attempted == deposit.downloads_completed:
-                   task_state = 'Complete'
-               else:
-                   task_state = 'Failed'
-
-        state_term = task_state.lower()
-        state_description = 'Deposit initiation: ' + task_state
+        state = _deposit_state_summary(deposit)
+        state_term = state.lower()
+        state_description = 'Deposit initiation: ' + state
 
         response = HttpResponse(render_to_string('locations/api/sword/state.xml', locals()))
         response['Content-Type'] = 'application/atom+xml;type=feed'
         return response
     else:
-        return _sword_error_response(405, 'This endpoint only responds to the GET HTTP method.')
+        return _sword_error_response(request, 405, 'This endpoint only responds to the GET HTTP method.')
+
+"""
+In order to determine the deposit status we need to check
+for three possibilities:
+
+1) The deposit involved no asynchronous depositing. The
+   downloads_attempted DB row column should be 0.
+
+2) The deposit involved asynchronous depositing, but
+   the depositing is incomplete. downloads_attempted is
+   greater than 0, but download_completion_time is not
+   set.
+      
+3) The deposit involved asynchronous depositing and
+   completed successfully. download_completion_time is set.
+   downloads_attempted is equal to downloads_completed.
+      
+4) The deposit involved asynchronous depositing and
+   completed unsuccessfully. download_completion_time is set.
+   downloads_attempted isn't equal to downloads_completed.
+"""
+
+# TODO: put this in the model?
+def _deposit_state_summary(deposit):
+    if deposit.downloads_attempted == 0:
+        state = 'Complete'
+    else:
+       if deposit.download_completion_time == None:
+           state = 'Incomplete'
+       else:
+           if deposit.downloads_attempted == deposit.downloads_completed:
+               state = 'Complete'
+           else:
+               state = 'Failed'
+
+    return state
 
 # respond with SWORD 2.0 deposit receipt XML
 def _deposit_receipt_response(request, deposit_uuid, status_code):
@@ -530,12 +537,9 @@ def _sword_error_response_render(request, error_details):
     error_xml = render_to_string('locations/api/sword/error.xml', error_details)
     return HttpResponse(error_xml, status=error_details['status'])
 
-def _sword_error_response(status, summary):
+def _sword_error_response(request, status, summary):
     error = _error(status, summary)
     return _sword_error_response_render(request, error)
 
 def _error(status, summary):
-    return {
-        'summary': summary,
-        'status': status
-    }
+    return {'summary': summary, 'status': status}

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -112,7 +112,14 @@ def collection(request, space_uuid):
             
             if request.body != '':
                 try:
-                    mets_data = _parse_name_and_content_urls_from_request_body(request)
+                    temp_filepath = helpers.write_request_body_to_temp_file(request)
+
+                    # parse name and content URLs out of XML
+                    try:
+                        mets_data = _parse_name_and_content_urls_from_mets_file(temp_filepath)
+                    except etree.XMLSyntaxError as e:
+                        os.unlink(temp_filepath)
+                        mets_data = None
 
                     if mets_data != None:
                         if mets_data['deposit_name'] == None:
@@ -129,6 +136,13 @@ def collection(request, space_uuid):
                                 return  _sword_error_response(request, 500, 'Space path (%s) does not exist: contact an administrator.' % (space.path))
                             else:
                                 deposit_uuid = _create_deposit_directory_and_db_entry(deposit_specification)
+
+                                # copy METS file to submission documentation directory then remove temp file
+                                deposit = helpers.get_deposit(deposit_uuid)
+                                submission_documentation_directory = os.path.join(deposit.full_path(), 'submissionDocumentation')
+                                if not os.path.exists(submission_documentation_directory):
+                                    os.mkdir(submission_documentation_directory)
+                                os.rename(temp_filepath, os.path.join(submission_documentation_directory, 'fedora-METS.xml'))
 
                                 if deposit_uuid != None:
                                     _spawn_batch_download_and_flag_finalization_if_requested(deposit_uuid, request, mets_data)

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -280,8 +280,16 @@ def deposit_edit(request, uuid):
                             return _sword_error_response(request, 500, 'Pipeline {property} not set.'.format(property=property_description))
 
                     # TODO deal with issue when IP isn't whitelisted
-                    # TODO... how to get appropriate destination path?
-                    destination_path = '/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/standardTransfer/' + os.path.basename(deposit.full_path())
+
+                    # TODO: add error if more than one location is returned
+                    processing_location = Location.objects.get(
+                        pipeline=sword_server.pipeline,
+                        purpose=Location.CURRENTLY_PROCESSING)
+
+                    destination_path = os.path.join(
+                        processing_location.full_path(),
+                        'watchedDirectories/activeTransfers/standardTransfer',
+                        os.path.basename(deposit.full_path()))
 
                     # move to standard transfers directory
                     destination_path = helpers.pad_destination_filepath_if_it_already_exists(destination_path)

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -27,12 +27,12 @@ def service_document(request):
     Service document endpoint: returns a list of all SWORD2 collections available.
 
     Each collection maps to a Location with purpose Location.SWORD_DEPOSIT,
-    inside a Space with access_protocol Space.SWORD_SERVER
+    inside a Space with access_protocol Space.FEDORA
 
     Example GET of service document:
       curl -v http://127.0.0.1:8000/api/v1/sword/
     """
-    locations = models.Location.active.filter(purpose=models.Location.SWORD_DEPOSIT).filter(space__access_protocol=models.Space.SWORD_SERVER)
+    locations = models.Location.active.filter(purpose=models.Location.SWORD_DEPOSIT).filter(space__access_protocol=models.Space.FEDORA)
 
     collections = []
     for location in locations:

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -322,7 +322,9 @@ def deposit_edit(request, uuid):
             if deposit.downloading_status() == 'complete':
                 if len(os.listdir(deposit.full_path())) > 0:
                     # get sword server so we can access pipeline information
-                    #sword_server = SwordServer.objects.get(space=deposit.space)
+                    sword_server = SwordServer.objects.get(space=deposit.space)
+                    result = _activate_transfer_and_request_approval_from_pipeline(deposit, sword_server)
+                    #result['deposit_uuid'] = deposit_uuid
 
                     if 'error' in result:
                         return _sword_error_response(request, 500, result['message'])
@@ -371,6 +373,7 @@ def _activate_transfer_and_request_approval_from_pipeline(deposit, sword_server)
     for property in ['remote_name', 'api_username', 'api_key']:
         if getattr(sword_server.pipeline, property)=='':
             property_description = property.replace('_', ' ')
+            # TODO: fix this
             return _sword_error_response(request, 500, 'Pipeline {property} not set.'.format(property=property_description))
 
     # TODO: add error if more than one location is returned

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -157,24 +157,50 @@ def collection(request, space_uuid):
                     else:
                         return _sword_error_response(request, 400, 'source_location is set, but relative_path_to_files is not.')
                 else:
-                    # a deposit of files stored on the storage server is being done
-                    location = Location.objects.get(uuid=source_location)
-                    path_to_deposit_files = os.path.join(location.full_path(), relative_path_to_files)
-
-                    deposit_specification = {'space_uuid': space_uuid}
-                    deposit_specification['name'] = os.path.basename(path_to_deposit_files) # replace this with optional name
-                    deposit_specification['source_path'] = path_to_deposit_files
-                    deposit_uuid = _create_deposit_directory_and_db_entry(deposit_specification)
-
-                    return HttpResponse(deposit_uuid)
-                    #shutil.copytree(path_to_deposit_files, os.path.join('', os.path.basename(path_to_deposit_files)))
-                    #return HttpResponse(path_to_deposit_files)
+                    # TODO: consider removing this?
+                    result = deposit_from_location_relative_path(source_location, relative_path_to_files, space.uuid)
+                    if 'error' in result and result['error'] != None:
+                        return _sword_error_response(request, 500, result['message'])
+                    else:
+                        return _deposit_receipt_response(request, result['deposit_uuid'], 200)
             else:
                 return _sword_error_response(request, 412, 'A request body must be sent when creating a deposit.')
         else:
             return _sword_error_response(request, 412, 'The In-Progress header must be set to either true or false when creating a deposit.')
     else:
         return _sword_error_response(request, 405, 'This endpoint only responds to the GET and POST HTTP methods.')
+
+def deposit_from_location_relative_path(source_location, relative_path_to_files, space_uuid=None, pipeline_uuid=None):
+    # if no explicit space or pipeline specified, nothing can be done
+    if space_uuid == None and pipeline_uuid == None:
+        return
+
+    # if a pipeline, but no space, was specified then look up the first SWORD server space
+    # associated with the pipeline
+    if space_uuid == None:
+        pipeline = Pipeline.objects.get(uuid=pipeline_uuid)
+        sword_server = SwordServer.objects.filter(pipeline=pipeline)[0]
+        space_uuid = sword_server.space.uuid
+    else:
+    # ...otherwise, get the pipeline associated with the SWORD server space
+        space = Space.objects.get(uuid=space_uuid)
+        sword_server = SwordServer.objects.get(space=space)
+        pipeline = sword_server.pipeline
+
+    # a deposit of files stored on the storage server is being done
+    location = Location.objects.get(uuid=source_location)
+    path_to_deposit_files = os.path.join(location.full_path(), relative_path_to_files)
+
+    deposit_specification = {'space_uuid': space_uuid}
+    deposit_specification['name'] = os.path.basename(path_to_deposit_files) # replace this with optional name
+    deposit_specification['source_path'] = path_to_deposit_files
+
+    deposit_uuid = _create_deposit_directory_and_db_entry(deposit_specification)
+    deposit = helpers.get_deposit(deposit_uuid)
+
+    result =  _activate_transfer_and_request_approval_from_pipeline(deposit, sword_server)
+    result['deposit_uuid'] = deposit_uuid
+    return result
 
 def _parse_name_and_content_urls_from_mets_file(filepath):
     tree = etree.parse(filepath)
@@ -296,50 +322,8 @@ def deposit_edit(request, uuid):
             if deposit.downloading_status() == 'complete':
                 if len(os.listdir(deposit.full_path())) > 0:
                     # get sword server so we can access pipeline information
-                    sword_server = SwordServer.objects.get(space=deposit.space)
+                    #sword_server = SwordServer.objects.get(space=deposit.space)
 
-                    # make sure pipeline API access is configured
-                    for property in ['remote_name', 'api_username', 'api_key']:
-                        if getattr(sword_server.pipeline, property)=='':
-                            property_description = property.replace('_', ' ')
-                            return _sword_error_response(request, 500, 'Pipeline {property} not set.'.format(property=property_description))
-
-                    # TODO deal with issue when IP isn't whitelisted
-
-                    # TODO: add error if more than one location is returned
-                    processing_location = Location.objects.get(
-                        pipeline=sword_server.pipeline,
-                        purpose=Location.CURRENTLY_PROCESSING)
-
-                    destination_path = os.path.join(
-                        processing_location.full_path(),
-                        'watchedDirectories/activeTransfers/standardTransfer',
-                        os.path.basename(deposit.full_path()))
-
-                    # move to standard transfers directory
-                    destination_path = helpers.pad_destination_filepath_if_it_already_exists(destination_path)
-                    shutil.move(deposit.full_path(), destination_path)
-
-                    # wait to make sure the MCP responds to the directory being in the watch directory
-                    time.sleep(4)
-
-                    # make request to pipeline's transfer approval API
-                    data = urllib.urlencode({
-                        'username': sword_server.pipeline.api_username,
-                        'api_key': sword_server.pipeline.api_key,
-                        'directory': os.path.basename(destination_path),
-                        'type': 'standard' # TODO: make this customizable via a URL param
-                    })
-                    approve_request = urllib2.Request('http://' + sword_server.pipeline.remote_name + '/api/transfer/approve/', data)
-
-                    try:
-                        approve_response = urllib2.urlopen(approve_request)
-                    except:
-                        # move back to deposit directory
-                        shutil.move(destination_path, deposit.full_path())
-                        return _sword_error_response(request, 500, 'Request to pipeline transfer approval API failed: check credentials and REST API IP whitelist.')
-
-                    result = json.loads(approve_response.read())
                     if 'error' in result:
                         return _sword_error_response(request, 500, result['message'])
 
@@ -367,6 +351,68 @@ def deposit_edit(request, uuid):
         return HttpResponse(status=204) # No content
     else:
         return _sword_error_response(request, 405, 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.')
+
+"""
+Handle requesting the approval of a transfer from a pipeline via a REST call.
+
+This function returns a dict representation of the results, either returning
+the JSON returned by the request to the pipeline (converted to a dict) or
+a dict indicating a pipeline authentication issue.
+
+The dict representation is of the form:
+
+{
+    'error': <True|False>,
+    'message': <description of success or failure>
+}
+"""
+def _activate_transfer_and_request_approval_from_pipeline(deposit, sword_server):
+    # make sure pipeline API access is configured
+    for property in ['remote_name', 'api_username', 'api_key']:
+        if getattr(sword_server.pipeline, property)=='':
+            property_description = property.replace('_', ' ')
+            return _sword_error_response(request, 500, 'Pipeline {property} not set.'.format(property=property_description))
+
+    # TODO: add error if more than one location is returned
+    processing_location = Location.objects.get(
+        pipeline=sword_server.pipeline,
+        purpose=Location.CURRENTLY_PROCESSING)
+
+    destination_path = os.path.join(
+        processing_location.full_path(),
+        'watchedDirectories/activeTransfers/standardTransfer',
+        os.path.basename(deposit.full_path()))
+
+    # move to standard transfers directory
+    destination_path = helpers.pad_destination_filepath_if_it_already_exists(destination_path)
+    shutil.move(deposit.full_path(), destination_path)
+
+    # wait to make sure the MCP responds to the directory being in the watch directory
+    time.sleep(4)
+
+    # make request to pipeline's transfer approval API
+    data = urllib.urlencode({
+        'username': sword_server.pipeline.api_username,
+        'api_key': sword_server.pipeline.api_key,
+        'directory': os.path.basename(destination_path),
+        'type': 'standard' # TODO: make this customizable via a URL param
+    })
+
+    pipeline_endpoint_url = 'http://' + sword_server.pipeline.remote_name + '/api/transfer/approve/'
+    approve_request = urllib2.Request(pipeline_endpoint_url, data)
+
+    try:
+        approve_response = urllib2.urlopen(approve_request)
+    except:
+        # move back to deposit directory
+        shutil.move(destination_path, deposit.full_path())
+        return {
+            'error': True,
+            'message': 'Request to pipeline ' + sword_server.pipeline.uuid + ' transfer approval API failed: check credentials and REST API IP whitelist.'
+        } #_sword_error_response(request, 500, 'Request to pipeline transfer approval API failed: check credentials and REST API IP whitelist.')
+
+    result = json.loads(approve_response.read())
+    return result
 
 """
 Example GET of files list:

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -404,8 +404,21 @@ def deposit_media(request, uuid):
         # replace a file in the deposit
         return _handle_adding_to_or_replacing_file_in_deposit(request, deposit, True)
     elif request.method == 'POST':
-        # add a file to the deposit
-        return _handle_adding_to_or_replacing_file_in_deposit(request, deposit)
+        # Allow async batch upload via METS XML body content
+        if 'HTTP_PACKAGING' in request.META and request.META['HTTP_PACKAGING'] == 'METS':
+            # If METS XML has been sent to indicate a list of files needing downloading, handle it
+            if request.body != '':
+                mets_data = _parse_name_and_content_urls_from_request_body(request)
+                if mets_data != None:
+                    _spawn_batch_download_and_flag_finalization_if_requested(uuid, request, mets_data)
+                    return _deposit_receipt_response(request, uuid, 201)
+                else:
+                    return _sword_error_response(request, 412, 'Error parsing XML ({error_message}).'.format(error_message=str(e)))
+            else:
+                return _sword_error_response(request, 400, 'No METS body content sent.')
+        else:
+            # add a file to the deposit
+            return _handle_adding_to_or_replacing_file_in_deposit(request, deposit)
     elif request.method == 'DELETE':
         filename = request.GET.get('filename', '')
         if filename != '':

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -1,51 +1,159 @@
 # stdlib, alphabetical
 import datetime
 from lxml import etree as etree
-import json
 from multiprocessing import Process
 import os
 import shutil
-import subprocess
 import tempfile
-import threading
 import time
-import urllib2
-import uuid
 
 # Core Django, alphabetical
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
-from django.db import transaction
 from django.http import HttpResponse
-from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils import timezone
 
 # This project, alphabetical
 from locations.models import Deposit
 from locations.models import Location
+import helpers
 
-def _deposit_storage_path(uuid):
-    try:
-        deposit = Deposit.objects.get(uuid=uuid)
-        return deposit.full_path()
-    except ObjectDoesNotExist:
-        return None
+"""
+Example GET of service document:
 
-def _deposit_storage_path_root(location_uuid):
-    location = Location.objects.get(uuid=location_uuid)
-    return location.full_path()
+  curl -v http://127.0.0.1/api/v2/sword
+"""
+def service_document(request):
+    transfer_collectiion_url = request.build_absolute_uri(
+        reverse('components.api.views_sword.transfer_collection')
+    )
+
+    service_document_xml = render_to_string('api/sword/service_document.xml', locals())
+    response = HttpResponse(service_document_xml)
+    response['Content-Type'] = 'application/atomserv+xml'
+    return response
+
+"""
+Example GET of collection deposit list:
+
+  curl -v http://localhost:8000/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/collection/
+
+Example POST creation of deposit:
+
+  curl -v -H "In-Progress: true" --data-binary @mets.xml --request POST http://localhost:8000/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/collection/
+"""
+# TODO: error if deposit is finalized, but has no files?
+def collection(request, location_uuid):
+    error = None
+    bad_request = None
+
+    if request.method == 'GET':
+        # return list of deposits as ATOM feed
+        col_iri = request.build_absolute_uri(
+            reverse('sword_collection', kwargs={'api_name': 'v1',
+                'resource_name': 'location', 'uuid': location_uuid}))
+
+        feed = {
+            'title': 'Deposits',
+            'url': col_iri
+        }
+
+        entries = []
+
+        for uuid in helpers.deposit_list(location_uuid):
+            deposit = Deposit.objects.get(uuid=uuid)
+
+            edit_iri = request.build_absolute_uri(
+                reverse('sword_deposit', kwargs={'api_name': 'v1',
+                    'resource_name': 'deposit', 'uuid': uuid}))
+
+            entries.append({
+                'title': deposit.name,
+                'url': edit_iri,
+            })
+
+        collection_xml = render_to_string('locations/api/sword/collection.xml', locals())
+        response = HttpResponse(collection_xml)
+        response['Content-Type'] = 'application/atom+xml;type=feed'
+        return response
+    elif request.method == 'POST':
+        # is the deposit still in progress?
+        if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'true':
+            # process creation request, if criteria met
+            if request.body != '':
+                try:
+                    temp_filepath = helpers.write_request_body_to_temp_file(request)
+
+                    # parse name and content URLs out of XML
+                    try:
+                        tree = etree.parse(temp_filepath)
+                        root = tree.getroot()
+                        deposit_name = root.get('LABEL')
+
+                        if deposit_name == None:
+                            bad_request = 'No deposit name found in XML.'
+                        else:
+                            # assemble deposit specification
+                            deposit_specification = {'location_uuid': location_uuid}
+                            deposit_specification['name'] = deposit_name
+                            if 'HTTP_ON_BEHALF_OF' in request.META:
+                                # TODO: should get this from author header
+                                deposit_specification['sourceofacquisition'] = request.META['HTTP_ON_BEHALF_OF']
+
+                            location_path = helpers.deposit_location_path(location_uuid)
+                            if not os.path.isdir(location_path):
+                                error = _error(500, 'Location path (%s) does not exist: contact an administrator.' % (location_path))
+                            else:
+                                deposit_uuid = _create_deposit_directory_and_db_entry(deposit_specification)
+
+                                if deposit_uuid != None:
+                                    # parse XML for content URLs
+                                    object_content_urls = []
+
+                                    elements = root.iterfind("{http://www.loc.gov/METS/}fileSec/"
+                                        + "{http://www.loc.gov/METS/}fileGrp[@ID='DATASTREAMS']/"
+                                        + "{http://www.loc.gov/METS/}fileGrp[@ID='OBJ']/"
+                                        + "{http://www.loc.gov/METS/}file/"
+                                        + "{http://www.loc.gov/METS/}FLocat"
+                                    )
+
+                                    for element in elements:
+                                        object_content_urls.append(element.get('{http://www.w3.org/1999/xlink}href'))
+
+                                    # create process so content URLs can be downloaded asynchronously
+                                    p = Process(target=_fetch_content, args=(deposit_uuid, object_content_urls))
+                                    p.start()
+
+                                    return _deposit_receipt_response(request, deposit_uuid, 201)
+                                else:
+                                    error = _error(500, 'Could not create deposit: contact an administrator.')
+                    except etree.XMLSyntaxError as e:
+                        error = _error(412, 'Error parsing XML ({error_message}).'.format(error_message=str(e)))
+                except Exception as e:
+                    bad_request = str(e)
+            else:
+                error = _error(412, 'A request body must be sent when creating a deposit.')
+        else:
+            # TODO: way to do one-step deposit creation by setting In-Progress to false
+            error = _error(412, 'The In-Progress header must be set to true when creating a deposit.')
+    else:
+        error = _error(405, 'This endpoint only responds to the GET and POST HTTP methods.')
+
+    if bad_request != None:
+        error = _error(400, bad_request)
+
+    if error != None:
+        return _sword_error_response(request, error)
 
 def _create_deposit_directory_and_db_entry(deposit_specification):
-    deposit_uuid = uuid.uuid4().__str__()
-
     if 'name' in deposit_specification:
         deposit_name = deposit_specification['name']
     else:
         deposit_name = 'Untitled'
 
     deposit_path = os.path.join(
-        _deposit_storage_path_root(deposit_specification['location_uuid']),
+        helpers.deposit_location_path(deposit_specification['location_uuid']),
         deposit_name
     )
 
@@ -65,72 +173,195 @@ def _create_deposit_directory_and_db_entry(deposit_specification):
         deposit.save()
         return deposit.uuid
 
-def _deposit_list(location_uuid):
-    location = Location.objects.get(uuid=location_uuid)
+def _fetch_content(deposit_uuid, object_content_urls):
+    # update deposit with number of files that need to be downloaded
+    deposit = Deposit.objects.get(uuid=deposit_uuid)
+    deposit.downloads_attempted = len(object_content_urls)
+    deposit.downloads_completed = 0
+    deposit.save()
 
-    deposit_list = []
-    deposits = Deposit.objects.filter(location=location)
-    for deposit in deposits:
-        deposit_list.append(deposit.uuid)
-    return deposit_list
+    # download the files
+    destination_path = helpers.deposit_storage_path(deposit_uuid)
+    temp_dir = tempfile.mkdtemp()
 
-def _sword_error_response(request, error_details):
-    error_details['request'] = request
-    error_details['update_time'] = datetime.datetime.now().__str__()
-    error_details['user_agent'] = request.META['HTTP_USER_AGENT']
-    error_xml = render_to_string('locations/api/sword/error.xml', error_details)
-    return HttpResponse(error_xml, status=error_details['status'])
+    completed = 0
+    for url in object_content_urls:
+        try:
+            filename = helpers.download_resource(url, temp_dir)
+            completed += 1
+        except:
+            pass
+        shutil.move(os.path.join(temp_dir, filename),
+            os.path.join(destination_path, filename))
 
-def _write_file_from_request_body(request, file_path):
-    bytes_written = 0
-    new_file = open(file_path, 'ab')
-    chunk = request.read()
-    if chunk != None:
-        new_file.write(chunk)
-        bytes_written += len(chunk)
-        chunk = request.read()
-    new_file.close()
-    return bytes_written
+    # remove temp dir
+    shutil.rmtree(temp_dir)
 
-def _get_file_md5_checksum(filepath):
-    raw_result = subprocess.Popen(["md5sum", filepath],stdout=subprocess.PIPE).communicate()[0]
-    return raw_result[0:32]
+    # record the number of successful downloads and completion time
+    deposit.downloads_completed = completed
+    deposit.download_completion_time = timezone.now()
+    deposit.save()
 
-def _handle_upload_request_with_potential_md5_checksum(request, file_path, success_status_code):
-    temp_filepath = _write_request_body_to_temp_file(request)
-    if 'HTTP_CONTENT_MD5' in request.META:
-        md5sum = _get_file_md5_checksum(temp_filepath)
-        if request.META['HTTP_CONTENT_MD5'] != md5sum:
-            os.remove(temp_filepath)
-            bad_request = 'MD5 checksum of uploaded file ({uploaded_md5sum}) does not match checksum provided in header ({header_md5sum}).'.format(uploaded_md5sum=md5sum, header_md5sum=request.META['HTTP_CONTENT_MD5'])
-            return _sword_error_response(request, {
-                'summary': bad_request,
-                'status': 400
-            })
+"""
+TODO: decouple deposits and locations for shorter URLs
+
+Example POST finalization of deposit:
+
+  curl -v -H "In-Progress: false" --request POST http://127.0.0.1/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/deposit/5bdf83cd-5858-4152-90e2-c2426e90e7c0/
+
+Example DELETE of deposit:
+
+  curl -v -XDELETE http://127.0.0.1/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/deposit/5bdf83cd-5858-4152-90e2-c2426e90e7c0/
+"""
+# TODO: add authentication
+def deposit(request, uuid):
+    error = None
+    bad_request = None
+
+    if request.method == 'GET':
+        # details about a deposit
+        return HttpResponse('Feed XML of files for deposit' + uuid)
+    elif request.method == 'POST':
+        # is the deposit ready to be processed?
+        if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'false':
+            # TODO: check that related tasks are complete before copying
+            # ...task row must exist and task endtime must be equal to or greater than start time
+            try:
+                if _deposit_has_been_submitted_for_processing(uuid):
+                    error = _error(400, 'This deposit has already been submitted for processing.')
+                else:
+                    deposit = Deposit.objects.get(uuid=uuid)
+
+                    if len(os.listdir(deposit.full_path())) > 0:
+                        """
+                        TODO: replace this will call to dashboard API
+                        helpers.copy_to_start_transfer(transfer.currentlocation, 'standard', {'uuid': uuid})
+
+                        # wait for watch directory to determine a transfer is awaiting
+                        # approval then attempt to approve it
+                        time.sleep(5)
+                        approve_transfer_via_mcp(
+                            os.path.basename(transfer.currentlocation),
+                            'standard',
+                        1
+                        ) # TODO: replace hardcoded user ID
+                        """
+                        pass
+
+                        return _deposit_receipt_response(request, uuid, 200)
+                    else:
+                        bad_request = 'This deposit contains no files.'
+
+            except ObjectDoesNotExist:
+                error = _error(404, 'This deposit could not be found.')
         else:
-            shutil.copyfile(temp_filepath, file_path)
-            os.remove(temp_filepath)
-            return HttpResponse(status=success_status_code)
-    else:
-        shutil.copyfile(temp_filepath, file_path)
-        os.remove(temp_filepath)
-        return HttpResponse(status=success_status_code)
+            bad_request = 'The In-Progress header must be set to false when starting deposit processing.'
+    elif request.method == 'PUT':
+        # update deposit
+        return HttpResponse(status=204) # No content
+    elif request.method == 'DELETE':
+        # delete deposit files
+        deposit_path = helpers.deposit_storage_path(uuid)
+        shutil.rmtree(deposit_path)
 
-def _parse_filename_from_content_disposition(header):
-    filename = header.split('filename=')[1]
-    if filename[0] == '"' or filename[0] == "'":
-        filename = filename[1:-1]
-    return filename
+        # delete entry in Transfers table (and task?)
+        deposit = Deposit.objects.get(uuid=uuid)
+        deposit.delete()
+        return HttpResponse(status=204) # No content
+    else:
+        error = _error(405, 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.')
+
+    if bad_request != None:
+        error = _error(400, bad_request)
+
+    if error != None:
+        return _sword_error_response(request, error)
+
+"""
+Example GET of files list:
+
+  curl -v http://127.0.0.1/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
+
+Example POST of file:
+
+  curl -v -H "Content-Disposition: attachment; filename=joke.jpg" --request POST \
+    --data-binary "@joke.jpg" \
+    http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
+
+Example DELETE of all files:
+
+  curl -v -XDELETE \
+      "http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
+
+Example DELETE of file:
+
+  curl -v -XDELETE \
+    "http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media?filename=thing.jpg"
+"""
+def deposit_media(request, uuid):
+    if _deposit_has_been_submitted_for_processing(uuid):
+        return _sword_error_response(request, {
+            'summary': 'This deposit has already been submitted for processing.',
+            'status': 400
+        })
+
+    error = None
+
+    if request.method == 'GET':
+        deposit_path = helpers.deposit_storage_path(uuid)
+        if deposit_path == None:
+            error = _error(404, 'This deposit does not exist.')
+        else:
+            if os.path.exists(deposit_path):
+                return HttpResponse(str(os.listdir(deposit_path)))
+            else:
+                error = _error(404, 'This deposit path (%s) does not exist.' % (deposit_path))
+    elif request.method == 'PUT':
+        # replace a file in the deposit
+        return _handle_upload_request(request, uuid, True)
+    elif request.method == 'POST':
+        # add a file to the deposit
+        return _handle_upload_request(request, uuid)
+    elif request.method == 'DELETE':
+        filename = request.GET.get('filename', '')
+        if filename != '':
+            deposit_path = helpers.deposit_storage_path(uuid)
+            file_path = os.path.join(deposit_path, filename) 
+            if os.path.exists(file_path):
+                os.remove(file_path)
+                return HttpResponse(status=204) # No content
+            else:
+                error = _error(404, 'The path to this file (%s) does not exist.' % (file_path))
+        else:
+            # delete all files in deposit
+            if _deposit_has_been_submitted_for_processing(uuid):
+                error = _error(400, 'This deposit has already been submitted for processing.')
+            else:
+                deposit = Deposit.objects.get(uuid=uuid)
+
+                for filename in os.listdir(deposit.full_path()):
+                    filepath = os.path.join(deposit.full_path(), filename)
+                    if os.path.isfile(filepath):
+                        os.remove(filepath)
+                    elif os.path.isdir(filepath):
+                        shutil.rmtree(filepath)
+
+                return HttpResponse(status=204) # No content
+    else:
+        error = _error(405, 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.')
+
+    if error != None:
+        return _sword_error_response(request, error)
 
 def _handle_upload_request(request, uuid, replace_file=False):
     error = None
     bad_request = None
 
     if 'HTTP_CONTENT_DISPOSITION' in request.META:
-        filename = _parse_filename_from_content_disposition(request.META['HTTP_CONTENT_DISPOSITION']) 
+        filename = helpers.parse_filename_from_content_disposition(request.META['HTTP_CONTENT_DISPOSITION']) 
 
         if filename != '':
-            file_path = os.path.join(_deposit_storage_path(uuid), filename)
+            file_path = os.path.join(helpers.deposit_storage_path(uuid), filename)
 
             if replace_file:
                 # if doing a file replace, the file being replaced must exist
@@ -158,406 +389,30 @@ def _handle_upload_request(request, uuid, replace_file=False):
         bad_request = 'Content-disposition must be set in request header.'
 
     if bad_request != None:
-        error = {
-            'summary': bad_request,
-            'status': 400
-        }
+        error = _error(400, bad_request)
 
     if error != None:
         return _sword_error_response(request, error)
 
-def _write_request_body_to_temp_file(request):
-    filehandle, temp_filepath = tempfile.mkstemp()
-    _write_file_from_request_body(request, temp_filepath)
-    return temp_filepath
-
-def _fetch_content(deposit_uuid, object_content_urls):
-    # update deposit with number of files that need to be downloaded
-    deposit = Deposit.objects.get(uuid=deposit_uuid)
-    deposit.downloads_attempted = len(object_content_urls)
-    deposit.downloads_completed = 0
-    deposit.save()
-
-    # download the files
-    destination_path = _deposit_storage_path(deposit_uuid)
-    temp_dir = tempfile.mkdtemp()
-
-    completed = 0
-    for url in object_content_urls:
-        try:
-            filename = _download_resource(url, temp_dir)
-            completed += 1
-        except:
-            pass
-        shutil.move(os.path.join(temp_dir, filename),
-            os.path.join(destination_path, filename))
-
-    # remove temp dir
-    shutil.rmtree(temp_dir)
-
-    # record the number of successful downloads and completion time
-    deposit.downloads_completed = completed
-    deposit.download_completion_time = timezone.now()
-    deposit.save()
-
-# respond with SWORD 2.0 deposit receipt XML
-def _deposit_receipt_response(request, deposit_uuid, status_code):
-    deposit = Deposit.objects.get(uuid=deposit_uuid)
-
-    # TODO: fix minor issues with template
-    media_iri = request.build_absolute_uri(
-        reverse('sword_deposit_media', kwargs={'api_name': 'v1',
-            'resource_name': 'deposit', 'uuid': deposit_uuid}))
-
-    edit_iri = request.build_absolute_uri(
-        reverse('sword_deposit', kwargs={'api_name': 'v1',
-            'resource_name': 'deposit', 'uuid': deposit_uuid}))
-
-    state_iri = request.build_absolute_uri(
-        reverse('sword_deposit_state', kwargs={'api_name': 'v1',
-            'resource_name': 'deposit', 'uuid': deposit_uuid}))
-
-    receipt_xml = render_to_string('locations/api/sword/deposit_receipt.xml', locals())
-
-    response = HttpResponse(receipt_xml, mimetype='text/xml', status=status_code)
-    response['Location'] = deposit_uuid
-    return response
-
-def _deposit_has_been_submitted_for_processing(deposit_uuid):
-    try:
-        deposit = models.Deposit.objects.get(uuid=deposit_uuid)
-        if deposit.status != 'complete':
-            return True
-        return False
-    except:
-        return False
-
-"""
-Example GET of service document:
-
-  curl -v http://127.0.0.1/api/v2/sword
-"""
-def service_document(request):
-    transfer_collectiion_url = request.build_absolute_uri(
-        reverse('components.api.views_sword.transfer_collection')
-    )
-
-    service_document_xml = render_to_string('api/sword/service_document.xml', locals())
-    response = HttpResponse(service_document_xml)
-    response['Content-Type'] = 'application/atomserv+xml'
-    return response
-
-"""
-Example GET of collection deposit list:
-
-  curl -v http://localhost:8000/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/collection/
-
-Example POST creation of deposit:
-
-  curl -v -H "In-Progress: true" --data-binary @mets.xml --request POST http://localhost:8000/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/collection/
-"""
-# TODO: add authentication
-# TODO: error if deposit is finalized, but has no files?
-def collection(request, location_uuid):
-    error = None
-    bad_request = None
-
-    if request.method == 'GET':
-        # return list of transfers as ATOM feed
-        feed = {
-            'title': 'Transfers',
-            #'url': request.build_absolute_uri(reverse('components.api.views_sword.transfer_collection'))
-        }
-
-        entries = []
-
-        entries = [{
-            'title': 'Hey',
-            'url': 'http://www.google.com'
-        }]
-        for uuid in _deposit_list(location_uuid):
-            deposit = Deposit.objects.get(uuid=uuid)
-            entries.append({
-                'title': deposit.name,
-                'url': 'http://www.google.com/',
-                #'url': request.build_absolute_uri(reverse('components.api.views_sword.transfer', args=[uuid]))
+def _handle_upload_request_with_potential_md5_checksum(request, file_path, success_status_code):
+    temp_filepath = helpers.write_request_body_to_temp_file(request)
+    if 'HTTP_CONTENT_MD5' in request.META:
+        md5sum = helpers.get_file_md5_checksum(temp_filepath)
+        if request.META['HTTP_CONTENT_MD5'] != md5sum:
+            os.remove(temp_filepath)
+            bad_request = 'MD5 checksum of uploaded file ({uploaded_md5sum}) does not match checksum provided in header ({header_md5sum}).'.format(uploaded_md5sum=md5sum, header_md5sum=request.META['HTTP_CONTENT_MD5'])
+            return _sword_error_response(request, {
+                'summary': bad_request,
+                'status': 400
             })
-
-        collection_xml = render_to_string('locations/api/sword/collection.xml', locals())
-        response = HttpResponse(collection_xml)
-        response['Content-Type'] = 'application/atom+xml;type=feed'
-        return response
-    elif request.method == 'POST':
-        # is the deposit still in progress?
-        if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'true':
-            # process creation request, if criteria met
-            if request.body != '':
-                try:
-                    temp_filepath = _write_request_body_to_temp_file(request)
-
-                    # parse XML
-                    try:
-                        tree = etree.parse(temp_filepath)
-                        root = tree.getroot()
-                        transfer_name = root.get('LABEL')
-
-                        if transfer_name == None:
-                            bad_request = 'No deposit name found in XML.'
-                        else:
-                            # assemble deposit specification
-                            transfer_specification = {'location_uuid': location_uuid}
-                            transfer_specification['name'] = transfer_name
-                            if 'HTTP_ON_BEHALF_OF' in request.META:
-                                # TODO: should get this from author header
-                                transfer_specification['sourceofacquisition'] = request.META['HTTP_ON_BEHALF_OF']
-
-                            location_path = _deposit_storage_path_root(location_uuid)
-                            if not os.path.isdir(location_path):
-                                error = {
-                                    'summary': 'Location path (%s) does not exist: contact an administrator.' % (location_path),
-                                    'status': 500
-                                }
-                            else:
-                                transfer_uuid = _create_deposit_directory_and_db_entry(transfer_specification)
-
-                                if transfer_uuid != None:
-                                    # parse XML for content URLs
-                                    object_content_urls = []
-
-                                    elements = root.iterfind("{http://www.loc.gov/METS/}fileSec/"
-                                        + "{http://www.loc.gov/METS/}fileGrp[@ID='DATASTREAMS']/"
-                                        + "{http://www.loc.gov/METS/}fileGrp[@ID='OBJ']/"
-                                        + "{http://www.loc.gov/METS/}file/"
-                                        + "{http://www.loc.gov/METS/}FLocat"
-                                    )
-
-                                    for element in elements:
-                                        object_content_urls.append(element.get('{http://www.w3.org/1999/xlink}href'))
-
-                                    # create process so content URLs can be downloaded asynchronously
-                                    p = Process(target=_fetch_content, args=(transfer_uuid, object_content_urls))
-                                    p.start()
-
-                                    return _deposit_receipt_response(request, transfer_uuid, 201)
-                                else:
-                                    error = {
-                                        'summary': 'Could not create deposit: contact an administrator.',
-                                        'status': 500
-                                    }
-                    except etree.XMLSyntaxError as e:
-                        error = {
-                            'summary': 'Error parsing XML ({error_message}).'.format(error_message=str(e)),
-                            'status': 412
-                        }
-                except Exception as e:
-                    bad_request = str(e)
-            else:
-                error = {
-                    'summary': 'A request body must be sent when creating a transfer.',
-                    'status': 412
-                }
         else:
-            # TODO: way to do one-step transfer creation by setting In-Progress to false
-            error = {
-                'summary': 'The In-Progress header must be set to true when creating a transfer.',
-                'status': 412
-            }
+            shutil.copyfile(temp_filepath, file_path)
+            os.remove(temp_filepath)
+            return HttpResponse(status=success_status_code)
     else:
-        error = {
-            'summary': 'This endpoint only responds to the GET and POST HTTP methods.',
-            'status': 405
-        }
-
-    if bad_request != None:
-        error = {
-            'summary': bad_request,
-            'status': 400
-        }
-
-    if error != None:
-        return _sword_error_response(request, error)
-
-"""
-TODO: decouple deposits and locations for shorter URLs
-
-Example POST finalization of transfer:
-
-  curl -v -H "In-Progress: false" --request POST http://127.0.0.1/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/deposit/5bdf83cd-5858-4152-90e2-c2426e90e7c0/
-
-Example DELETE if transfer:
-
-  curl -v -XDELETE http://127.0.0.1/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/deposit/5bdf83cd-5858-4152-90e2-c2426e90e7c0/
-"""
-# TODO: add authentication
-def deposit(request, uuid):
-    error = None
-    bad_request = None
-
-    if request.method == 'GET':
-        # details about a deposit
-        return HttpResponse('Feed XML of files for deposit' + uuid)
-    elif request.method == 'POST':
-        # is the deposit ready to be processed?
-        if 'HTTP_IN_PROGRESS' in request.META and request.META['HTTP_IN_PROGRESS'] == 'false':
-            # TODO: check that related tasks are complete before copying
-            # ...task row must exist and task endtime must be equal to or greater than start time
-            try:
-                if _deposit_has_been_submitted_for_processing(uuid):
-                    error = {
-                        'summary': 'This deposit has already been submitted for processing.',
-                        'status': 400
-                    }
-                else:
-                    deposit = Deposit.objects.get(uuid=uuid)
-
-                    if len(os.listdir(deposit.full_path())) > 0:
-                        """
-                        TODO: replace this will call to dashboard API
-                        helpers.copy_to_start_transfer(transfer.currentlocation, 'standard', {'uuid': uuid})
-
-                        # wait for watch directory to determine a transfer is awaiting
-                        # approval then attempt to approve it
-                        time.sleep(5)
-                        approve_transfer_via_mcp(
-                            os.path.basename(transfer.currentlocation),
-                            'standard',
-                        1
-                        ) # TODO: replace hardcoded user ID
-                        """
-                        pass
-
-                        return _deposit_receipt_response(request, uuid, 200)
-                    else:
-                        bad_request = 'This deposit contains no files.'
-
-            except ObjectDoesNotExist:
-                error = {
-                    'summary': 'This deposit could not be found.',
-                    'status': 404
-                }
-        else:
-            bad_request = 'The In-Progress header must be set to false when starting deposit processing.'
-    elif request.method == 'PUT':
-        # update deposit
-        return HttpResponse(status=204) # No content
-    elif request.method == 'DELETE':
-        # delete deposit files
-        deposit_path = _deposit_storage_path(uuid)
-        shutil.rmtree(deposit_path)
-
-        # delete entry in Transfers table (and task?)
-        deposit = Deposit.objects.get(uuid=uuid)
-        deposit.delete()
-        return HttpResponse(status=204) # No content
-    else:
-        error = {
-            'summary': 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.',
-            'status': 405
-        }
-
-    if bad_request != None:
-        error = {
-            'summary': bad_request,
-            'status': 400
-        }
-
-    if error != None:
-                return _sword_error_response(request, error)
-
-"""
-Example GET of files list:
-
-  curl -v http://127.0.0.1/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
-
-Example POST of file:
-
-  curl -v -H "Content-Disposition: attachment; filename=joke.jpg" --request POST \
-    --data-binary "@joke.jpg" \
-    http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
-
-Example DELETE of all files:
-
-  curl -v -XDELETE \
-      "http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
-
-Example DELETE of file:
-
-  curl -v -XDELETE \
-    "http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media?filename=thing.jpg"
-"""
-# TODO: implement Content-MD5 header so we can verify file upload was successful
-# TODO: better Content-Disposition header parsing
-# TODO: add authentication
-def deposit_media(request, uuid):
-    if _deposit_has_been_submitted_for_processing(uuid):
-        return _sword_error_response(request, {
-            'summary': 'This deposit has already been submitted for processing.',
-            'status': 400
-        })
-
-    error = None
-
-    if request.method == 'GET':
-        deposit_path = _deposit_storage_path(uuid)
-        if deposit_path == None:
-            error = {
-                'summary': 'This deposit does not exist.',
-                'status': 404
-            }
-        else:
-            if os.path.exists(deposit_path):
-                return HttpResponse(str(os.listdir(deposit_path)))
-                #return helpers.json_response(os.listdir(deposit_path))
-            else:
-                error = {
-                    'summary': 'This deposit path (%s) does not exist.' % (deposit_path),
-                    'status': 404
-                }
-    elif request.method == 'PUT':
-        # replace a file in the deposit
-        return _handle_upload_request(request, uuid, True)
-    elif request.method == 'POST':
-        # add a file to the deposit
-        return _handle_upload_request(request, uuid)
-    elif request.method == 'DELETE':
-        filename = request.GET.get('filename', '')
-        if filename != '':
-            deposit_path = _deposit_storage_path(uuid)
-            file_path = os.path.join(deposit_path, filename) 
-            if os.path.exists(file_path):
-                os.remove(file_path)
-                return HttpResponse(status=204) # No content
-            else:
-                error = {
-                    'summary': 'The path to this file (%s) does not exist.' % (file_path),
-                    'status': 404
-                }
-        else:
-            # delete all files in deposit
-            if _deposit_has_been_submitted_for_processing(uuid):
-                error = {
-                    'summary': 'This deposit has already been submitted for processing.',
-                    'status': 400
-                }
-            else:
-                deposit = Deposit.objects.get(uuid=uuid)
-
-                for filename in os.listdir(deposit.full_path()):
-                    filepath = os.path.join(deposit.full_path(), filename)
-                    if os.path.isfile(filepath):
-                        os.remove(filepath)
-                    elif os.path.isdir(filepath):
-                        shutil.rmtree(filepath)
-
-                return HttpResponse(status=204) # No content
-    else:
-        error = {
-            'summary': 'This endpoint only responds to the GET, POST, PUT, and DELETE HTTP methods.',
-            'status': 405
-        }
-
-    if error != None:
-                return _sword_error_response(request, error)
+        shutil.copyfile(temp_filepath, file_path)
+        os.remove(temp_filepath)
+        return HttpResponse(status=success_status_code)
 
 """
 Example GET of state:
@@ -610,33 +465,53 @@ def deposit_state(request, uuid):
         response['Content-Type'] = 'application/atom+xml;type=feed'
         return response
     else:
-        error = {
-            'summary': 'This endpoint only responds to the GET HTTP method.',
-            'status': 405
-        }
+        error = _error(405, 'This endpoint only responds to the GET HTTP method.')
 
     if error != None:
                 return _sword_error_response(request, error)
 
-def _download_resource(url, destination_path):
-    response = urllib2.urlopen(url)
-    filename = _filename_from_response(response)
+# respond with SWORD 2.0 deposit receipt XML
+def _deposit_receipt_response(request, deposit_uuid, status_code):
+    deposit = Deposit.objects.get(uuid=deposit_uuid)
 
-    if filename == None:
-        filename = os.path.basename(url)
+    # TODO: fix minor issues with template
+    media_iri = request.build_absolute_uri(
+        reverse('sword_deposit_media', kwargs={'api_name': 'v1',
+            'resource_name': 'deposit', 'uuid': deposit_uuid}))
 
-    filepath = os.path.join(destination_path, filename)
-    buffer = 16 * 1024
-    with open(filepath, 'wb') as fp:
-        while True:
-            chunk = response.read(buffer)
-            if not chunk: break
-            fp.write(chunk)
-    return filename
+    edit_iri = request.build_absolute_uri(
+        reverse('sword_deposit', kwargs={'api_name': 'v1',
+            'resource_name': 'deposit', 'uuid': deposit_uuid}))
 
-def _filename_from_response(response):
-    info = response.info()
-    if 'content-disposition' in info:
-        return _parse_filename_from_content_disposition(info['content-disposition'])
-    else:
-        return None
+    state_iri = request.build_absolute_uri(
+        reverse('sword_deposit_state', kwargs={'api_name': 'v1',
+            'resource_name': 'deposit', 'uuid': deposit_uuid}))
+
+    receipt_xml = render_to_string('locations/api/sword/deposit_receipt.xml', locals())
+
+    response = HttpResponse(receipt_xml, mimetype='text/xml', status=status_code)
+    response['Location'] = deposit_uuid
+    return response
+
+def _sword_error_response(request, error_details):
+    error_details['request'] = request
+    error_details['update_time'] = datetime.datetime.now().__str__()
+    error_details['user_agent'] = request.META['HTTP_USER_AGENT']
+    error_xml = render_to_string('locations/api/sword/error.xml', error_details)
+    return HttpResponse(error_xml, status=error_details['status'])
+
+def _error(status, summary):
+    return {
+        'summary': summary,
+        'status': status
+    }
+
+# TODO: is this right?
+def _deposit_has_been_submitted_for_processing(deposit_uuid):
+    try:
+        deposit = models.Deposit.objects.get(uuid=deposit_uuid)
+        if deposit.status != 'complete':
+            return True
+        return False
+    except:
+        return False

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -207,11 +207,11 @@ TODO: decouple deposits and locations for shorter URLs
 
 Example POST finalization of deposit:
 
-  curl -v -H "In-Progress: false" --request POST http://127.0.0.1/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/deposit/5bdf83cd-5858-4152-90e2-c2426e90e7c0/
+  curl -v -H "In-Progress: false" --request POST http://127.0.0.1:8000/api/v1/deposit/149cc29d-6472-4bcf-bee8-f8223bf60580/sword/
 
 Example DELETE of deposit:
 
-  curl -v -XDELETE http://127.0.0.1/api/v1/location/96606387-cc70-4b09-b422-a7220606488d/sword/deposit/5bdf83cd-5858-4152-90e2-c2426e90e7c0/
+  curl -v -XDELETE http://127.0.0.1:8000/api/v1/deposit/149cc29d-6472-4bcf-bee8-f8223bf60580/sword/
 """
 # TODO: add authentication
 def deposit(request, uuid):
@@ -280,23 +280,23 @@ def deposit(request, uuid):
 """
 Example GET of files list:
 
-  curl -v http://127.0.0.1/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
+  curl -v http://127.0.0.1:8000/api/v1/deposit/149cc29d-6472-4bcf-bee8-f8223bf60580/sword/media/
 
 Example POST of file:
 
   curl -v -H "Content-Disposition: attachment; filename=joke.jpg" --request POST \
     --data-binary "@joke.jpg" \
-    http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
+    http://127.0.0.1:8000/api/v1/deposit/9c8b4ac0-0407-4360-a10d-af6c62a48b69/sword/media/
 
 Example DELETE of all files:
 
   curl -v -XDELETE \
-      "http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media
+    http://127.0.0.1:8000/api/v1/deposit/9c8b4ac0-0407-4360-a10d-af6c62a48b69/sword/media/
 
 Example DELETE of file:
 
   curl -v -XDELETE \
-    "http://localhost/api/v2/transfer/sword/03ce11a5-32c1-445a-83ac-400008894f78/media?filename=thing.jpg"
+    http://127.0.0.1:8000/api/v1/deposit/9c8b4ac0-0407-4360-a10d-af6c62a48b69/sword/media/?filename=joke.jpg
 """
 def deposit_media(request, uuid):
     if _deposit_has_been_submitted_for_processing(uuid):
@@ -400,11 +400,9 @@ def _handle_upload_request_with_potential_md5_checksum(request, file_path, succe
         md5sum = helpers.get_file_md5_checksum(temp_filepath)
         if request.META['HTTP_CONTENT_MD5'] != md5sum:
             os.remove(temp_filepath)
-            bad_request = 'MD5 checksum of uploaded file ({uploaded_md5sum}) does not match checksum provided in header ({header_md5sum}).'.format(uploaded_md5sum=md5sum, header_md5sum=request.META['HTTP_CONTENT_MD5'])
-            return _sword_error_response(request, {
-                'summary': bad_request,
-                'status': 400
-            })
+            bad_request = 'MD5 checksum of uploaded file ({uploaded_md5sum}) does not match ' + 'checksum provided in header ({header_md5sum}).'.format(
+                uploaded_md5sum=md5sum, header_md5sum=request.META['HTTP_CONTENT_MD5'])
+            return _sword_error_response(request, _error(400, bad_request))
         else:
             shutil.copyfile(temp_filepath, file_path)
             os.remove(temp_filepath)

--- a/storage_service/locations/api/urls.py
+++ b/storage_service/locations/api/urls.py
@@ -8,7 +8,6 @@ v1_api.register(v1.LocationResource())
 v1_api.register(v1.PackageResource())
 v1_api.register(v1.PipelineResource())
 
-
 v2_api = Api(api_name='v2')
 v2_api.register(v2.SpaceResource())
 v2_api.register(v2.LocationResource())
@@ -17,5 +16,7 @@ v2_api.register(v2.PipelineResource())
 
 urlpatterns = patterns('',
     (r'', include(v1_api.urls)),
+    url(r'v1/sword/$', 'locations.api.sword.views.service_document', name='sword_service_document'),
     (r'', include(v2_api.urls)),
+    url(r'v2/sword/$', 'locations.api.sword.views.service_document', name='sword_service_document'),
 )

--- a/storage_service/locations/constants.py
+++ b/storage_service/locations/constants.py
@@ -42,5 +42,7 @@ PROTOCOL[Space.LOM] = {
 PROTOCOL[Space.SWORD_SERVER] = {
     'model': SwordServer,
     'form': SwordServerForm,
-    'fields': []
+    'fields': ['fedora_user',
+               'fedora_password',
+               'fedora_name']
 }

--- a/storage_service/locations/constants.py
+++ b/storage_service/locations/constants.py
@@ -1,6 +1,7 @@
 
-from .models import LocalFilesystem, NFS, PipelineLocalFS, Lockssomatic, SwordServer, Space
-from .forms import LocalFilesystemForm, NFSForm, PipelineLocalFSForm, LockssomaticForm, SwordServerForm
+from .models import LocalFilesystem, NFS, PipelineLocalFS, Lockssomatic, Fedora, Space
+from .forms import LocalFilesystemForm, NFSForm, PipelineLocalFSForm, LockssomaticForm, FedoraForm
+
 
 ########################## SPACES ##########################
 
@@ -39,9 +40,9 @@ PROTOCOL[Space.LOM] = {
                'checksum_type',]
 }
 
-PROTOCOL[Space.SWORD_SERVER] = {
-    'model': SwordServer,
-    'form': SwordServerForm,
+PROTOCOL[Space.FEDORA] = {
+    'model': Fedora,
+    'form': FedoraForm,
     'fields': ['fedora_user',
                'fedora_password',
                'fedora_name']

--- a/storage_service/locations/constants.py
+++ b/storage_service/locations/constants.py
@@ -1,7 +1,6 @@
 
-from .models import LocalFilesystem, NFS, PipelineLocalFS, Space, Lockssomatic
-from .forms import LocalFilesystemForm, NFSForm, PipelineLocalFSForm, LockssomaticForm
-
+from .models import LocalFilesystem, NFS, PipelineLocalFS, Lockssomatic, SwordServer, Space
+from .forms import LocalFilesystemForm, NFSForm, PipelineLocalFSForm, LockssomaticForm, SwordServerForm
 
 ########################## SPACES ##########################
 
@@ -38,4 +37,10 @@ PROTOCOL[Space.LOM] = {
                'external_domain',
                'keep_local',
                'checksum_type',]
+}
+
+PROTOCOL[Space.SWORD_SERVER] = {
+    'model': SwordServer,
+    'form': SwordServerForm,
+    'fields': []
 }

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -66,6 +66,12 @@ class LockssomaticForm(forms.ModelForm):
         return data
 
 
+class SwordServerForm(forms.ModelForm):
+    class Meta:
+        model = models.SwordServer
+        fields = ()
+
+
 class LocationForm(forms.ModelForm):
     class Meta:
         model = models.Location

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -66,9 +66,9 @@ class LockssomaticForm(forms.ModelForm):
         return data
 
 
-class SwordServerForm(forms.ModelForm):
+class FedoraForm(forms.ModelForm):
     class Meta:
-        model = models.SwordServer
+        model = models.Fedora
         fields = ('fedora_user', 'fedora_password', 'fedora_name', )
 
 

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -18,7 +18,7 @@ class PipelineForm(forms.ModelForm):
 class SpaceForm(forms.ModelForm):
     class Meta:
         model = models.Space
-        fields = ('access_protocol', 'size', 'path', 'staging_path')
+        fields = ('access_protocol', 'size', 'path', 'staging_path', 'fedora_user', 'fedora_password', 'fedora_name')
 
     def __init__(self, *args, **kwargs):
         super(SpaceForm, self).__init__(*args, **kwargs)

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -18,7 +18,7 @@ class PipelineForm(forms.ModelForm):
 class SpaceForm(forms.ModelForm):
     class Meta:
         model = models.Space
-        fields = ('access_protocol', 'size', 'path', 'staging_path', 'fedora_user', 'fedora_password', 'fedora_name')
+        fields = ('access_protocol', 'size', 'path', 'staging_path')
 
     def __init__(self, *args, **kwargs):
         super(SpaceForm, self).__init__(*args, **kwargs)
@@ -69,7 +69,7 @@ class LockssomaticForm(forms.ModelForm):
 class SwordServerForm(forms.ModelForm):
     class Meta:
         model = models.SwordServer
-        fields = ('pipeline',)
+        fields = ('fedora_user', 'fedora_password', 'fedora_name', )
 
 
 class LocationForm(forms.ModelForm):

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -69,7 +69,7 @@ class LockssomaticForm(forms.ModelForm):
 class SwordServerForm(forms.ModelForm):
     class Meta:
         model = models.SwordServer
-        fields = ()
+        fields = ('pipeline',)
 
 
 class LocationForm(forms.ModelForm):

--- a/storage_service/locations/migrations/0004_v0_4_0.py
+++ b/storage_service/locations/migrations/0004_v0_4_0.py
@@ -22,6 +22,39 @@ class Migration(SchemaMigration):
         ))
         db.send_create_signal(u'locations', ['Lockssomatic'])
 
+        # Adding model 'Fedora'
+        db.create_table(u'locations_fedora', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('space', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['locations.Space'], to_field='uuid', unique=True)),
+            ('fedora_user', self.gf('django.db.models.fields.CharField')(max_length=64)),
+            ('fedora_password', self.gf('django.db.models.fields.CharField')(max_length=256)),
+            ('fedora_name', self.gf('django.db.models.fields.CharField')(max_length=256)),
+        ))
+        db.send_create_signal(u'locations', ['Fedora'])
+
+        # Adding model 'PackageDownloadTask'
+        db.create_table(u'locations_packagedownloadtask', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('uuid', self.gf('django.db.models.fields.CharField')(unique=True, max_length=36, blank=True)),
+            ('package', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['locations.Package'], to_field='uuid')),
+            ('downloads_attempted', self.gf('django.db.models.fields.IntegerField')(default=0)),
+            ('downloads_completed', self.gf('django.db.models.fields.IntegerField')(default=0)),
+            ('download_completion_time', self.gf('django.db.models.fields.DateTimeField')(default=None, null=True, blank=True)),
+        ))
+        db.send_create_signal(u'locations', ['PackageDownloadTask'])
+
+        # Adding model 'PackageDownloadTaskFile'
+        db.create_table(u'locations_packagedownloadtaskfile', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('uuid', self.gf('django.db.models.fields.CharField')(unique=True, max_length=36, blank=True)),
+            ('task', self.gf('django.db.models.fields.related.ForeignKey')(related_name='download_file_set', to_field='uuid', to=orm['locations.PackageDownloadTask'])),
+            ('filename', self.gf('django.db.models.fields.CharField')(max_length=256)),
+            ('url', self.gf('django.db.models.fields.TextField')()),
+            ('completed', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('failed', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal(u'locations', ['PackageDownloadTaskFile'])
+
         # Adding field 'Pipeline.remote_name'
         db.add_column(u'locations_pipeline', 'remote_name',
                       self.gf('django.db.models.fields.CharField')(default=None, max_length=256, null=True, blank=True),
@@ -37,11 +70,19 @@ class Migration(SchemaMigration):
                       self.gf('django.db.models.fields.CharField')(default=None, max_length=256, null=True, blank=True),
                       keep_default=False)
 
+        # Adding field 'Package.description'
+        db.add_column(u'locations_package', 'description',
+                      self.gf('django.db.models.fields.CharField')(default=None, max_length=256, null=True, blank=True),
+                      keep_default=False)
+
         # Adding field 'Package.misc_attributes'
         db.add_column(u'locations_package', 'misc_attributes',
                       self.gf('jsonfield.fields.JSONField')(default={}, null=True, blank=True),
                       keep_default=False)
 
+
+        # Changing field 'Package.origin_pipeline'
+        db.alter_column(u'locations_package', 'origin_pipeline_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['locations.Pipeline'], to_field='uuid', null=True))
         # Adding field 'Space.staging_path'
         db.add_column(u'locations_space', 'staging_path',
                       self.gf('django.db.models.fields.TextField')(default='/var/archivematica/storage_service/'),
@@ -52,6 +93,15 @@ class Migration(SchemaMigration):
         # Deleting model 'Lockssomatic'
         db.delete_table(u'locations_lockssomatic')
 
+        # Deleting model 'Fedora'
+        db.delete_table(u'locations_fedora')
+
+        # Deleting model 'PackageDownloadTask'
+        db.delete_table(u'locations_packagedownloadtask')
+
+        # Deleting model 'PackageDownloadTaskFile'
+        db.delete_table(u'locations_packagedownloadtaskfile')
+
         # Deleting field 'Pipeline.remote_name'
         db.delete_column(u'locations_pipeline', 'remote_name')
 
@@ -61,9 +111,15 @@ class Migration(SchemaMigration):
         # Deleting field 'Pipeline.api_key'
         db.delete_column(u'locations_pipeline', 'api_key')
 
+        # Deleting field 'Package.description'
+        db.delete_column(u'locations_package', 'description')
+
         # Deleting field 'Package.misc_attributes'
         db.delete_column(u'locations_package', 'misc_attributes')
 
+
+        # Changing field 'Package.origin_pipeline'
+        db.alter_column(u'locations_package', 'origin_pipeline_id', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['locations.Pipeline'], to_field='uuid'))
         # Deleting field 'Space.staging_path'
         db.delete_column(u'locations_space', 'staging_path')
 
@@ -120,6 +176,14 @@ class Migration(SchemaMigration):
             'user_email': ('django.db.models.fields.EmailField', [], {'max_length': '254'}),
             'user_id': ('django.db.models.fields.PositiveIntegerField', [], {})
         },
+        u'locations.fedora': {
+            'Meta': {'object_name': 'Fedora'},
+            'fedora_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'fedora_password': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'fedora_user': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
         u'locations.localfilesystem': {
             'Meta': {'object_name': 'LocalFilesystem'},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
@@ -169,14 +233,34 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'Package'},
             'current_location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Location']", 'to_field': "'uuid'"}),
             'current_path': ('django.db.models.fields.TextField', [], {}),
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'misc_attributes': ('jsonfield.fields.JSONField', [], {'default': '{}', 'null': 'True', 'blank': 'True'}),
-            'origin_pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"}),
+            'origin_pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'", 'null': 'True', 'blank': 'True'}),
             'package_type': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
             'pointer_file_location': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'to_field': "'uuid'", 'null': 'True', 'to': u"orm['locations.Location']"}),
             'pointer_file_path': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'size': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
             'status': ('django.db.models.fields.CharField', [], {'default': "'FAIL'", 'max_length': '8'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.packagedownloadtask': {
+            'Meta': {'object_name': 'PackageDownloadTask'},
+            'download_completion_time': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'downloads_attempted': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'downloads_completed': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Package']", 'to_field': "'uuid'"}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.packagedownloadtaskfile': {
+            'Meta': {'object_name': 'PackageDownloadTaskFile'},
+            'completed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'failed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'task': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'download_file_set'", 'to_field': "'uuid'", 'to': u"orm['locations.PackageDownloadTask']"}),
+            'url': ('django.db.models.fields.TextField', [], {}),
             'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
         },
         u'locations.pipeline': {

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1918,3 +1918,6 @@ class Deposit(models.Model):
         """ Returns full path of deposit: space + location + deposit paths. """
         return os.path.normpath(
             os.path.join(self.location.full_path(), self.path)) # TODO: change to relative path
+
+    def has_been_submitted_for_processing(self):
+        return self.deposit_completion_time != None

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1911,8 +1911,6 @@ class Pipeline(models.Model):
         it.  If a shared_path is provided, currently processing location is at
         that path.  Creates Transfer Source and AIP Store locations based on
         configuration from administration.Settings.
-
-        Also create a SWORD server Space.
         """
         # Use shared path if provided
         if not shared_path:
@@ -1964,20 +1962,3 @@ class Pipeline(models.Model):
                     p['purpose'], location, self))
                 LocationPipeline.objects.get_or_create(
                     pipeline=self, location=location)
-
-        # create SWORD space if it doesn't already exist
-        space_path = os.path.join(os.path.join('/', shared_path), 'staging', 'deposits', self.uuid)
-        space, space_created = Space.objects.get_or_create(
-            access_protocol=Space.SWORD_SERVER, path=space_path)
-
-        if space_created:
-            try:
-                os.makedirs(space_path)
-            except OSError as e:
-                if e.errno != errno.EEXIST:
-                    logging.error("Unable to create directory {} for SWORD server space.".format(space.path))
-
-        # create SWORD server for pipeline if it doesn't already exist
-        sword_server, sword_server_created = SwordServer.objects.get_or_create(space=space, pipeline=self)
-        if sword_server_created:
-            logging.info("SWORD server created: {}".format(sword_server))

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1904,4 +1904,4 @@ class Deposit(models.Model):
     def full_path(self):
         """ Returns full path of deposit: space + location + deposit paths. """
         return os.path.normpath(
-            os.path.join(self.location.full_path, self.path)) # TODO: change to relative path
+            os.path.join(self.location.full_path(), self.path)) # TODO: change to relative path

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1278,7 +1278,9 @@ class Package(models.Model):
     """ A package stored in a specific location. """
     uuid = UUIDField(editable=False, unique=True, version=4,
         help_text="Unique identifier")
-    origin_pipeline = models.ForeignKey('Pipeline', to_field='uuid')
+    description = models.CharField(max_length=256, default=None,
+        null=True, blank=True, help_text="Human-readable description.")
+    origin_pipeline = models.ForeignKey('Pipeline', to_field='uuid', null=True, blank=True)
     current_location = models.ForeignKey(Location, to_field='uuid')
     current_path = models.TextField()
     pointer_file_location = models.ForeignKey(Location, to_field='uuid', related_name='+', null=True, blank=True)

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1207,6 +1207,10 @@ class PackageDownloadTask(models.Model):
     downloads_completed = models.IntegerField(default=0)
     download_completion_time = models.DateTimeField(default=None, null=True, blank=True)
 
+    def __unicode__(self):
+        return u'PackageDownloadTask ID: {uuid} for {package}'.format(
+            uuid=self.uuid, package=self.package)
+
     COMPLETE = 'complete'
     INCOMPLETE = 'incomplete'
     FAILED = 'failed'
@@ -1240,7 +1244,7 @@ class PackageDownloadTask(models.Model):
 class PackageDownloadTaskFile(models.Model):
     uuid = UUIDField(editable=False, unique=True, version=4,
         help_text="Unique identifier")
-    task = models.ForeignKey('PackageDownloadTask', to_field='uuid')
+    task = models.ForeignKey('PackageDownloadTask', to_field='uuid', related_name='download_file_set')
 
     filename = models.CharField(max_length=256)
     url = models.TextField()
@@ -1249,6 +1253,12 @@ class PackageDownloadTaskFile(models.Model):
         help_text="True if file downloaded successfully.")
     failed = models.BooleanField(default=False,
         help_text="True if file failed to download.")
+
+    def __unicode__(self):
+        return u'Download {filename} from {url} ({status})'.format(
+            filename=self.filename,
+            url=self.url,
+            status=self.downloading_status())
 
     def downloading_status(self):
         if self.completed:

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1900,6 +1900,10 @@ class Deposit(models.Model):
         help_text="Name of the deposit.")
     path = models.TextField(
         help_text="Absolute path to the deposit on the storage service machine.")
+    create_time = models.DateTimeField(auto_now_add=True)
+    downloads_attempted = models.IntegerField(default=0)
+    downloads_completed = models.IntegerField(default=0)
+    download_completion_time = models.DateTimeField(default=None, null=True, blank=True)
 
     def full_path(self):
         """ Returns full path of deposit: space + location + deposit paths. """

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1125,6 +1125,7 @@ class Location(models.Model):
     BACKLOG = 'BL'
     CURRENTLY_PROCESSING = 'CP'
     STORAGE_SERVICE_INTERNAL = 'SS'
+    SWORD_DEPOSIT = 'SD'
 
     PURPOSE_CHOICES = (
         (TRANSFER_SOURCE, 'Transfer Source'),

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -108,6 +108,14 @@ class Space(models.Model):
     last_verified = models.DateTimeField(default=None, null=True, blank=True,
         help_text="Time this location was last verified to be accessible.")
 
+    # SWORD-related attributes
+    fedora_user = models.CharField(max_length=64,
+        help_text="Fedora user name (for SWORD functionality)")
+    fedora_password = models.CharField(max_length=256,
+        help_text="Fedora password (for SWORD functionality)")
+    fedora_name = models.CharField(max_length=256,
+        help_text="Name or IP of the remote Fedora machine.")
+
     mounted_locally = set([LOCAL_FILESYSTEM, NFS, SWORD_SERVER])
     ssh_only_access = set([PIPELINE_LOCAL_FS])
 

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1885,3 +1885,23 @@ class Pipeline(models.Model):
             sword_server = SwordServer(space=space)
             sword_server.save()
             logging.info("Protocol Space created: {}".format(sword_server))
+        #location = Location.objects.create(
+        #    purpose=Location.TRANSFER_SOURCE, '1762e436-2ae0-4e23-8ab0-afe8f3a9ebd0')
+        #LocationPipeline.objects.get_or_create(
+        #    pipeline=self, location=location)
+
+class Deposit(models.Model):
+    """ Stores information about a deposit of files. """
+
+    uuid = UUIDField(editable=False, unique=True, version=4,
+        help_text="Unique identifier")
+    location = models.ForeignKey('Location', to_field='uuid')
+    name = models.CharField(max_length=256,
+        help_text="Name of the deposit.")
+    path = models.TextField(
+        help_text="Absolute path to the deposit on the storage service machine.")
+
+    def full_path(self):
+        """ Returns full path of deposit: space + location + deposit paths. """
+        return os.path.normpath(
+            os.path.join(self.location.full_path, self.path)) # TODO: change to relative path

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1301,6 +1301,7 @@ class Package(models.Model):
     DEL_REQ = 'DEL_REQ'
     DELETED = 'DELETED'
     FAIL = 'FAIL'
+    FINALIZED = 'FINALIZE'
     STATUS_CHOICES = (
         (PENDING, "Upload Pending"),  # Still on Archivematica
         (STAGING, "Staged on Storage Service"), # In Storage Service staging dir
@@ -1309,6 +1310,7 @@ class Package(models.Model):
         (FAIL, "Failed"),  # Error occured - may or may not be at final location
         (DEL_REQ, "Delete requested"),
         (DELETED, "Deleted"),
+        (FINALIZED, "Deposit Finalized")
     )
     status = models.CharField(max_length=8, choices=STATUS_CHOICES,
         default=FAIL,
@@ -1816,9 +1818,7 @@ class Package(models.Model):
 
     # SWORD-related methods
     def has_been_submitted_for_processing(self):
-        if 'deposit_completion_time' not in self.misc_attributes:
-            return False
-        return self.misc_attributes['deposit_completion_time'] != None
+        return 'deposit_completion_time' in self.misc_attributes
 
 
 class Event(models.Model):

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1921,3 +1921,36 @@ class Deposit(models.Model):
 
     def has_been_submitted_for_processing(self):
         return self.deposit_completion_time != None
+
+    """
+    In order to determine the downloading status (whether or not the
+    deposit is ready to be finalized) we need to check for three
+    possibilities:
+
+    1) The deposit involved no asynchronous depositing. The
+       downloads_attempted DB row column should be 0.
+
+    2) The deposit involved asynchronous depositing, but
+       the depositing is incomplete. downloads_attempted is
+       greater than 0, but download_completion_time is not
+       set.
+
+    3) The deposit involved asynchronous depositing and
+       completed successfully. download_completion_time is set.
+       downloads_attempted is equal to downloads_completed.
+
+    4) The deposit involved asynchronous depositing and
+       completed unsuccessfully. download_completion_time is set.
+       downloads_attempted isn't equal to downloads_completed.
+    """
+    def downloading_status(self):
+        if self.downloads_attempted == 0:
+            return 'complete'
+        else:
+            if self.download_completion_time == None:
+                return 'incomplete'
+            else:
+                if self.downloads_attempted == self.downloads_completed:
+                    return 'complete'
+                else:
+                    return 'failed'

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1240,6 +1240,28 @@ class LocationDownloadTask(models.Model):
                 else:
                     return 'failed'
 
+class LocationDownloadTaskFile(models.Model):
+    uuid = UUIDField(editable=False, unique=True, version=4,
+        help_text="Unique identifier")
+    task = models.ForeignKey('LocationDownloadTask', to_field='uuid')
+
+    filename = models.CharField(max_length=256)
+    url = models.TextField()
+
+    completed = models.BooleanField(default=False,
+        help_text="True if file downloaded successfully.")
+    failed = models.BooleanField(default=False,
+        help_text="True if file failed to download.")
+
+    def downloading_status(self):
+        if self.completed:
+            return 'complete'
+        else:
+            if self.failed:
+                return 'failed'
+            else:
+                return 'downloading'
+
 
 ########################## PACKAGES ##########################
 # NOTE If the Packages section gets much bigger, move to its own app

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -84,13 +84,13 @@ class Space(models.Model):
     NFS = 'NFS'
     PIPELINE_LOCAL_FS = 'PIPE_FS'
     LOM = 'LOM'
-    SWORD_SERVER = 'SWORD_S'
+    FEDORA = 'FEDORA'
     ACCESS_PROTOCOL_CHOICES = (
         (LOCAL_FILESYSTEM, "Local Filesystem"),
         (NFS, "NFS"),
         (PIPELINE_LOCAL_FS, "Pipeline Local Filesystem"),
         (LOM, "LOCKSS-o-matic"),
-        (SWORD_SERVER, "SWORD Server"),
+        (FEDORA, "FEDORA via SWORD2"),
     )
     access_protocol = models.CharField(max_length=8,
         choices=ACCESS_PROTOCOL_CHOICES,
@@ -108,7 +108,7 @@ class Space(models.Model):
     last_verified = models.DateTimeField(default=None, null=True, blank=True,
         help_text="Time this location was last verified to be accessible.")
 
-    mounted_locally = set([LOCAL_FILESYSTEM, NFS, SWORD_SERVER])
+    mounted_locally = set([LOCAL_FILESYSTEM, NFS, FEDORA])
     ssh_only_access = set([PIPELINE_LOCAL_FS])
 
     class Meta:
@@ -1060,8 +1060,8 @@ class Lockssomatic(models.Model):
         return entry, slug
 
 
-class SwordServer(models.Model):
-    """ SWORD server that accepts deposits."""
+class Fedora(models.Model):
+    """ Accepts deposits from FEDORA via a SWORD2 server. """
     space = models.OneToOneField('Space', to_field='uuid')
 
     # Authentication related attributes
@@ -1074,7 +1074,7 @@ class SwordServer(models.Model):
 
     def save(self, *args, **kwargs):
         self.verify()
-        super(SwordServer, self).save(*args, **kwargs)
+        super(Fedora, self).save(*args, **kwargs)
 
     def verify(self):
         """ Verify that the space is accessible to the storage service. """

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1157,6 +1157,7 @@ class Location(models.Model):
     # SWORD-related attributes
     deposit_completion_time = models.DateTimeField(default=None, null=True, blank=True)
     ready_for_finalization = models.BooleanField(default=False)
+    finalization_attempt_failed = models.BooleanField(default=False)
 
     class Meta:
         verbose_name = "Location"

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -108,14 +108,6 @@ class Space(models.Model):
     last_verified = models.DateTimeField(default=None, null=True, blank=True,
         help_text="Time this location was last verified to be accessible.")
 
-    # SWORD-related attributes
-    fedora_user = models.CharField(max_length=64,
-        help_text="Fedora user name (for SWORD functionality)")
-    fedora_password = models.CharField(max_length=256,
-        help_text="Fedora password (for SWORD functionality)")
-    fedora_name = models.CharField(max_length=256,
-        help_text="Name or IP of the remote Fedora machine.")
-
     mounted_locally = set([LOCAL_FILESYSTEM, NFS, SWORD_SERVER])
     ssh_only_access = set([PIPELINE_LOCAL_FS])
 
@@ -1071,7 +1063,14 @@ class Lockssomatic(models.Model):
 class SwordServer(models.Model):
     """ SWORD server that accepts deposits."""
     space = models.OneToOneField('Space', to_field='uuid')
-    pipeline = models.ForeignKey('Pipeline', to_field='uuid')
+
+    # Authentication related attributes
+    fedora_user = models.CharField(max_length=64,
+        help_text="Fedora user name (for SWORD functionality)")
+    fedora_password = models.CharField(max_length=256,
+        help_text="Fedora password (for SWORD functionality)")
+    fedora_name = models.CharField(max_length=256,
+        help_text="Name or IP of the remote Fedora machine.")
 
     def save(self, *args, **kwargs):
         self.verify()
@@ -1143,6 +1142,7 @@ class Location(models.Model):
         # (QUARANTINE, 'Quarantine'),
         (BACKLOG, 'Transfer Backlog'),
         (CURRENTLY_PROCESSING, 'Currently Processing'),
+        (SWORD_DEPOSIT, 'FEDORA Deposits'),
         (STORAGE_SERVICE_INTERNAL, 'Storage Service Internal Processing'),
     )
     purpose = models.CharField(max_length=2,
@@ -1161,11 +1161,6 @@ class Location(models.Model):
         help_text="Amount used, in bytes.")
     enabled = models.BooleanField(default=True,
         help_text="True if space can be accessed.")
-
-    # SWORD-related attributes
-    deposit_completion_time = models.DateTimeField(default=None, null=True, blank=True)
-    ready_for_finalization = models.BooleanField(default=False)
-    finalization_attempt_failed = models.BooleanField(default=False)
 
     class Meta:
         verbose_name = "Location"
@@ -1293,6 +1288,7 @@ class Package(models.Model):
     DIP = "DIP"
     TRANSFER = "transfer"
     FILE = 'file'
+    DEPOSIT = 'deposit'
     PACKAGE_TYPE_CHOICES = (
         (AIP, 'AIP'),
         (AIC, 'AIC'),
@@ -1300,6 +1296,7 @@ class Package(models.Model):
         (DIP, 'DIP'),
         (TRANSFER, 'Transfer'),
         (FILE, 'Single File'),
+        (DEPOSIT, 'FEDORA Deposit')
     )
     package_type = models.CharField(max_length=8, choices=PACKAGE_TYPE_CHOICES)
 

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1879,16 +1879,24 @@ class Pipeline(models.Model):
                 LocationPipeline.objects.get_or_create(
                     pipeline=self, location=location)
 
+        # TODO: not sure if we need a space for this, or just a new location purpose
         space, space_created = Space.objects.get_or_create(
-            access_protocol=Space.SWORD_SERVER, path='/' + os.path.join(shared_path, 'staging'))
+            access_protocol=Space.SWORD_SERVER, path='/' + os.path.join(shared_path, 'staging', 'deposits'))
         if space_created:
             sword_server = SwordServer(space=space)
             sword_server.save()
             logging.info("Protocol Space created: {}".format(sword_server))
-        #location = Location.objects.create(
-        #    purpose=Location.TRANSFER_SOURCE, '1762e436-2ae0-4e23-8ab0-afe8f3a9ebd0')
-        #LocationPipeline.objects.get_or_create(
-        #    pipeline=self, location=location)
+
+        # TODO: integrate this with the other location creation logic
+        # associate pipeline with transfer deposit location
+        defaults = utils.get_setting('default_transfer_deposit', [])
+        for uuid in defaults:
+            location = Location.objects.get(uuid=uuid)
+            assert location.purpose == Location.TRANSFER_SOURCE
+            logging.info("Adding new transfer deposits directory to {}".format(
+                self))
+            LocationPipeline.objects.get_or_create(
+                pipeline=self, location=location)
 
 class Deposit(models.Model):
     """ Stores information about a deposit of files. """

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1151,6 +1151,11 @@ class Location(models.Model):
         help_text="Amount used, in bytes.")
     enabled = models.BooleanField(default=True,
         help_text="True if space can be accessed.")
+    # SWORD-related attributes
+    downloads_attempted = models.IntegerField(default=0)
+    downloads_completed = models.IntegerField(default=0)
+    download_completion_time = models.DateTimeField(default=None, null=True, blank=True)
+    deposit_completion_time = models.DateTimeField(default=None, null=True, blank=True)
 
     class Meta:
         verbose_name = "Location"
@@ -1175,6 +1180,43 @@ class Location(models.Model):
     def get_description(self):
         """ Returns a user-friendly description (or the path). """
         return self.description or self.full_path
+
+    # SWORD-related methods
+    def has_been_submitted_for_processing(self):
+        return self.deposit_completion_time != None
+
+    """
+    In order to determine the downloading status (whether or not the
+    deposit is ready to be finalized) we need to check for three
+    possibilities:
+
+    1) The deposit involved no asynchronous depositing. The
+       downloads_attempted DB row column should be 0.
+
+    2) The deposit involved asynchronous depositing, but
+       the depositing is incomplete. downloads_attempted is
+       greater than 0, but download_completion_time is not
+       set.
+
+    3) The deposit involved asynchronous depositing and
+       completed successfully. download_completion_time is set.
+       downloads_attempted is equal to downloads_completed.
+
+    4) The deposit involved asynchronous depositing and
+       completed unsuccessfully. download_completion_time is set.
+       downloads_attempted isn't equal to downloads_completed.
+    """
+    def downloading_status(self):
+        if self.downloads_attempted == 0:
+            return 'complete'
+        else:
+            if self.download_completion_time == None:
+                return 'incomplete'
+            else:
+                if self.downloads_attempted == self.downloads_completed:
+                    return 'complete'
+                else:
+                    return 'failed'
 
 
 class LocationPipeline(models.Model):
@@ -1879,78 +1921,10 @@ class Pipeline(models.Model):
                 LocationPipeline.objects.get_or_create(
                     pipeline=self, location=location)
 
-        # TODO: not sure if we need a space for this, or just a new location purpose
+        # create SWORD space if it doesn't already exist
         space, space_created = Space.objects.get_or_create(
             access_protocol=Space.SWORD_SERVER, path='/' + os.path.join(shared_path, 'staging', 'deposits'))
         if space_created:
             sword_server = SwordServer(space=space)
             sword_server.save()
             logging.info("Protocol Space created: {}".format(sword_server))
-
-        # TODO: integrate this with the other location creation logic
-        # associate pipeline with transfer deposit location
-        defaults = utils.get_setting('default_transfer_deposit', [])
-        for uuid in defaults:
-            location = Location.objects.get(uuid=uuid)
-            assert location.purpose == Location.TRANSFER_SOURCE
-            logging.info("Adding new transfer deposits directory to {}".format(
-                self))
-            LocationPipeline.objects.get_or_create(
-                pipeline=self, location=location)
-
-class Deposit(models.Model):
-    """ Stores information about a deposit of files. """
-
-    uuid = UUIDField(editable=False, unique=True, version=4,
-        help_text="Unique identifier")
-    location = models.ForeignKey('Location', to_field='uuid')
-    name = models.CharField(max_length=256,
-        help_text="Name of the deposit.")
-    path = models.TextField(
-        help_text="Absolute path to the deposit on the storage service machine.")
-    create_time = models.DateTimeField(auto_now_add=True)
-    downloads_attempted = models.IntegerField(default=0)
-    downloads_completed = models.IntegerField(default=0)
-    download_completion_time = models.DateTimeField(default=None, null=True, blank=True)
-    deposit_completion_time = models.DateTimeField(default=None, null=True, blank=True)
-
-    def full_path(self):
-        """ Returns full path of deposit: space + location + deposit paths. """
-        return os.path.normpath(
-            os.path.join(self.location.full_path(), self.path)) # TODO: change to relative path
-
-    def has_been_submitted_for_processing(self):
-        return self.deposit_completion_time != None
-
-    """
-    In order to determine the downloading status (whether or not the
-    deposit is ready to be finalized) we need to check for three
-    possibilities:
-
-    1) The deposit involved no asynchronous depositing. The
-       downloads_attempted DB row column should be 0.
-
-    2) The deposit involved asynchronous depositing, but
-       the depositing is incomplete. downloads_attempted is
-       greater than 0, but download_completion_time is not
-       set.
-
-    3) The deposit involved asynchronous depositing and
-       completed successfully. download_completion_time is set.
-       downloads_attempted is equal to downloads_completed.
-
-    4) The deposit involved asynchronous depositing and
-       completed unsuccessfully. download_completion_time is set.
-       downloads_attempted isn't equal to downloads_completed.
-    """
-    def downloading_status(self):
-        if self.downloads_attempted == 0:
-            return 'complete'
-        else:
-            if self.download_completion_time == None:
-                return 'incomplete'
-            else:
-                if self.downloads_attempted == self.downloads_completed:
-                    return 'complete'
-                else:
-                    return 'failed'

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1912,6 +1912,7 @@ class Deposit(models.Model):
     downloads_attempted = models.IntegerField(default=0)
     downloads_completed = models.IntegerField(default=0)
     download_completion_time = models.DateTimeField(default=None, null=True, blank=True)
+    deposit_completion_time = models.DateTimeField(default=None, null=True, blank=True)
 
     def full_path(self):
         """ Returns full path of deposit: space + location + deposit paths. """

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1153,8 +1153,10 @@ class Location(models.Model):
         help_text="Amount used, in bytes.")
     enabled = models.BooleanField(default=True,
         help_text="True if space can be accessed.")
+
     # SWORD-related attributes
     deposit_completion_time = models.DateTimeField(default=None, null=True, blank=True)
+    ready_for_finalization = models.BooleanField(default=False)
 
     class Meta:
         verbose_name = "Location"

--- a/storage_service/templates/locations/api/sword/_entries.xml
+++ b/storage_service/templates/locations/api/sword/_entries.xml
@@ -1,7 +1,1 @@
-{% for entry in entries %}
-  <atom:entry>
-    <atom:id>{{ entry.url }}</atom:id>
-    <atom:title type="text">{{ entry.title }}</atom:title>
-    <atom:link href="{{ entry.url }}" rel="self">
-    </atom:link>
-  </atom:entry>{% endfor %}
+{% for entry in entries %}{% include 'locations/api/sword/_entry.xml' %}{% endfor %}

--- a/storage_service/templates/locations/api/sword/_entries.xml
+++ b/storage_service/templates/locations/api/sword/_entries.xml
@@ -1,0 +1,7 @@
+{% for entry in entries %}
+  <atom:entry>
+    <atom:id>{{ entry.url }}</atom:id>
+    <atom:title type="text">{{ entry.title }}</atom:title>
+    <atom:link href="{{ entry.url }}" rel="self">
+    </atom:link>
+  </atom:entry>{% endfor %}

--- a/storage_service/templates/locations/api/sword/_entry.xml
+++ b/storage_service/templates/locations/api/sword/_entry.xml
@@ -2,5 +2,6 @@
     <atom:id>{{ entry.url }}</atom:id>
     <atom:title type="text">{{ entry.title }}</atom:title>
     <atom:link href="{{ entry.url }}" rel="self">
+    {% if entry.summary %}<atom:summary>{{ entry.summary }}</atom:summary>{% endif %}
     </atom:link>
   </atom:entry>

--- a/storage_service/templates/locations/api/sword/_entry.xml
+++ b/storage_service/templates/locations/api/sword/_entry.xml
@@ -1,0 +1,6 @@
+  <atom:entry>
+    <atom:id>{{ entry.url }}</atom:id>
+    <atom:title type="text">{{ entry.title }}</atom:title>
+    <atom:link href="{{ entry.url }}" rel="self">
+    </atom:link>
+  </atom:entry>

--- a/storage_service/templates/locations/api/sword/collection.xml
+++ b/storage_service/templates/locations/api/sword/collection.xml
@@ -1,4 +1,4 @@
-<atom:feed xmlns="http://www.w3.org/2005/Atom">
+<atom:feed xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>{{ feed.url }}</atom:id>
   <atom:title type="text">{{ feed.title }}</atom:title>
   <atom:link href="{{ feed.url }}" rel="self">

--- a/storage_service/templates/locations/api/sword/collection.xml
+++ b/storage_service/templates/locations/api/sword/collection.xml
@@ -1,0 +1,7 @@
+<atom:feed xmlns="http://www.w3.org/2005/Atom">
+  <atom:id>{{ feed.url }}</atom:id>
+  <atom:title type="text">{{ feed.title }}</atom:title>
+  <atom:link href="{{ feed.url }}" rel="self">
+  </atom:link>
+  {% include 'locations/api/sword/_entries.xml' %}
+</atom:feed>

--- a/storage_service/templates/locations/api/sword/deposit_receipt.xml
+++ b/storage_service/templates/locations/api/sword/deposit_receipt.xml
@@ -2,8 +2,8 @@
         xmlns:sword="http://purl.org/net/sword/"
         xmlns:dcterms="http://purl.org/dc/terms/">
 
-    <title>{{ transfer_name }}</title>
-    <id>{{ transfer_id }}</id>
+    <title>{{ deposit.name }}</title>
+    <id>{{ deposit.uuid }}</id>
     <updated>{{ current_datetime }}</updated>
     <generator uri="https://www.archivematica.org" version="1.0"/>
 

--- a/storage_service/templates/locations/api/sword/deposit_receipt.xml
+++ b/storage_service/templates/locations/api/sword/deposit_receipt.xml
@@ -2,7 +2,7 @@
         xmlns:sword="http://purl.org/net/sword/"
         xmlns:dcterms="http://purl.org/dc/terms/">
 
-    <title>{{ deposit.name }}</title>
+    <title>{{ deposit.description }}</title>
     <id>{{ deposit.uuid }}</id>
     <updated>{{ current_datetime }}</updated>
     <generator uri="https://www.archivematica.org" version="1.0"/>

--- a/storage_service/templates/locations/api/sword/deposit_receipt.xml
+++ b/storage_service/templates/locations/api/sword/deposit_receipt.xml
@@ -1,0 +1,19 @@
+<entry xmlns="http://www.w3.org/2005/Atom"
+        xmlns:sword="http://purl.org/net/sword/"
+        xmlns:dcterms="http://purl.org/dc/terms/">
+
+    <title>{{ transfer_name }}</title>
+    <id>{{ transfer_id }}</id>
+    <updated>{{ current_datetime }}</updated>
+    <generator uri="https://www.archivematica.org" version="1.0"/>
+
+    <summary>A deposit was started.</summary>
+    <sword:treatment>A deposit directory was created and, optionally, asynchronous download of digital objects.</sword:treatment>
+
+    <link rel="alternate" href="http://www.swordserver.ac.uk/col1/mydeposit.html"/>
+    <link rel="edit-media" href="{{ media_iri }}"/>
+    <link rel="edit" href="{{ edit_iri }}" />
+    <link rel="http://purl.org/net/sword/terms/add" href="{{ edit_iri }}" />
+    <link rel="http://purl.org/net/sword/terms/statement" type="application/atom+xml;type=feed"
+      href="{{ state_iri }}" />
+</entry>

--- a/storage_service/templates/locations/api/sword/entry.xml
+++ b/storage_service/templates/locations/api/sword/entry.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+{% include 'locations/api/sword/_entry.xml' %}

--- a/storage_service/templates/locations/api/sword/error.xml
+++ b/storage_service/templates/locations/api/sword/error.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<sword:error href="http://purl.org/net/sword/error/ErrorBadRequest" xmlns="http://www.w3.org/2005/Atom" xmlns:sword="http://purl.org/net/sword/">
+  <summary type="text">{{ summary }}</summary>
+  <title type="text">ERROR</title>
+  <updated>{{ update_time }}</updated>
+  <generator uri="{{ request.get_full_path }}" version="1.0">Archivematica</generator>
+  <sword:userAgent>{{ user_agent }}</sword:userAgent>
+  <link rel="alternate" href="https://www.archivematica.org/wiki/Sword_API" type="text/html"/>
+</sword:error>

--- a/storage_service/templates/locations/api/sword/service_document.xml
+++ b/storage_service/templates/locations/api/sword/service_document.xml
@@ -1,0 +1,20 @@
+<service xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:sword="http://purl.org/net/sword/terms/"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns="http://www.w3.org/2007/app">
+
+  <sword:version>2.0</sword:version>
+
+  <workspace>
+    <atom:title>Archivematica storage service</atom:title>
+
+    {% for collection in collections %}
+    <collection href="{{ collection.url }}">
+      <atom:title>{{ collection.title }}</atom:title>
+      <accept>*/*</accept>
+      <accept alternate="multipart-related">*/*</accept>
+      <sword:mediation>false</sword:mediation>
+    </collection>
+    {% endfor %}
+  </workspace>
+</service>

--- a/storage_service/templates/locations/api/sword/state.xml
+++ b/storage_service/templates/locations/api/sword/state.xml
@@ -1,0 +1,10 @@
+<atom:feed xmlns:sword="http://purl.org/net/sword/terms/" 
+            xmlns:atom="http://www.w3.org/2005/Atom">
+
+    <atom:category scheme="http://purl.org/net/sword/terms/state"
+        term="{{ state_term }}"
+        label="State">
+            {{ state_description }}
+    </atom:category>
+
+</atom:feed>

--- a/storage_service/templates/locations/api/sword/state.xml
+++ b/storage_service/templates/locations/api/sword/state.xml
@@ -7,4 +7,6 @@
             {{ state_description }}
     </atom:category>
 
+    {% include 'locations/api/sword/_entries.xml' %}
+
 </atom:feed>

--- a/storage_service/templates/snippets/packages_table.html
+++ b/storage_service/templates/snippets/packages_table.html
@@ -2,6 +2,7 @@
     <thead>
       <tr>
         <th>UUID</th>
+        <th>Description</th>
         <th>Originating Pipeline</th>
         <th>Current Location</th>
         <th>Size</th>
@@ -15,8 +16,15 @@
     {% for package in packages %}
       <tr>
         <td>{{ package.uuid }}</td>
-        <td><a href="{% url 'pipeline_detail' package.origin_pipeline.uuid %}">{{ package.origin_pipeline }}</a></td>
-        <td>{{ package.full_path }}</td>
+        <td>{{ package.description }}</td>
+        <td>
+          {% if package.origin_pipeline %}
+          <a href="{% url 'pipeline_detail' package.origin_pipeline.uuid %}">{{ package.origin_pipeline }}</a>
+          {% else %}
+          None
+          {% endif %}
+        </td>
+        <td><a href="{% url 'location_detail' package.current_location.uuid %}">{{ package.full_path }}</a></td>
         <td>{{ package.size|filesizeformat }}</td>
         <td>{{ package.get_package_type_display }}</td>
         <td>


### PR DESCRIPTION
Add support for depositing files from FEDORA, using SWORD2 as the API.  See https://www.archivematica.org/wiki/Sword_API for the full spec.

Adds a new FEDORA Space, new 'FEDORA/SWORD Deposit' purpose for locations, and Deposit type of package.  Pipelines now contain information for using the dashboard API.  Also adds several models to track asynchronous downloads to a deposit.

Interactions described on wiki (and in code docstrings), but the API includes:
- service document IRI (information about collections)
- collection IRI (information about deposits, create new deposits)
- deposit IRI (for getting information about the deposit, and finalizing it)
- deposit media IRI (for posting new media to a specific deposit)

History cleaned up as best I can - more can be done if requested.
