### PR TITLE
Improve default location creation

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -325,7 +325,7 @@ class LocationResource(ModelResource):
 
         # Get the object for this endpoint
         try:
-            destination_location = Location.objects.get(uuid=kwargs['uuid'])
+            destination_location = Location.active.get(uuid=kwargs['uuid'])
         except Location.DoesNotExist:
             return http.HttpNotFound()
 
@@ -341,7 +341,7 @@ class LocationResource(ModelResource):
             # splitting origin_uri on / results in:
             # ['', 'api', 'v1', '<resource_name>', '<uuid>', '']
             origin_uuid = origin_uri.split('/')[4]
-            origin_location = Location.objects.get(uuid=origin_uuid)
+            origin_location = Location.active.get(uuid=origin_uuid)
         except (IndexError, Location.DoesNotExist):
             return http.HttpNotFound("The URL provided '%s' was not a link to a valid Location." % origin_uri)
 

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -201,7 +201,7 @@ class Package(models.Model):
         if local_path:
             return local_path
         # Not locally accessible, so copy to SS internal temp dir
-        ss_internal = Location.objects.get(purpose=Location.STORAGE_SERVICE_INTERNAL)
+        ss_internal = Location.active.get(purpose=Location.STORAGE_SERVICE_INTERNAL)
         temp_dir = tempfile.mkdtemp(dir=ss_internal.full_path)
         int_path = os.path.join(temp_dir, self.current_path)
         self.current_location.space.move_to_storage_service(
@@ -460,7 +460,7 @@ class Package(models.Model):
         deleted.
         """
         if extract_path is None:
-            ss_internal = Location.objects.get(purpose=Location.STORAGE_SERVICE_INTERNAL)
+            ss_internal = Location.active.get(purpose=Location.STORAGE_SERVICE_INTERNAL)
             extract_path = tempfile.mkdtemp(dir=ss_internal.full_path)
         full_path = self.fetch_local_path()
 
@@ -507,7 +507,7 @@ class Package(models.Model):
         """
 
         if extract_path is None:
-            ss_internal = Location.objects.get(purpose=Location.STORAGE_SERVICE_INTERNAL)
+            ss_internal = Location.active.get(purpose=Location.STORAGE_SERVICE_INTERNAL)
             extract_path = tempfile.mkdtemp(dir=ss_internal.full_path)
         if algorithm not in self.COMPRESSION_ALGORITHMS:
             raise ValueError('Algorithm %s not in %s' % algorithm, self.COMPRESSION_ALGORITHMS)

--- a/storage_service/locations/models/pipeline.py
+++ b/storage_service/locations/models/pipeline.py
@@ -83,10 +83,12 @@ class Pipeline(models.Model):
             local_fs = LocalFilesystem(space=space)
             local_fs.save()
             LOGGER.info("Protocol Space created: %s", local_fs)
-        currently_processing, _ = Location.objects.get_or_create(
+        currently_processing, _ = Location.active.get_or_create(
             purpose=Location.CURRENTLY_PROCESSING,
-            space=space,
-            relative_path=shared_path)
+            defaults={
+                'space': space,
+                'relative_path': shared_path
+            })
         LocationPipeline.objects.get_or_create(
             pipeline=self, location=currently_processing)
         LOGGER.info("Currently processing: %s", currently_processing)

--- a/storage_service/locations/tests/test_api.py
+++ b/storage_service/locations/tests/test_api.py
@@ -1,0 +1,62 @@
+
+import json
+
+from django.test import TestCase
+from django.test.client import Client
+
+from locations import models
+
+class TestAPI(TestCase):
+
+    fixtures = ['base.json', 'pipelines.json']
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_cant_move_from_non_existant_locations(self):
+        data = {
+            'origin_location': '/api/v2/location/dne1aacf-8492-4382-8ef3-262cc5420dne/',
+            'files': [{'source': 'foo', 'destination': 'bar'}],
+            'pipeline': '/api/v2/pipeline/b25f6b71-3ebf-4fcc-823c-1feb0a2553dd/',
+        }
+        response = self.client.post('/api/v2/location/213086c8-232e-4b9e-bb03-98fbc7a7966a/', data=json.dumps(data), content_type='application/json')
+        # Verify error
+        assert response.status_code == 404
+        assert 'not a link to a valid Location' in response.content
+
+    def test_cant_move_to_non_existant_locations(self):
+        data = {
+            'origin_location': '/api/v2/location/6e61aacf-8492-4382-8ef3-262cc5420259/',
+            'files': [{'source': 'foo', 'destination': 'bar'}],
+            'pipeline': '/api/v2/pipeline/b25f6b71-3ebf-4fcc-823c-1feb0a2553dd/',
+        }
+        response = self.client.post('/api/v2/location/dne086c8-232e-4b9e-bb03-98fbc7a7966a/', data=json.dumps(data), content_type='application/json')
+        # Verify error
+        assert response.status_code == 404
+
+    def test_cant_move_from_disabled_locations(self):
+        # Set origin location disabled
+        models.Location.objects.filter(uuid='6e61aacf-8492-4382-8ef3-262cc5420259').update(enabled=False)
+        # Send request
+        data = {
+            'origin_location': '/api/v2/location/6e61aacf-8492-4382-8ef3-262cc5420259/',
+            'files': [{'source': 'foo', 'destination': 'bar'}],
+            'pipeline': '/api/v2/pipeline/b25f6b71-3ebf-4fcc-823c-1feb0a2553dd/',
+        }
+        response = self.client.post('/api/v2/location/213086c8-232e-4b9e-bb03-98fbc7a7966a/', data=json.dumps(data), content_type='application/json')
+        # Verify error
+        assert response.status_code == 404
+        assert 'not a link to a valid Location' in response.content
+
+    def test_cant_move_to_disabled_locations(self):
+        # Set posting to location disabled
+        models.Location.objects.filter(uuid='213086c8-232e-4b9e-bb03-98fbc7a7966a').update(enabled=False)
+        # Send request
+        data = {
+            'origin_location': '/api/v2/location/6e61aacf-8492-4382-8ef3-262cc5420259/',
+            'files': [{'source': 'foo', 'destination': 'bar'}],
+            'pipeline': '/api/v2/pipeline/b25f6b71-3ebf-4fcc-823c-1feb0a2553dd/',
+        }
+        response = self.client.post('/api/v2/location/213086c8-232e-4b9e-bb03-98fbc7a7966a/', data=json.dumps(data), content_type='application/json')
+        # Verify error
+        assert response.status_code == 404

--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -449,7 +449,7 @@ def callback_detail(request, uuid):
     try:
         callback = Callback.objects.get(uuid=uuid)
     except Callback.DoesNotExist:
-        messages.warning(request, "Callback {} does not exist.".format(location_uuid))
+        messages.warning(request, "Callback {} does not exist.".format(uuid))
         return redirect('callback_list')
     return render(request, 'locations/callback_detail.html', locals())
 

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -291,6 +291,11 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': True,
         },
+        'django.request.tastypie': {
+            'handlers': ['logfile', 'verboselogfile'],
+            'propagate': True,
+            'level': 'ERROR',
+        },
         'administration': {
             'handlers': ['logfile', 'verboselogfile'],
             'level': 'DEBUG',

--- a/storage_service/storage_service/tests/test_startup.py
+++ b/storage_service/storage_service/tests/test_startup.py
@@ -1,0 +1,68 @@
+
+from django.test import TestCase
+
+from locations import models
+
+from urls import startup
+
+class TestStartup(TestCase):
+    """
+    Test startup code that creates default Space & Locations.
+    """
+
+    def test_create_default_locations(self):
+        # Assert no Space or Location exists
+        assert not models.Space.objects.all().exists()
+        assert not models.Location.objects.all().exists()
+        # Run test
+        startup()
+        # Assert Space & Locations created
+        assert models.Space.objects.get(access_protocol='FS')
+        assert models.Location.objects.get(purpose='TS')
+        assert models.Location.objects.get(purpose='AS')
+        assert models.Location.objects.get(purpose='DS')
+        assert models.Location.objects.get(purpose='BL')
+        assert models.Location.objects.get(purpose='SS')
+        assert models.Location.objects.get(purpose='AR')
+        # Assert no other Spaces or Locations were created
+        assert len(models.Space.objects.all()) == 1
+        assert len(models.Location.objects.all()) == 6
+
+    def test_handle_multiple_identical_spaces(self):
+        # Create Spaces with the same path
+        models.Space.objects.create(path='/', access_protocol='FS')
+        models.Space.objects.create(path='/', access_protocol='FS')
+        assert len(models.Space.objects.filter(access_protocol='FS')) == 2
+        # Run test
+        startup()
+        # Verify no locations exist - space errored gracefully
+        assert len(models.Space.objects.filter(access_protocol='FS')) == 2
+        assert not models.Location.objects.all().exists()
+
+    def test_handle_multiple_identical_locations(self):
+        # Create existing Location
+        s = models.Space.objects.create(path='/', access_protocol='FS')
+        models.Location.objects.create(space=s, purpose='SS', relative_path='var/archivematica/storage_service', description='For storage service internal usage.')
+        models.Location.objects.create(space=s, purpose='SS', relative_path='var/archivematica/storage_service', description='For storage service internal usage.',)
+        assert len(models.Space.objects.filter(access_protocol='FS')) == 1
+        assert len(models.Location.objects.filter(purpose='SS')) == 2
+        # Run test
+        startup()
+        # Verify no new Location was created
+        assert len(models.Space.objects.filter(access_protocol='FS')) == 1
+        assert len(models.Location.objects.filter(purpose='SS')) == 2
+
+    def test_dont_create_if_same_purpose_already_exist(self):
+        # Create existing Locations
+        s = models.Space.objects.create(path='/', access_protocol='FS')
+        models.Location.objects.create(space=s, purpose='TS', relative_path='mnt/transfers')
+        models.Location.objects.create(space=s, purpose='AS', relative_path='mnt/aips')
+        models.Location.objects.create(space=s, purpose='DS', relative_path='mnt/dips')
+        models.Location.objects.create(space=s, purpose='BL', relative_path='mnt/backlog')
+        models.Location.objects.create(space=s, purpose='SS', relative_path='mnt/storage_service')
+        models.Location.objects.create(space=s, purpose='AR', relative_path='mnt/aips/recovery')
+        assert len(models.Location.objects.all()) == 6
+        # Run test
+        startup()
+        # Verify no new Locations created
+        assert len(models.Location.objects.all()) == 6

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -98,7 +98,7 @@ def startup():
 
     for loc_info in default_locations:
         try:
-            new_loc, created = locations_models.Location.objects.get_or_create(
+            new_loc, created = locations_models.Location.active.get_or_create(
                 purpose=loc_info['purpose'],
                 defaults={
                     'space': space,

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -100,9 +100,11 @@ def startup():
         try:
             new_loc, created = locations_models.Location.objects.get_or_create(
                 purpose=loc_info['purpose'],
-                space=space,
-                relative_path=loc_info['relative_path'],
-                description=loc_info['description'])
+                defaults={
+                    'space': space,
+                    'relative_path': loc_info['relative_path'],
+                    'description': loc_info['description']
+                })
             if created:
                 LOGGER.info('Created default %s Location %s', loc_info['purpose'], new_loc)
         except locations_models.Location.MultipleObjectsReturned:


### PR DESCRIPTION
Previously, when creating default locations, we checked if a Location with the exact same attributes (path, description, etc) already existed, and created one if it didn't.  This causes problems when a Location with that purpose already exists but has been modified, eg storage service internal, since there can only be one.  Update to only look for a Location with the same purpose.

To support disabling Locations instead of deleting them, ensure queries against Location use 'active' not 'objects'.

Add tests.
