### PR TITLE
Package: add support for checking fixity

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,4 @@ django-extensions==1.1.1
 lxml==3.2.3
 six==1.4.1
 django-jsonfield==0.9.12
+bagit==1.3.7

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -669,6 +669,20 @@ class Package(models.Model):
             return os.path.join(self.pointer_file_location.full_path(),
                 self.pointer_file_path)
 
+    def is_compressed(self):
+        """ Determines whether or not the package is a compressed file. """
+        full_path = self.full_path()
+        if os.path.isdir(full_path):
+            return False
+        elif os.path.isfile(full_path):
+            return True
+        else:
+            if not os.path.exists(full_path):
+                message = "Package {} (located at {}) does not exist".format(self.uuid, full_path)
+            else:
+                message = "{} is neither a file nor a directory".format(full_path)
+            raise StorageException(message)
+
     def _check_quotas(self, dest_space, dest_location):
         """
         Verify that there is enough storage space on dest_space and dest_location for this package.  All sizes in bytes.


### PR DESCRIPTION
This teaches Packages how to check their own fixity, and report the results. This is currently only supported for bags (which have a record of their own fixity), e.g. AICs or AIPs.

This also adds a new API call which allows external services to request fixity scans and receive a report of the results. The URL is in the format /file/<uuid>/check_fixity/

Note that this fixity scan isn't intended to be 100% authoritative against tampering (since it depends on a manifest file in the same physical location as the files it documents that is not signed), just against data integrity.

refs #6567
