### PR TITLE
UI-generated Location path is relative to Space

### DIFF
--- a/storage_service/static/js/single_directory_picker.js
+++ b/storage_service/static/js/single_directory_picker.js
@@ -27,9 +27,10 @@ function createSingleDirectoryPicker(path, textFieldCssId, triggerElementCssId, 
             description: 'Select directory',
             iconHtml: 'Select',
             logic: function(result) {
-              var path = result.path;
+              // Path with the base path stripped
+              var path = result.path.replace(selector.basePath, '')
 
-              // hack to work around issue
+              // strip leading '/'s
               while (path[0] == '/') {
                 path = path.substr(1, path.length - 1);
               }
@@ -47,6 +48,7 @@ function createSingleDirectoryPicker(path, textFieldCssId, triggerElementCssId, 
         'parent': '',
         'children': []
       };
+      selector.basePath = path
 
       selector.render();
     }

--- a/storage_service/templates/locations/location_form.html
+++ b/storage_service/templates/locations/location_form.html
@@ -43,7 +43,7 @@
         'id_relative_path',
         'id_relative_path_browse',
         'directory_picker',
-        '/api/v2/space/{{ space.uuid }}/browse/'
+        '{% url "browse" "v2" "space" space.uuid %}'
       );
     });
   </script>


### PR DESCRIPTION
refs #5608

Javascript that generates the path from browse dialog stores the base path, and removes that from selected path.  Also continues to strip leading '/'s.  Updated URL to not be hard-coded.
