### PR TITLE
Duracloud: set chunk size to 1GB

### DIFF
--- a/storage_service/locations/models/duracloud.py
+++ b/storage_service/locations/models/duracloud.py
@@ -43,7 +43,7 @@ class Duracloud(models.Model):
     ]
 
     MANIFEST_SUFFIX = '.dura-manifest'
-    CHUNK_SIZE = 5 * 1024 * 1024 * 1024  # 5 GB
+    CHUNK_SIZE = 1 * 1024 * 1024 * 1024  # 1 GB
 
     def __init__(self, *args, **kwargs):
         super(Duracloud, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Workaround for a bug in the DuraCloud REST API that kicks in when the size
of the file being transferred is larger than 2^31 bytes (2.14 GB).
After the bug is fixed, it should be OK to restore to 5GB.
