### PR TITLE
increase default timeout values

### DIFF
--- a/install/storage
+++ b/install/storage
@@ -18,6 +18,8 @@ server {
 
     location / {
         uwsgi_pass storage;
+        uwsgi_read_timeout 3600;
+        uwsgi_send_timeout 3600;
         include /etc/nginx/uwsgi_params;
     }
 


### PR DESCRIPTION
refs #7311

The storage service uses nginx by default as a web server. The default
timeout values are 60 seconds in nginx.  This change increases
those timeout values to 1 hour.  This allows Archivematica to POST
large files (e.g. large AIP's) to the Storage Service.
