### PR TITLE
Preserve original file timestamps

### DIFF
--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -318,7 +318,7 @@ class Space(models.Model):
 
         # Rsync file over
         # TODO Do this asyncronously, with restarting failed attempts
-        command = ['rsync', '-vv', '--chmod=ugo+rw', '-r', source, destination]
+        command = ['rsync', '-a', '-vv', '--chmod=ugo+rw', '-r', source, destination]
         LOGGER.info("rsync command: %s", command)
 
         p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
Tested this change just now, files in a transfer source location keep their original timestamps when they are copied to the processing location to start a transfer, and are maintained all the way through to the METS file in the final aip.
