### PR TITLE
Default Locations: Add exception handling

### DIFF
--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -34,6 +34,7 @@ urlpatterns = patterns('',
 
 
 def startup():
+    import django.core.exceptions
     import errno
     import os.path
     from locations import models as locations_models
@@ -41,72 +42,87 @@ def startup():
     import logging
     logger = logging.getLogger(__name__)
     logging.basicConfig(level=logging.INFO)
-    logging.info("Running startup")
-    space, space_created = locations_models.Space.objects.get_or_create(
-        access_protocol=locations_models.Space.LOCAL_FILESYSTEM,
-        path=os.sep, defaults={
-            "staging_path": os.path.join(os.sep, 'var', 'archivematica', 'storage_service')
-        })
-    if space_created:
-        local_fs = locations_models.LocalFilesystem(space=space)
-        local_fs.save()
-    transfer_source, _ = locations_models.Location.objects.get_or_create(
-        purpose=locations_models.Location.TRANSFER_SOURCE,
-        space=space,
-        relative_path='home')
-    aip_storage, _ = locations_models.Location.objects.get_or_create(
-        purpose=locations_models.Location.AIP_STORAGE,
-        space=space,
-        relative_path=os.path.join('var', 'archivematica', 'sharedDirectory', 'www', 'AIPsStore'),
-        description='Store AIP in standard Archivematica Directory')
-    dip_storage, _ = locations_models.Location.objects.get_or_create(
-        purpose=locations_models.Location.DIP_STORAGE,
-        space=space,
-        relative_path=os.path.join('var', 'archivematica', 'sharedDirectory', 'www', 'DIPsStore'),
-        description='Store DIP in standard Archivematica Directory')
-    backlog, _ = locations_models.Location.objects.get_or_create(
-        purpose=locations_models.Location.BACKLOG,
-        space=space,
-        relative_path=os.path.join('var', 'archivematica', 'sharedDirectory', 'www', 'AIPsStore', 'transferBacklog'),
-        description='Default transfer backlog')
-    internal_use, internal_use_created = locations_models.Location.objects.get_or_create(
-        purpose=locations_models.Location.STORAGE_SERVICE_INTERNAL,
-        defaults={
-            'space': space,
+    logger.info("Running startup")
+    try:
+        space, space_created = locations_models.Space.objects.get_or_create(
+            access_protocol=locations_models.Space.LOCAL_FILESYSTEM,
+            path=os.sep, defaults={
+                "staging_path": os.path.join(os.sep, 'var', 'archivematica', 'storage_service')
+            })
+        if space_created:
+            locations_models.LocalFilesystem.objects.create(space=space)
+            logger.info('Created default Space %s', space)
+    except django.core.exceptions.MultipleObjectsReturned:
+        logger.info('Multiple default Spaces exist, done default setup.')
+        return
+
+    default_locations = [
+        {
+            'purpose': locations_models.Location.TRANSFER_SOURCE,
+            'relative_path': 'home',
+            'description': '',
+            'default_setting': 'default_transfer_source',
+        },
+        {
+            'purpose': locations_models.Location.AIP_STORAGE,
+            'relative_path': os.path.join('var', 'archivematica', 'sharedDirectory', 'www', 'AIPsStore'),
+            'description': 'Store AIP in standard Archivematica Directory',
+            'default_setting': 'default_aip_storage',
+        },
+        {
+            'purpose': locations_models.Location.DIP_STORAGE,
+            'relative_path': os.path.join('var', 'archivematica', 'sharedDirectory', 'www', 'DIPsStore'),
+            'description': 'Store DIP in standard Archivematica Directory',
+            'default_setting': 'default_dip_storage',
+        },
+        {
+            'purpose': locations_models.Location.BACKLOG,
+            'relative_path': os.path.join('var', 'archivematica', 'sharedDirectory', 'www', 'AIPsStore', 'transferBacklog'),
+            'description': 'Default transfer backlog',
+            'default_setting': 'default_backlog',
+        },
+        {
+            'purpose': locations_models.Location.STORAGE_SERVICE_INTERNAL,
             'relative_path': os.path.join('var', 'archivematica', 'storage_service'),
-            'description': 'For storage service internal usage.'
-        }
-    )
-    if internal_use_created:
-        try:
-            os.mkdir(internal_use.full_path)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                logging.error("Internal storage location {} not accessible.".format(internal_use.full_path()))
-    recovery, recovery_created = locations_models.Location.objects.get_or_create(
-        purpose=locations_models.Location.AIP_RECOVERY,
-        defaults={
-            'space': space,
+            'description': 'For storage service internal usage.',
+            'default_setting': None,
+            'create_dirs': True,
+        },
+        {
+            'purpose': locations_models.Location.AIP_RECOVERY,
             'relative_path': os.path.join('var', 'archivematica', 'storage_service', 'recover'),
-            'description': 'Default AIP recovery'
-        }
-    )
-    if recovery_created:
+            'description': 'Default AIP recovery',
+            'default_setting': 'default_recovery',
+            'create_dirs': True,
+        },
+    ]
+
+    for loc_info in default_locations:
         try:
-            os.mkdir(recovery.full_path)
-            os.mkdir(os.path.join(recovery.full_path, 'backup'))
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                logging.error("Recovery location {} not accessible.".format(recovery.full_path))
-    if not utils.get_setting('default_transfer_source'):
-        utils.set_setting('default_transfer_source', [transfer_source.uuid])
-    if not utils.get_setting('default_aip_storage'):
-        utils.set_setting('default_aip_storage', [aip_storage.uuid])
-    if not utils.get_setting('default_dip_storage'):
-        utils.set_setting('default_dip_storage', [dip_storage.uuid])
-    if not utils.get_setting('default_backlog'):
-        utils.set_setting('default_backlog', [backlog.uuid])
-    if not utils.get_setting('default_recovery'):
-        utils.set_setting('default_recovery', [recovery.uuid])
+            new_loc, created = locations_models.Location.objects.get_or_create(
+                purpose=loc_info['purpose'],
+                space=space,
+                relative_path=loc_info['relative_path'],
+                description=loc_info['description'])
+            if created:
+                logger.info('Created default %s Location %s', loc_info['purpose'], new_loc)
+        except locations_models.Location.MultipleObjectsReturned:
+            continue
+
+        if created and loc_info.get('create_dirs'):
+            logger.info('Creating %s Location %s', loc_info['purpose'], new_loc)
+            try:
+                os.mkdir(new_loc.full_path)
+                # Hack for extra recovery dir
+                if loc_info['purpose'] == locations_models.Location.AIP_RECOVERY:
+                    os.mkdir(os.path.join(new_loc.full_path, 'backup'))
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    logger.error("%s location %s not accessible.", loc_info['purpose'], new_loc.full_path)
+
+        if loc_info['default_setting'] and utils.get_setting(loc_info['default_setting']) is None:
+            utils.set_setting(loc_info['default_setting'], [new_loc.uuid])
+            logger.info('Set %s as %s', new_loc, loc_info['default_setting'])
+
 
 startup()


### PR DESCRIPTION
Add try-except blocks around Space and Location creation so that defaults creation does not block interacting with the storage service if there are problems.  Restructure Location creation to reduce boilerplate.

refs #7416
