### PR TITLE
Infrastructure updates - get_local_path, browse & delete in Spaces, etc

### DIFF
--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -93,7 +93,7 @@ def download_file_stream(filepath, temp_dir=None):
     """
     # If not found, return 404
     if not os.path.exists(filepath):
-        return http.HttpNotFound("File not found")
+        return http.HttpResponseNotFound("File not found")
 
     filename = os.path.basename(filepath)
     extension = os.path.splitext(filepath)[1].lower()

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -282,7 +282,7 @@ class LocationResource(ModelResource):
         location = bundle.obj
         path = request.GET.get('path', '')
         path = self.decode_path(path)
-        path = os.path.join(str(location.full_path()), path)
+        path = os.path.join(str(location.full_path), path)
 
         objects = self.get_objects(location.space, path)
 
@@ -477,7 +477,7 @@ class PackageResource(ModelResource):
             # This isn't configured by default
             site_url = getattr(settings, "SITE_BASE_URL", None)
             signals.deletion_request.send(sender=self, url=site_url,
-                uuid=package.uuid, location=package.full_path())
+                uuid=package.uuid, location=package.full_path)
         else:
             response = {
                 'error_message': 'A deletion request already exists for this AIP.'
@@ -500,10 +500,10 @@ class PackageResource(ModelResource):
 
         # Get Package details
         package = bundle.obj
-        full_path = package.full_path()
+        full_path = package.full_path
 
         # If local file exists - return that
-        if not package.is_compressed():
+        if not package.is_compressed:
             # The basename of the AIP is included with the request, because
             # all packages contain a base directory. That directory is already
             # inside the full path though, so remove it here.
@@ -547,7 +547,7 @@ class PackageResource(ModelResource):
     @_custom_endpoint(expected_methods=['get'])
     def pointer_file_request(self, request, bundle, **kwargs):
         # Get AIP details
-        pointer_path = bundle.obj.full_pointer_file_path()
+        pointer_path = bundle.obj.full_pointer_file_path
         if not pointer_path:
             response = http.HttpNotFound("Resource with UUID {} does not have a pointer file".format(bundle.obj.uuid))
         else:
@@ -596,7 +596,7 @@ class PackageResource(ModelResource):
         report = json.dumps(response)
         if not success:
             signals.failed_fixity_check.send(sender=self,
-                uuid=bundle.obj.uuid, location=bundle.obj.full_path(),
+                uuid=bundle.obj.uuid, location=bundle.obj.full_path,
                 report=report)
 
         return http.HttpResponse(

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -508,7 +508,7 @@ class PackageResource(ModelResource):
 
         # Get Package details
         package = bundle.obj
-        full_path = package.get_local_path()
+        full_path = package.fetch_local_path()
 
         # If local file exists - return that
         if not package.is_compressed:

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -381,7 +381,7 @@ class PackageResource(ModelResource):
     api/v1/file/<uuid>/delete_aip/ supports:
     POST: Create a delete request for that AIP.
 
-    Validate fixity (api/v1/file/<uuid>/validate/) supports:
+    Validate fixity (api/v1/file/<uuid>/check_fixity/) supports:
     GET: Scan package for fixity
     """
     origin_pipeline = fields.ForeignKey(PipelineResource, 'origin_pipeline')
@@ -500,7 +500,7 @@ class PackageResource(ModelResource):
 
         # Get Package details
         package = bundle.obj
-        full_path = package.full_path
+        full_path = package.get_local_path()
 
         # If local file exists - return that
         if not package.is_compressed:

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -5,8 +5,6 @@
 import json
 import logging
 import os
-import subprocess
-import tempfile
 import urllib
 
 # Core Django, alphabetical
@@ -335,7 +333,7 @@ class LocationResource(ModelResource):
             origin_uuid = origin_uri.split('/')[4]
             origin_location = Location.objects.get(uuid=origin_uuid)
         except (IndexError, Location.DoesNotExist):
-            raise NotFound("The URL provided '%s' was not a link to a valid Location." % origin_uri)
+            raise http.HttpNotFound("The URL provided '%s' was not a link to a valid Location." % origin_uri)
 
         # For each file in files, call move to/from
         origin_space = origin_location.space
@@ -490,7 +488,7 @@ class PackageResource(ModelResource):
                 uuid=package.uuid, location=package.full_path)
         else:
             response = {
-                'error_message': 'A deletion request already exists for this AIP.'
+                'message': 'A deletion request already exists for this AIP.'
             }
             status_code = 200
 

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -546,7 +546,7 @@ class PackageResource(ModelResource):
             temp_dir = None
             full_path = package.get_download_path(lockss_au_number)
         except StorageException:
-            full_path, temp_dir = package.compress_package()
+            full_path, temp_dir = package.compress_package(Package.COMPRESSION_TAR)
 
         response = utils.download_file_stream(full_path)
 

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -12,7 +12,7 @@ class PipelineForm(forms.ModelForm):
 
     class Meta:
         model = models.Pipeline
-        fields = ('uuid', 'description', 'enabled')
+        fields = ('uuid', 'description', 'remote_name', 'api_username', 'api_key', 'enabled')
 
 
 class SpaceForm(forms.ModelForm):

--- a/storage_service/locations/migrations/0004_v0_4_0.py
+++ b/storage_service/locations/migrations/0004_v0_4_0.py
@@ -22,6 +22,21 @@ class Migration(SchemaMigration):
         ))
         db.send_create_signal(u'locations', ['Lockssomatic'])
 
+        # Adding field 'Pipeline.remote_name'
+        db.add_column(u'locations_pipeline', 'remote_name',
+                      self.gf('django.db.models.fields.CharField')(default=None, max_length=256, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Pipeline.api_username'
+        db.add_column(u'locations_pipeline', 'api_username',
+                      self.gf('django.db.models.fields.CharField')(default=None, max_length=256, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Pipeline.api_key'
+        db.add_column(u'locations_pipeline', 'api_key',
+                      self.gf('django.db.models.fields.CharField')(default=None, max_length=256, null=True, blank=True),
+                      keep_default=False)
+
         # Adding field 'Package.misc_attributes'
         db.add_column(u'locations_package', 'misc_attributes',
                       self.gf('jsonfield.fields.JSONField')(default={}, null=True, blank=True),
@@ -36,6 +51,15 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
         # Deleting model 'Lockssomatic'
         db.delete_table(u'locations_lockssomatic')
+
+        # Deleting field 'Pipeline.remote_name'
+        db.delete_column(u'locations_pipeline', 'remote_name')
+
+        # Deleting field 'Pipeline.api_username'
+        db.delete_column(u'locations_pipeline', 'api_username')
+
+        # Deleting field 'Pipeline.api_key'
+        db.delete_column(u'locations_pipeline', 'api_key')
 
         # Deleting field 'Package.misc_attributes'
         db.delete_column(u'locations_package', 'misc_attributes')
@@ -157,9 +181,12 @@ class Migration(SchemaMigration):
         },
         u'locations.pipeline': {
             'Meta': {'object_name': 'Pipeline'},
+            'api_key': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'api_username': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
             'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
             'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'remote_name': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
             'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36'})
         },
         u'locations.pipelinelocalfs': {

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -227,6 +227,15 @@ class Space(models.Model):
                 source_path, destination_path, *args, **kwargs)
         except AttributeError:
             raise NotImplementedError('{} space has not implemented move_from_storage_service'.format(self.get_access_protocol_display()))
+        # Delete staging copy
+        if source_path != destination_path:
+            try:
+                if os.path.isdir(source_path):
+                    shutil.rmtree(os.path.normpath(source_path))
+                elif os.path.isfile(source_path):
+                    os.remove(os.path.normpath(source_path))
+            except OSError:
+                logging.warning('Unable to remove %s', source_path, exc_info=True)
 
     def post_move_from_storage_service(self, staging_path=None, destination_path=None, package=None, *args, **kwargs):
         """ Hook for any actions that need to be taken after moving from the storage service to the final destination. """

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -100,7 +100,7 @@ class Space(models.Model):
         help_text="Amount used in bytes")
     path = models.TextField(validators=[validate_space_path],
         help_text="Absolute path to the space on the storage service machine.")
-    staging_path=models.TextField(validators=[validate_space_path],
+    staging_path = models.TextField(validators=[validate_space_path],
         help_text="Absolute path to a staging area.  Must be UNIX filesystem compatible, preferably on the same filesystem as the path.")
     verified = models.BooleanField(default=False,
        help_text="Whether or not the space has been verified to be accessible.")
@@ -260,6 +260,9 @@ class Space(models.Model):
         """
         # Create directories
         logging.info("Rsyncing from {} to {}".format(source, destination))
+
+        if source == destination:
+            return
 
         # Rsync file over
         # TODO Do this asyncronously, with restarting failed attempts
@@ -1387,7 +1390,7 @@ class Package(models.Model):
                 flocat.set('{{{ns}}}href'.format(ns=utils.NSMAP['xlink']), self.full_path)
             # Add USE="Archival Information Package" to fileGrp.  Required for
             # LOCKSS, and not provided in Archivematica <=1.1
-            if not root.find('.//mets:fileGrp[@USE="Archival Information Package"]', namespaces=utils.NSMAP):
+            if root.find('.//mets:fileGrp[@USE="Archival Information Package"]', namespaces=utils.NSMAP) is not None:
                 root.find('.//mets:fileGrp', namespaces=utils.NSMAP).set('USE', 'Archival Information Package')
 
             with open(pointer_absolute_path, 'w') as f:

--- a/storage_service/locations/models.py
+++ b/storage_service/locations/models.py
@@ -1693,6 +1693,15 @@ class Pipeline(models.Model):
     description = models.CharField(max_length=256, default=None,
         null=True, blank=True,
         help_text="Human readable description of the Archivematica instance.")
+    remote_name = models.CharField(max_length=256, default=None,
+        null=True, blank=True,
+        help_text="Host or IP address of the pipeline server for making API calls.")
+    api_username = models.CharField(max_length=256, default=None,
+        null=True, blank=True,
+        help_text="Username to use when making API calls to the pipeline.")
+    api_key = models.CharField(max_length=256, default=None,
+        null=True, blank=True,
+        help_text="API key to use when making API calls to the pipeline.")
     enabled = models.BooleanField(default=True,
         help_text="Enabled if this pipeline is able to access the storage service.")
 

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -79,10 +79,11 @@ def startup():
     )
     if created:
         try:
-            os.mkdir(internal_use.full_path())
+            os.mkdir(internal_use.full_path)
         except OSError as e:
             if e.errno != errno.EEXIST:
-                logging.error("Internal storage location {} not accessible.".format(internal_use.full_path()))
+                logging.error("Internal storage location {} not accessible.".format(internal_use.full_path))
+
     if not utils.get_setting('default_transfer_source'):
         utils.set_setting('default_transfer_source', [transfer_source.uuid])
     if not utils.get_setting('default_aip_storage'):

--- a/storage_service/templates/locations/pipeline_detail.html
+++ b/storage_service/templates/locations/pipeline_detail.html
@@ -7,7 +7,9 @@
 <div class='pipeline'>
   <dl>
     <dt>UUID</dt> <dd>{{ pipeline.uuid }}</dd>
-    <dt>Description</dt> <dd>{{ pipeline.description }}</dd>
+    <dt>Description</dt> <dd>{{ pipeline.description|default:"&lt;None&gt;" }}</dd>
+    <dt>Remote name</dt> <dd>{{ pipeline.remote_name|default:"&lt;None&gt;" }}</dd>
+    <dt>API Username / Key</dt> <dd> {{ pipeline.api_username|default:"&lt;None&gt;" }} / {{ pipeline.api_key|default:"&lt;None&gt;" }}</dd>
     <dt>Enabled</dt> <dd>{{ pipeline.enabled|yesno:"Enabled,Disabled" }}</dd>
     <dt>Actions</dt> <dd>
       <ul>


### PR DESCRIPTION
Several infrastructure and miscellaneous updates in one, coming from AIP reingest work but independent of it.
- `browse` and `delete_path` are now implemented in protocol spaces, instead of in Space or Package, as they are very dependent on the protocol and should be handled by the appropriate space.
- `full_path` and `full_pointer_file_path` are now `@property`'s, since that's effectively  what they are
- Added `get_local_path` to help work with packages that are not store locally, but need to be worked with locally.  As the name implies, gets a local path for that package - either the actual local path, or by copying it to the SS internal location
- Pipelines store some pipeline API information so they can call pipeline APIs
- `compress_package` accepts an algorithm parameter
