### PR TITLE
Add new post-store callback API

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,7 @@ South==0.8.4
 django-tastypie==0.9.15
 django-extensions==1.1.1
 lxml==3.2.3
+requests==2.2.1
 six==1.4.1
 django-jsonfield==0.9.12
 bagit==1.3.7

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -382,3 +382,17 @@ def sword_error_response(request, status, summary):
     error_xml = render_to_string('locations/api/sword/error.xml', error_details)
     return HttpResponse(error_xml, status=error_details['status'])
 
+def store_mets_data(mets_path, deposit, object_id):
+    submission_documentation_directory = os.path.join(deposit.full_path(), 'submissionDocumentation')
+    if not os.path.exists(submission_documentation_directory):
+        os.mkdir(submission_documentation_directory)
+
+    mets_name = object_id.replace(':', '-') + '-METS.xml'
+    target = os.path.join(submission_documentation_directory, mets_name)
+
+    # There may be a previous METS file if the same file is being
+    # re-transferred, so remove and update the METS in this case.
+    if os.path.exists(target):
+        os.path.unlink(target)
+
+    os.rename(mets_path, target)

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -208,10 +208,8 @@ def _fetch_content(deposit_uuid, objects):
                 os.unlink(temp_filename)
                 raise Exception("Incorrect checksum")
 
-            shutil.move(
-                temp_filename,
-                os.path.join(deposit.full_path(), filename)
-            )
+            new_path = os.path.join(deposit.full_path(), filename)
+            shutil.move(temp_filename, new_path)
 
             # mark download task file record complete or failed
             task_file.completed = True
@@ -219,6 +217,13 @@ def _fetch_content(deposit_uuid, objects):
 
             logging.info('Saved file to ' + os.path.join(deposit.full_path(), filename))
             completed += 1
+
+            file_record = models.File(
+                name=item['filename'],
+                source_id=item['object_id'],
+                checksum=generate_checksum(new_path, 'sha512').hexdigest()
+            )
+            file_record.save()
         except Exception as e:
             logging.error('Package download task encountered an error:' + str(e))
             # an error occurred

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -242,6 +242,7 @@ def _parse_name_and_content_urls_from_mets_file(filepath):
     tree = etree.parse(filepath)
     root = tree.getroot()
     deposit_name = root.get('LABEL')
+    object_id = root.get('OBJID')
     logging.info('found deposit name in mets: ' + deposit_name)
 
     # parse XML for content URLs
@@ -266,6 +267,7 @@ def _parse_name_and_content_urls_from_mets_file(filepath):
            raise Exception('If using CHECKSUM attribute, CHECKSUMTYPE attribute value must be set to MD5 in XML')
 
        objects.append({
+           'object_id': object_id,
            'filename': filename,
            'url': url,
            'checksum': checksum

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -139,7 +139,10 @@ def collection(request, location):
                         submission_documentation_directory = os.path.join(deposit.full_path(), 'submissionDocumentation')
                         if not os.path.exists(submission_documentation_directory):
                             os.mkdir(submission_documentation_directory)
-                        os.rename(temp_filepath, os.path.join(submission_documentation_directory, 'fedora-METS.xml'))
+
+                        object_id = mets_data.get('object_id', 'fedora')
+                        mets_name = object_id.replace(':', '-') + '-METS.xml'
+                        os.rename(temp_filepath, os.path.join(submission_documentation_directory, mets_name))
 
                         _spawn_batch_download_and_flag_finalization_if_requested(deposit, request, mets_data)
 
@@ -276,7 +279,8 @@ def _parse_name_and_content_urls_from_mets_file(filepath):
 
     return {
         'deposit_name': deposit_name,
-        'objects': objects
+        'objects': objects,
+        'object_id': object_id
     }
 
 def _create_deposit_directory_and_db_entry(location, deposit_name=None, source_path=None, sourceofacquisition=None):

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -86,3 +86,8 @@ class ConfirmEventForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(ConfirmEventForm, self).__init__(*args, **kwargs)
         self.fields['status_reason'].required = True
+
+class CallbackForm(forms.ModelForm):
+    class Meta:
+        model = models.Callback
+        fields = ('uri', 'event', 'method', 'expected_status')

--- a/storage_service/locations/migrations/0005_v0_5_0.py
+++ b/storage_service/locations/migrations/0005_v0_5_0.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'File'
+        db.create_table(u'locations_file', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('uuid', self.gf('django.db.models.fields.CharField')(unique=True, max_length=36, blank=True)),
+            ('name', self.gf('django.db.models.fields.TextField')(max_length=1000)),
+            ('source_id', self.gf('django.db.models.fields.TextField')(max_length=128)),
+            ('checksum', self.gf('django.db.models.fields.TextField')(max_length=128)),
+            ('stored', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal(u'locations', ['File'])
+
+        # Adding model 'Callback'
+        db.create_table(u'locations_callback', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('uuid', self.gf('django.db.models.fields.CharField')(max_length=36, blank=True)),
+            ('uri', self.gf('django.db.models.fields.CharField')(max_length=1024)),
+            ('event', self.gf('django.db.models.fields.CharField')(max_length=15)),
+            ('method', self.gf('django.db.models.fields.CharField')(max_length=10)),
+            ('expected_status', self.gf('django.db.models.fields.IntegerField')(default=200)),
+            ('enabled', self.gf('django.db.models.fields.BooleanField')(default=True)),
+        ))
+        db.send_create_signal(u'locations', ['Callback'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'File'
+        db.delete_table(u'locations_file')
+
+        # Deleting model 'Callback'
+        db.delete_table(u'locations_callback')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'locations.callback': {
+            'Meta': {'object_name': 'Callback'},
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'event': ('django.db.models.fields.CharField', [], {'max_length': '15'}),
+            'expected_status': ('django.db.models.fields.IntegerField', [], {'default': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'uri': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.event': {
+            'Meta': {'object_name': 'Event'},
+            'admin_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'event_reason': ('django.db.models.fields.TextField', [], {}),
+            'event_type': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Package']", 'to_field': "'uuid'"}),
+            'pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'status_reason': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'store_data': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'user_email': ('django.db.models.fields.EmailField', [], {'max_length': '254'}),
+            'user_id': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        u'locations.fedora': {
+            'Meta': {'object_name': 'Fedora'},
+            'fedora_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'fedora_password': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'fedora_user': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
+        u'locations.file': {
+            'Meta': {'object_name': 'File'},
+            'checksum': ('django.db.models.fields.TextField', [], {'max_length': '128'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {'max_length': '1000'}),
+            'source_id': ('django.db.models.fields.TextField', [], {'max_length': '128'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'}),
+            'stored': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'locations.localfilesystem': {
+            'Meta': {'object_name': 'LocalFilesystem'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
+        u'locations.location': {
+            'Meta': {'object_name': 'Location'},
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pipeline': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['locations.Pipeline']", 'null': 'True', 'through': u"orm['locations.LocationPipeline']", 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'quota': ('django.db.models.fields.BigIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'relative_path': ('django.db.models.fields.TextField', [], {}),
+            'space': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'"}),
+            'used': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.locationpipeline': {
+            'Meta': {'object_name': 'LocationPipeline'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Location']", 'to_field': "'uuid'"}),
+            'pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'"})
+        },
+        u'locations.lockssomatic': {
+            'Meta': {'object_name': 'Lockssomatic'},
+            'au_size': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'checksum_type': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'collection_iri': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'content_provider_id': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'external_domain': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'keep_local': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'sd_iri': ('django.db.models.fields.URLField', [], {'max_length': '256'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
+        u'locations.nfs': {
+            'Meta': {'object_name': 'NFS'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'manually_mounted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'remote_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'remote_path': ('django.db.models.fields.TextField', [], {}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'default': "'nfs4'", 'max_length': '64'})
+        },
+        u'locations.package': {
+            'Meta': {'object_name': 'Package'},
+            'current_location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Location']", 'to_field': "'uuid'"}),
+            'current_path': ('django.db.models.fields.TextField', [], {}),
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'misc_attributes': ('jsonfield.fields.JSONField', [], {'default': '{}', 'null': 'True', 'blank': 'True'}),
+            'origin_pipeline': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Pipeline']", 'to_field': "'uuid'", 'null': 'True', 'blank': 'True'}),
+            'package_type': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'pointer_file_location': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'to_field': "'uuid'", 'null': 'True', 'to': u"orm['locations.Location']"}),
+            'pointer_file_path': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'size': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'FAIL'", 'max_length': '8'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.packagedownloadtask': {
+            'Meta': {'object_name': 'PackageDownloadTask'},
+            'download_completion_time': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'downloads_attempted': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'downloads_completed': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['locations.Package']", 'to_field': "'uuid'"}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.packagedownloadtaskfile': {
+            'Meta': {'object_name': 'PackageDownloadTaskFile'},
+            'completed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'failed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'task': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'download_file_set'", 'to_field': "'uuid'", 'to': u"orm['locations.PackageDownloadTask']"}),
+            'url': ('django.db.models.fields.TextField', [], {}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'locations.pipeline': {
+            'Meta': {'object_name': 'Pipeline'},
+            'api_key': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'api_username': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'remote_name': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36'})
+        },
+        u'locations.pipelinelocalfs': {
+            'Meta': {'object_name': 'PipelineLocalFS'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'remote_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'remote_user': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'space': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['locations.Space']", 'to_field': "'uuid'", 'unique': 'True'})
+        },
+        u'locations.space': {
+            'Meta': {'object_name': 'Space'},
+            'access_protocol': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_verified': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.TextField', [], {}),
+            'size': ('django.db.models.fields.BigIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'staging_path': ('django.db.models.fields.TextField', [], {}),
+            'used': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'}),
+            'verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['locations']

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -267,8 +267,8 @@ class Space(models.Model):
         try:
             return self.get_child_space().update_package_status(package)
         except AttributeError:
-            pass  # TODO should this be required?
-            # raise NotImplementedError('{} space has not implemented update_package_status'.format(self.get_access_protocol_display()))
+            message = '{} space has not implemented update_package_status'.format(self.get_access_protocol_display())
+            return (None, message)
 
 
     # HELPER FUNCTIONS

--- a/storage_service/locations/urls.py
+++ b/storage_service/locations/urls.py
@@ -55,4 +55,18 @@ urlpatterns = patterns('locations.views',
     # Spaces AJAX
     url(r'^spaces/get_form_type/$', 'ajax_space_create_protocol_form',
         name='ajax_space_create_protocol_form'),
+
+    # Callbacks
+    url(r'^callbacks/$', 'callback_list',
+        name='callback_list'),
+    url(r'^callbacks/(?P<uuid>'+UUID+')/$', 'callback_detail',
+        name='callback_detail'),
+    url(r'^callbacks/create/$', 'callback_edit',
+        name='callback_create'),
+    url(r'^callbacks/(?P<uuid>'+UUID+')/edit/$', 'callback_edit',
+        name='callback_edit'),
+    url(r'^callbacks/(?P<uuid>'+UUID+')/delete/$', 'callback_delete',
+        name='callback_delete'),
+    url(r'^callbacks/(?P<uuid>'+UUID+')/switch_enabled/$', 'callback_switch_enabled',
+        name='callback_switch_enabled'),
 )

--- a/storage_service/templates/locations/callback_detail.html
+++ b/storage_service/templates/locations/callback_detail.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block page_title %}{{ callback.uri }} Callback Information{% endblock %}
+
+{% block content %}
+
+<div class="callback">
+  <dl>
+    <dt>URI</dt> <dd>{{ callback.uri }}</dd>
+    <dt>Event</dt> <dd>{{ callback.event }}</dd>
+    <dt>HTTP Method</dt> <dd>{{ callback.method }}</dd>
+    <dt>Expected status</dt> <dd>{{ callback.expected_status }}</dd>
+    <dt>Enabled</dt> <dd>{{ callback.enabled|yesno:"Enabled,Disabled"}}</dd>
+    <dt>Actions</dt> <dd>
+      <ul>
+        <li><a href="{% url 'callback_edit' callback.uuid %}">Edit</a></li>
+        <li><a href="{% url 'callback_switch_enabled' callback.uuid %}?next={{ request.path }}">{{ callback.enabled|yesno:"Disable,Enable" }}</a></li>
+        <li><a href="{% url 'callback_delete' callback.uuid %}">Delete</a></li>
+      </ul>
+    </dd>
+  </dl>
+</div>
+
+{% endblock %}

--- a/storage_service/templates/locations/callback_form.html
+++ b/storage_service/templates/locations/callback_form.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block page_title %}{{action}} Callback{% endblock %}
+
+{% block content %}
+
+<div class='callback'>
+    {% if callback %}
+    <form action="{% url 'callback_edit' callback.uuid %}" method="post">
+    {% else %}
+    <form action="{% url 'callback_create' %}" method="post">
+    {% endif %}
+    {% csrf_token %}
+        {{ form.as_p }}
+        <input type="submit" value="{{action}} Callback" class='btn btn-primary' />
+    </form>
+</div>
+{% endblock %}

--- a/storage_service/templates/locations/callback_list.html
+++ b/storage_service/templates/locations/callback_list.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block page_title %}All Callbacks{% endblock %}
+
+{% block content %}
+
+{% include 'snippets/callback_description.html' %}
+
+<p><a href="{% url 'callback_create' %}">Create new callback</a></p>
+
+{% if callbacks %}
+  {% include "snippets/callbacks_table.html" %}
+{% else %}
+  <p>No callbacks currently exist.</p>
+{% endif %}
+
+{% endblock %}

--- a/storage_service/templates/snippets/callback_description.html
+++ b/storage_service/templates/snippets/callback_description.html
@@ -1,0 +1,1 @@
+<p>Callbacks allow REST calls to be made by the Archivematica Storage Service after performing certain types of actions. This allows external services to be notified when internal actions have taken place.</p>

--- a/storage_service/templates/snippets/callbacks_table.html
+++ b/storage_service/templates/snippets/callbacks_table.html
@@ -1,0 +1,26 @@
+  <table class="datatable">
+    <thead>
+      <tr>
+        <th>Event</th>
+        <th>URI</th>
+        <th>Method</th>
+        <th>Expected response</th>
+        <th>UUID</th>
+        <th>Enabled</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for callback in callbacks %}
+      <tr>
+        <td>{{ callback.event }}</td>
+        <td>{{ callback.uri }}</td>
+        <td>{{ callback.method }}</td>
+        <td>{{ callback.expected_status }}</td>
+        <td>{{ callback.uuid }}</td>
+        <td>{{ callback.enabled|yesno:"Enabled,Disabled" }}</td>
+        <td><a href="{% url 'callback_edit' callback.uuid %}">Edit</a> | <a href="{% url 'callback_switch_enabled' callback.uuid %}?next={{ request.path }}">{{ callback.enabled|yesno:"Disable,Enable" }}</a> | <a href="{% url 'callback_delete' callback.uuid %}?next={{ request.path }}">Delete</a></td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>


### PR DESCRIPTION
This adds support for post-store callbacks, via a new API that would be called by Archivematica. The current usecase is to support reporting back to Islandora for each file that's stored.

The storage service currently doesn't maintain a persistent memory of files; this adds a new minimal File model that can be used to track files on transfer start. Since we don't currently assign or track UUIDs to individual files in the storage service, this instead calculates checksums on arrival and uses that to identify the file at a later point in time. This is kind of a hack.

(In the long term, I think it'd make sense to do some of the file cleanup and UUID assignment in the storage service, and send the files over to Archivematica with UUIDs assigned and the transfer METS already built; then we can just inspect the AIP METS to locate files. That would be best done when we have a) a background task scheduler, b) a standalone METS writer, though.)

The settings for the callback are global; may make more sense to make them controlled per-pipeline.

Another few supporting improvements:
- The SWORD helpers checksum function has been replaced with a checksum function in common.utils that uses hashlib, and supports any checksum algorithm that hashlib supports. File's checksum column was sized large enough to fit a whirlpool or sha512 hash<s>,though that's bigger than we'd actually use for the time being</s>. UPDATE: Storing sha512 now.
- Package gained a new instance method, `Package.each_file`, that iterates over each file in a package as a convenience wrapper around `os.walk`. It also supports extracting compressed packages if necessary.

This isn't tested against an actual Islandora instance yet.
