### PR TITLE
Add email notification for deletion requests, fixity failures

### DIFF
--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -27,6 +27,11 @@ import sword2
 
 # This project, alphabetical
 from common import utils
+# Note that while the signals are not actually used here,
+# they should be imported here to make sure that they
+# are imported very early on globally. This ensures that
+# the signals themselves are registered early.
+from locations import signals
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(filename="/tmp/storage-service.log",

--- a/storage_service/locations/signals.py
+++ b/storage_service/locations/signals.py
@@ -1,0 +1,50 @@
+import logging
+from django.dispatch import receiver, Signal
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(filename="/tmp/storage_service.log",
+                    level=logging.INFO)
+
+
+deletion_request = Signal(providing_args=["uuid", "location", "url"])
+failed_fixity_check = Signal(providing_args=["uuid", "location", "report"])
+
+
+def _notify_administrators(subject, message):
+    admin_users = User.objects.filter(is_superuser=True)
+    for user in admin_users:
+        try:
+            user.email_user(subject, message)
+        except Exception:
+            logging.exception("Unable to send email to %s", user.email)
+
+
+@receiver(deletion_request, dispatch_uid="deletion_request")
+def report_deletion_request(sender, **kwargs):
+    subject = "Deletion request for package {}".format(kwargs["uuid"])
+    message = """
+A package deletion request was received for the package with UUID {}. This package is currently stored at: {}.
+""".format(kwargs["uuid"], kwargs["location"])
+
+    # The URL may not be configured in the site; if it isn't,
+    # don't try to tell the user the URL to approve/deny the request.
+    if kwargs["url"]:
+        message = message + """
+To approve this deletion request, visit: {}{}
+""".format(kwargs["url"], reverse('aip_delete_request'))
+
+    _notify_administrators(subject, message)
+
+
+@receiver(failed_fixity_check, dispatch_uid="fixity_check")
+def report_failed_fixity_check(sender, **kwargs):
+    subject = "Fixity check failed for package {}".format(kwargs["uuid"])
+    message = """
+A fixity check failed for the package with UUID {}. This package is currently stored at: {}
+
+Full failure report (in JSON format):
+{}
+""".format(kwargs["uuid"], kwargs["location"], kwargs["report"])
+    _notify_administrators(subject, message)


### PR DESCRIPTION
This adds email notifications to a couple of events: AIP deletion requests, and fixity check failures.

The storage service will send emails to every user account with superuser privileges, are the accounts with permission to do things like approve AIP deletion. It's implemented using Django signals, and a new `signals` module had been added to `locations`.

It uses Django's email support; in order for it to work, the email server and authentication information to use must be configured in Django's settings files (or in environment variables). If email isn't configured, then these signals won't send an email (they'll print the message they would have sent to stdout instead).

Django is not configured with a way to get the site's URL by default; in order for the AIP deletion request to provide a URL, this must be configured with the SITE_BASE_URL config setting, with a value similar to "http://example.com". If that parameter is omitted, then the AIP deletion request email won't include a link to the page where requests can be approved or denied.
