### PR TITLE
Edit user URL use ID not username

### DIFF
--- a/storage_service/administration/urls.py
+++ b/storage_service/administration/urls.py
@@ -10,6 +10,6 @@ urlpatterns = patterns('administration.views',
         name='user_list'),
     url(r'^users/create/$', 'user_create',
         name='user_create'),
-    url(r'^users/(?P<username>[-\w]+)/edit/$', 'user_edit',
+    url(r'^users/(?P<id>[-\w]+)/edit/$', 'user_edit',
         name='user_edit'),
 )

--- a/storage_service/administration/views.py
+++ b/storage_service/administration/views.py
@@ -31,9 +31,9 @@ def user_list(request):
     users = get_user_model().objects.all()
     return render(request, 'administration/user_list.html', locals())
 
-def user_edit(request, username):
+def user_edit(request, id):
     action = "Edit"
-    edit_user = get_object_or_404(get_user_model(), username=username)
+    edit_user = get_object_or_404(get_user_model(), id=id)
     user_form = settings_forms.UserChangeForm(request.POST or None, instance=edit_user)
     password_form = SetPasswordForm(data=request.POST or None, user=edit_user)
     if 'user' in request.POST and user_form.is_valid():

--- a/storage_service/templates/administration/user_form.html
+++ b/storage_service/templates/administration/user_form.html
@@ -6,7 +6,7 @@
 
 <div class='user'>
     {% if edit_user %}
-    <form action="{% url 'user_edit' edit_user.username %}" method="post">
+    <form action="{% url 'user_edit' edit_user.id %}" method="post">
     {% else %}
     <form action="{% url 'user_create' %}" method="post">
     {% endif %}
@@ -16,7 +16,7 @@
     </form>
 
     {% if edit_user %}
-    <form action="{% url 'user_edit' edit_user.username %}" method="post">
+    <form action="{% url 'user_edit' edit_user.id %}" method="post">
       {% csrf_token %}
       {{ password_form.as_p }}
       <input type="submit" name='password' value="Change Password" />

--- a/storage_service/templates/administration/user_list.html
+++ b/storage_service/templates/administration/user_list.html
@@ -25,7 +25,7 @@
         <td>{{ user_display.is_active }}</td>
         <td>
           {% if user.is_superuser or user.id == user_display.id %}
-            <a class="btn edit small" href="{% url 'user_edit' user_display.username %}">Edit</a>
+            <a class="btn edit small" href="{% url 'user_edit' user_display.id %}">Edit</a>
           {% endif %}
       </tr>
     {% endfor %}


### PR DESCRIPTION
refs #6674

Django's 'reverse' bails on characters that are not alphanumeric or - (including . and @).  Update user-related URLs to use the ID instead of the username, as some special characters are allowed in the username.
