### PR TITLE
Make internal processing location configurable

### DIFF
--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1053,6 +1053,7 @@ class Location(models.Model):
         # (QUARANTINE, 'Quarantine'),
         (BACKLOG, 'Transfer Backlog'),
         (CURRENTLY_PROCESSING, 'Currently Processing'),
+        (STORAGE_SERVICE_INTERNAL, 'Storage Service Internal Processing'),
     )
     purpose = models.CharField(max_length=2,
         choices=PURPOSE_CHOICES,


### PR DESCRIPTION
The only location in the storage service that is not user-configurable is the internal processing location. This ended up causing a problem at one client where the machine the SS is installed on has limited hard drive space, and rapidly ran out of room due almost entirely to the contents of this location. There were two issues trying to change this:
- The location type isn't available in the menu, so even though there is an option to edit this location, it couldn't be saved because its own type wasn't available in the dropdown
- On every startup, a new location with the default path is created if none exists, so trying to move the original location would result in a second location at the original path appearing
