### PR TITLE
improve installer script

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -33,7 +33,9 @@ echo "configuring django database and static files"
 
 
 echo "updating directory permissions"
-chown -R archivematica:archivematica /var/archivematica/
+chown -R archivematica:archivematica /var/archivematica/storage-service
+chown -R archivematica:archivematica /var/archivematica/storage_service
+chown -R archivematica:archivematica /var/archivematica/.storage-service
 chown -R archivematica:archivematica /usr/share/python/archivematica-storage-service
 
 rm -f /tmp/storage_service.log


### PR DESCRIPTION
refs #7312

Do not change permissions on files that are not created by the
storage service.

Previously, the installer chown'ed the entire /var/archivematica directory.  Some users have put their own files or symlinks to other filesystems in /var/archivematica, so this change limits the scope of what is chown'ed.
