### PR TITLE
Package.extract_file: determine basename using lsar

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ X-Python-Version: 2.7
 
 Package: archivematica-storage-service
 Architecture: i386 amd64
-Depends: ${python:Depends}, ${misc:Depends}, python-lxml, nginx, unar, uwsgi, uwsgi-plugin-python
+Depends: ${python:Depends}, ${misc:Depends}, python-lxml, nginx, unar (>= 1.8.1-4), uwsgi, uwsgi-plugin-python
 Description: Django webapp for managing storage in an Archivematica
     installation.
 Homepage: http://archivematica.org


### PR DESCRIPTION
The current code assumes there will only be one file extension. This switches to using lsar to determine the actual directory name. Ideally we'll switch to using lsar's JSON output, but it's currently broken for nested archives.
