### PR TITLE
Store uncompressed AIPs

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -509,6 +509,10 @@ class PackageResource(ModelResource):
         elif package.package_type in Package.PACKAGE_TYPE_CAN_EXTRACT:
             # If file doesn't exist, try to extract it
             (extracted_file_path, temp_dir) = package.extract_file(relative_path_to_file)
+        else:
+            # If the package is compressed and we can't extract it,
+            return http.HttpResponse(status=501,
+                content="Unable to extract package of type: {}".format(package.package_type))
 
         response = utils.download_file_stream(extracted_file_path, temp_dir)
 

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -530,7 +530,10 @@ class PackageResource(ModelResource):
     def pointer_file_request(self, request, bundle, **kwargs):
         # Get AIP details
         pointer_path = bundle.obj.full_pointer_file_path()
-        response = utils.download_file_stream(pointer_path)
+        if not pointer_path:
+            response = http.HttpNotFound("Resource with UUID {} does not have a pointer file".format(bundle.obj.uuid))
+        else:
+            response = utils.download_file_stream(pointer_path)
         return response
 
     @_custom_endpoint(expected_methods=['get'])

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -495,10 +495,14 @@ class PackageResource(ModelResource):
         package = bundle.obj
         full_path = package.full_path()
 
-        local_path = os.path.join(full_path, relative_path_to_file)
-        if os.path.exists(local_path):
-            # Local file exists - return that
-            extracted_file_path = local_path
+        # If local file exists - return that
+        if not package.is_compressed():
+            # The basename of the AIP is included with the request, because
+            # all packages contain a base directory. That directory is already
+            # inside the full path though, so remove it here.
+            basename = os.path.join(os.path.basename(full_path), '')
+            relative_path_to_file = relative_path_to_file.split(basename, 1)[1]
+            extracted_file_path = os.path.join(full_path, relative_path_to_file)
         elif package.package_type in Package.PACKAGE_TYPE_CAN_EXTRACT:
             # If file doesn't exist, try to extract it
             (extracted_file_path, temp_dir) = package.extract_file(relative_path_to_file)

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -503,6 +503,9 @@ class PackageResource(ModelResource):
             basename = os.path.join(os.path.basename(full_path), '')
             relative_path_to_file = relative_path_to_file.split(basename, 1)[1]
             extracted_file_path = os.path.join(full_path, relative_path_to_file)
+            if not os.path.exists(extracted_file_path):
+                return http.HttpResponse(status=404,
+                    content="Requested file, {}, not found in AIP".format(relative_path_to_file))
         elif package.package_type in Package.PACKAGE_TYPE_CAN_EXTRACT:
             # If file doesn't exist, try to extract it
             (extracted_file_path, temp_dir) = package.extract_file(relative_path_to_file)

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1205,6 +1205,8 @@ class Package(models.Model):
     def get_download_path(self, lockss_au_number=None):
         full_path = self.full_path()
         if lockss_au_number is None:
+            if not self.is_compressed():
+                raise StorageException("Cannot return a download path for an uncompressed package")
             path = full_path
         elif self.current_location.space.access_protocol == Space.LOM:
             # Only LOCKSS breaks files into AUs

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1182,7 +1182,7 @@ class Package(models.Model):
         """ Return the full path of the AIP's pointer file, None if not an AIP.
 
         Includes the space, location and package paths joined."""
-        if self.package_type not in (self.AIP, self.AIC):
+        if not self.pointer_file_location:
             return None
         else:
             return os.path.join(self.pointer_file_location.full_path(),


### PR DESCRIPTION
This is the sister PR to artefactual/archivematica#40.

This allows storing uncompressed AIPs via the storage service.
- Store AIP now works if no pointer file is present.
- Packages can now compress themselves, and the download API from the package resource will compress uncompressed packages before serving them.

Ignore the last commit here; it's duplicated from the other branch.
