### PR TITLE
Duracloud: Percent encode file paths when fetching

### DIFF
--- a/storage_service/locations/fixtures/vcr_cassettes/duracloud_delete_percent_encoding.yaml
+++ b/storage_service/locations/fixtures/vcr_cassettes/duracloud_delete_percent_encoding.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-54-generic]
+    method: GET
+    uri: https://archivematica.duracloud.org:443/durastore/testing/delete/delete%20%23.txt
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAytJLS5RSMvMSeUCAN6QRt4KAAAA
+    headers:
+      access-control-allow-methods: ['GET, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['30']
+      content-type: [application/octet-stream]
+      date: ['Tue, 02 Dec 2014 23:35:47 GMT']
+      etag: [b05403212c66bdc8ccc597fedf6cd5fe]
+      keep-alive: ['timeout=5, max=100']
+      last-modified: ['2014-12-02T23:37:49']
+      set-cookie: [JSESSIONID=AC02B5EDAC521C0DC85F645E26C2A4C0; Path=/durastore/;
+          Secure; HttpOnly]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-54-generic]
+    method: DELETE
+    uri: https://archivematica.duracloud.org:443/durastore/testing/delete/delete%20%23.txt
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3LOzytJzStRSEnNSS1J1YdQCsp6JRUwsRSF4tLk5NTi4rTSnJxKAAAAAP//AwC2
+        C6gVMAAAAA==
+    headers:
+      access-control-allow-methods: ['GET, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-type: [text/plain]
+      date: ['Tue, 02 Dec 2014 23:35:47 GMT']
+      keep-alive: ['timeout=5, max=100']
+      set-cookie: [JSESSIONID=A452FD4A44BE2159DA2F6DE5FECC6E08; Path=/durastore/;
+          Secure; HttpOnly]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-54-generic]
+    method: GET
+    uri: https://archivematica.duracloud.org:443/durastore/testing/delete/delete%20%23.txt
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2yQsU7EMBBEf2UkijQogBKhU7pwSSQKKEhBbeK9YC5nB3t9F+XrWROEKKhWmh2/
+        mXXrvfNQzHSa2dgR7DASY/ZuJs+GAg5iGJxlsoxM00RMN9vAVc4LZzAWGVNI7zPoSAKpsHdx0rCO
+        cTBW/xKMJOFi+B2PDf6hJVhf4C0OR6mhjkZ92HJd58viFqfP7FX+E5UnH6X+FXpWHINkaqpQ3pbX
+        qF979OTPZhClPqnVJe6mv9BnFIY0qLC7L3Z3Rdd0+6ZrHup2c7Tf37LhbJymv+oThaBGWTzLbZ2L
+        Vn8BAAD//wMAQPHE9UUBAAA=
+    headers:
+      access-control-allow-methods: ['GET, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-type: [text/plain]
+      date: ['Tue, 02 Dec 2014 23:35:48 GMT']
+      keep-alive: ['timeout=5, max=100']
+      set-cookie: [JSESSIONID=76A40A5E1C407CD2EF89C7A319604CA7; Path=/durastore/;
+          Secure; HttpOnly]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 404, message: Not Found}
+version: 1

--- a/storage_service/locations/fixtures/vcr_cassettes/duracloud_move_from_ss_percent_encoding.yaml
+++ b/storage_service/locations/fixtures/vcr_cassettes/duracloud_move_from_ss_percent_encoding.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: !!python/object:__builtin__.file {}
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['15']
+      User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-54-generic]
+    method: PUT
+    uri: https://archivematica.duracloud.org:443/durastore/testing/test/bad%20%23name.txt
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      access-control-allow-methods: ['GET, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['20']
+      content-type: [text/plain]
+      date: ['Tue, 02 Dec 2014 23:33:24 GMT']
+      etag: [d8f459e8df78555b9dccd782a3ae01fe]
+      keep-alive: ['timeout=5, max=100']
+      location: ['https://archivematica.duracloud.org/durastore/testing/test/bad%20%23name.txt']
+      set-cookie: [JSESSIONID=5A1774E1E58FFD005FEF7928A5702B17; Path=/durastore/;
+          Secure; HttpOnly]
+      vary: [Accept-Encoding]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-54-generic]
+    method: GET
+    uri: https://archivematica.duracloud.org:443/durastore/testing/test/bad%20%23name.txt
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0tKTFFQzkvMTVVIy8xJ5QIAyheIHQ8AAAA=
+    headers:
+      access-control-allow-methods: ['GET, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['35']
+      content-type: [application/octet-stream]
+      date: ['Tue, 02 Dec 2014 23:33:24 GMT']
+      etag: [d8f459e8df78555b9dccd782a3ae01fe]
+      keep-alive: ['timeout=5, max=100']
+      last-modified: ['2014-12-02T23:35:54']
+      set-cookie: [JSESSIONID=4978F5AE66962D733FA20259576ACD7B; Path=/durastore/;
+          Secure; HttpOnly]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-54-generic]
+    method: DELETE
+    uri: https://archivematica.duracloud.org:443/durastore/testing/test/bad%20%23name.txt
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3LOzytJzStRKEktLtFPSkxRUM5LzE3VK6koUUhJzUktSU1RKC5NTk4tLk4rzcmp
+        BAAAAP//AwAoSD4KLwAAAA==
+    headers:
+      access-control-allow-methods: ['GET, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-type: [text/plain]
+      date: ['Tue, 02 Dec 2014 23:33:24 GMT']
+      keep-alive: ['timeout=5, max=100']
+      set-cookie: [JSESSIONID=F2DB8591360E79DA373EEB0678F3A7A0; Path=/durastore/;
+          Secure; HttpOnly]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+version: 1

--- a/storage_service/locations/fixtures/vcr_cassettes/duracloud_move_to_ss_percent_encoding.yaml
+++ b/storage_service/locations/fixtures/vcr_cassettes/duracloud_move_to_ss_percent_encoding.yaml
@@ -1,0 +1,30 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-54-generic]
+    method: GET
+    uri: https://archivematica.duracloud.org:443/durastore/testing/test/bad%20%23name/bad%20%23name.txt
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAytJLS5RSMvMSeUCAN6QRt4KAAAA
+    headers:
+      access-control-allow-methods: ['GET, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['30']
+      content-type: [application/octet-stream]
+      date: ['Tue, 02 Dec 2014 23:33:25 GMT']
+      etag: [b05403212c66bdc8ccc597fedf6cd5fe]
+      keep-alive: ['timeout=5, max=100']
+      last-modified: ['2014-12-02T23:25:03']
+      set-cookie: [JSESSIONID=1AF49D044E9F784E2265DCB39F7ED6B4; Path=/durastore/;
+          Secure; HttpOnly]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+version: 1


### PR DESCRIPTION
Duracloud was truncating the file paths at the #, causing gets of those files to fail.  Encode all paths that go to Duracloud.  Add tests.

Should probably be committed to qa/0.5.1 as well

refs #7643
