### PR TITLE
Support storing DIPs via the storage service

### DIFF
--- a/storage_service/administration/forms.py
+++ b/storage_service/administration/forms.py
@@ -96,6 +96,13 @@ class DefaultLocationsForm(SettingsForm):
     new_aip_storage = DefaultLocationField(
         required=False,
         label="New AIP Storage:")
+    default_dip_storage = forms.MultipleChoiceField(
+        choices=[],
+        required=False,
+        label="Default DIP storage locations for new pipelines")
+    new_dip_storage = DefaultLocationField(
+        required=False,
+        label="New DIP Storage:")
     default_backlog = forms.MultipleChoiceField(
         choices=[],
         required=False,
@@ -116,6 +123,10 @@ class DefaultLocationsForm(SettingsForm):
         self.fields['default_aip_storage'].choices = [
             (l.uuid, l.get_description()) for l in
             Location.active.filter(purpose=Location.AIP_STORAGE)] + \
+            [('new', 'Create new location for each pipeline')]
+        self.fields['default_dip_storage'].choices = [
+            (l.uuid, l.get_description()) for l in
+            Location.active.filter(purpose=Location.DIP_STORAGE)] + \
             [('new', 'Create new location for each pipeline')]
         self.fields['default_backlog'].choices = [
             (l.uuid, l.get_description()) for l in

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -432,7 +432,7 @@ class PackageResource(ModelResource):
         origin_location_uri = bundle.data.get('origin_location', False)
         origin_location = self.origin_location.build_related_resource(origin_location_uri, bundle.request).obj
         origin_path = bundle.data.get('origin_path', False)
-        if bundle.obj.package_type in (Package.AIP, Package.AIC) and bundle.obj.current_location.purpose in (Location.AIP_STORAGE):
+        if bundle.obj.package_type in (Package.AIP, Package.AIC, Package.DIP) and bundle.obj.current_location.purpose in (Location.AIP_STORAGE, Location.DIP_STORAGE):
             # Store AIP/AIC
             bundle.obj.store_aip(origin_location, origin_path)
         elif bundle.obj.package_type in (Package.TRANSFER) and bundle.obj.current_location.purpose in (Location.BACKLOG):

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -58,6 +58,11 @@ def startup():
         space=space,
         relative_path=os.path.join('var', 'archivematica', 'sharedDirectory', 'www', 'AIPsStore'),
         description='Store AIP in standard Archivematica Directory')
+    dip_storage, _ = locations_models.Location.objects.get_or_create(
+        purpose=locations_models.Location.DIP_STORAGE,
+        space=space,
+        relative_path=os.path.join('var', 'archivematica', 'sharedDirectory', 'www', 'DIPsStore'),
+        description='Store DIP in standard Archivematica Directory')
     backlog, _ = locations_models.Location.objects.get_or_create(
         purpose=locations_models.Location.BACKLOG,
         space=space,
@@ -77,6 +82,8 @@ def startup():
         utils.set_setting('default_transfer_source', [transfer_source.uuid])
     if not utils.get_setting('default_aip_storage'):
         utils.set_setting('default_aip_storage', [aip_storage.uuid])
+    if not utils.get_setting('default_dip_storage'):
+        utils.set_setting('default_dip_storage', [dip_storage.uuid])
     if not utils.get_setting('default_backlog'):
         utils.set_setting('default_backlog', [backlog.uuid])
 


### PR DESCRIPTION
This creates a new storage purpose, "DIP Storage", which is primarily used to store uncompressed directory DIPs.

Refs #6564
