### PR TITLE
Restrict Location purposes based on Space's protocol

### DIFF
--- a/storage_service/locations/models/fedora.py
+++ b/storage_service/locations/models/fedora.py
@@ -9,6 +9,7 @@ from django.db import models
 from django_extensions.db.fields import UUIDField
 
 # This project, alphabetical
+from location import Location
 
 
 class Fedora(models.Model):
@@ -26,6 +27,10 @@ class Fedora(models.Model):
     class Meta:
         verbose_name = "FEDORA"
         app_label = 'locations'
+
+    ALLOWED_LOCATION_PURPOSE = [
+        Location.SWORD_DEPOSIT
+    ]
 
     def save(self, *args, **kwargs):
         self.verify()

--- a/storage_service/locations/models/local_filesystem.py
+++ b/storage_service/locations/models/local_filesystem.py
@@ -10,6 +10,7 @@ from django.db import models
 # This project, alphabetical
 
 # This module, alphabetical
+from location import Location
 
 
 class LocalFilesystem(models.Model):
@@ -19,6 +20,15 @@ class LocalFilesystem(models.Model):
     class Meta:
         verbose_name = "Local Filesystem"
         app_label = 'locations'
+
+    ALLOWED_LOCATION_PURPOSE = [
+        Location.AIP_STORAGE,
+        Location.DIP_STORAGE,
+        Location.CURRENTLY_PROCESSING,
+        Location.STORAGE_SERVICE_INTERNAL,
+        Location.TRANSFER_SOURCE,
+        Location.BACKLOG,
+    ]
 
     def move_to_storage_service(self, src_path, dest_path, dest_space):
         """ Moves src_path to dest_space.staging_path/dest_path. """

--- a/storage_service/locations/models/lockssomatic.py
+++ b/storage_service/locations/models/lockssomatic.py
@@ -18,6 +18,7 @@ import sword2
 from common import utils
 
 # This module, alphabetical
+from location import Location
 from package import Package
 
 
@@ -44,6 +45,10 @@ class Lockssomatic(models.Model):
     class Meta:
         verbose_name = 'LOCKSS-o-matic'
         app_label = 'locations'
+
+    ALLOWED_LOCATION_PURPOSE = [
+        Location.AIP_STORAGE,
+    ]
 
     # Uses the SWORD protocol to talk to LOM
     sword_connection = None

--- a/storage_service/locations/models/nfs.py
+++ b/storage_service/locations/models/nfs.py
@@ -10,6 +10,7 @@ from django.db import models
 # This project, alphabetical
 
 # This module, alphabetical
+from location import Location
 
 
 class NFS(models.Model):
@@ -30,6 +31,15 @@ class NFS(models.Model):
     class Meta:
         verbose_name = "Network File System (NFS)"
         app_label = 'locations'
+
+    ALLOWED_LOCATION_PURPOSE = [
+        Location.AIP_STORAGE,
+        Location.DIP_STORAGE,
+        Location.CURRENTLY_PROCESSING,
+        Location.STORAGE_SERVICE_INTERNAL,
+        Location.TRANSFER_SOURCE,
+        Location.BACKLOG,
+    ]
 
     def move_to_storage_service(self, src_path, dest_path, dest_space):
         """ Moves src_path to dest_space.staging_path/dest_path. """

--- a/storage_service/locations/models/pipeline_local.py
+++ b/storage_service/locations/models/pipeline_local.py
@@ -11,6 +11,7 @@ from django.db import models
 # This project, alphabetical
 
 # This module, alphabetical
+from location import Location
 
 
 class PipelineLocalFS(models.Model):
@@ -28,6 +29,14 @@ class PipelineLocalFS(models.Model):
     class Meta:
         verbose_name = "Pipeline Local FS"
         app_label = 'locations'
+
+    ALLOWED_LOCATION_PURPOSE = [
+        Location.AIP_STORAGE,
+        Location.DIP_STORAGE,
+        Location.CURRENTLY_PROCESSING,
+        Location.TRANSFER_SOURCE,
+        Location.BACKLOG,
+    ]
 
     def browse(self, path):
         user = self.remote_user

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -50,6 +50,15 @@ def validate_space_path(path):
 #         verbose_name = "Example Space"
 #         app_label = 'locations'
 #
+#     ALLOWED_LOCATION_PURPOSE = [
+#         Location.AIP_STORAGE,
+#         Location.DIP_STORAGE,
+#         Location.CURRENTLY_PROCESSING,
+#         Location.STORAGE_SERVICE_INTERNAL,
+#         Location.TRANSFER_SOURCE,
+#         Location.BACKLOG,
+#     ]
+#
 #     def browse(self, path):
 #         pass
 #

--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -118,7 +118,7 @@ def location_edit(request, space_uuid, location_uuid=None):
     else:
         action = "Create"
         location = None
-    form = forms.LocationForm(request.POST or None, instance=location)
+    form = forms.LocationForm(request.POST or None, space_protocol=space.access_protocol, instance=location)
     if form.is_valid():
         location = form.save(commit=False)
         location.space = space


### PR DESCRIPTION
Not all Spaces support all purposes. Add the ability to restrict what purpose a Location can be based on the Space's protocol.

This requires #28 
