### PR TITLE
Tests: Setup default testing config in pytest.ini

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -7,4 +7,5 @@ Sphinx==1.2b1
 ipython==1.1.0
 pytest
 pytest-django
+pytest-pythonpath
 vcrpy>=1.0.0

--- a/storage_service/pytest.ini
+++ b/storage_service/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+django_find_project=false
+python_paths=/usr/lib/archivematica/storage-service/
+DJANGO_SETTINGS_MODULE=storage_service.settings.local


### PR DESCRIPTION
Add Django settings and a useful PYTHONPATH to the pytest.ini file.

Unlike Archivematica, the Storage Service doesn't create symlinks to itself in a fixed location.  I set the python_path to /usr/lib/archivematica/storage-service/ which is where the debian package installs it, and ran `ln -s /path/to/archivematica-storage-service/storage_service storage-service` from `/usr/lib/archivematica/`  Please test this and tell me if it actually makes running tests easier.
