### PR TITLE
Extract file: Optionally strip SIP name & UUID

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -500,15 +500,17 @@ class PackageResource(ModelResource):
 
         # Get Package details
         package = bundle.obj
-        full_path = package.full_path()
 
         # If local file exists - return that
         if not package.is_compressed():
-            # The basename of the AIP is included with the request, because
-            # all packages contain a base directory. That directory is already
-            # inside the full path though, so remove it here.
+            full_path = package.full_path()
+            # The basename of the AIP may be included with the request, because
+            # all AIPs contain a base directory. That directory may already be
+            # inside the full path though, so remove the basename only if the
+            # relative path begins with it.
             basename = os.path.join(os.path.basename(full_path), '')
-            relative_path_to_file = relative_path_to_file.split(basename, 1)[1]
+            if relative_path_to_file.startswith(basename):
+                relative_path_to_file = relative_path_to_file.replace(basename, '', 1)
             extracted_file_path = os.path.join(full_path, relative_path_to_file)
             if not os.path.exists(extracted_file_path):
                 return http.HttpResponse(status=404,


### PR DESCRIPTION
refs #7214

Uncompressed AIPs may not have the SIP name & UUID in the file path. Currently, view AIP files has the extra folder, but view backlog files does not. Update code to work whether or not the path is prepended with the SIP name & UUID by optionally stripping it.

This should also be merged into qa/0.x
