### PR TITLE
Post-move fixes

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -370,7 +370,8 @@ class LocationResource(ModelResource):
                     source_path=destination_path,
                     destination_path=destination_path,
                 )
-                destination_space.post_move_from_storage_service()
+                destination_space.post_move_from_storage_service(
+                    destination_path, destination_path)
 
             else:
                 return http.HttpBadRequest

--- a/storage_service/locations/models/nfs.py
+++ b/storage_service/locations/models/nfs.py
@@ -57,10 +57,6 @@ class NFS(models.Model):
         self.space._create_local_directory(destination_path)
         return self.space._move_rsync(source_path, destination_path)
 
-    def post_move_from_storage_service(self, staging_path, destination_path, package):
-        # TODO Remove the staging file, since rsync leaves it behind
-        pass
-
     def save(self, *args, **kwargs):
         self.verify()
         super(NFS, self).save(*args, **kwargs)

--- a/storage_service/locations/models/pipeline_local.py
+++ b/storage_service/locations/models/pipeline_local.py
@@ -128,7 +128,3 @@ class PipelineLocalFS(models.Model):
 
         # Move file
         return self.space._move_rsync(source_path, destination_path)
-
-    def post_move_from_storage_service(self, staging_path, destination_path, package):
-        # TODO Remove the staging file, since rsync leaves it behind
-        pass

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -266,21 +266,6 @@ class Space(models.Model):
                 source_path, destination_path, *args, **kwargs)
         except AttributeError:
             raise NotImplementedError('{} space has not implemented move_from_storage_service'.format(self.get_access_protocol_display()))
-        # Delete staging copy
-        if source_path != destination_path:
-            try:
-                if os.path.isdir(source_path):
-                    # Need to convert this to an str - if this is a
-                    # unicode string, rmtree will use os.path.join
-                    # on the directory and the names of its children,
-                    # which can result in an attempt to join mixed encodings;
-                    # this blows up if the filename cannot be converted to
-                    # unicode.
-                    shutil.rmtree(str(os.path.normpath(source_path)))
-                elif os.path.isfile(source_path):
-                    os.remove(os.path.normpath(source_path))
-            except OSError:
-                LOGGER.warning('Unable to remove %s', source_path, exc_info=True)
 
     def post_move_from_storage_service(self, staging_path, destination_path, package=None, *args, **kwargs):
         """
@@ -304,6 +289,22 @@ class Space(models.Model):
         except AttributeError:
             # This is optional for the child class to implement
             pass
+        # Delete staging copy
+        if staging_path != destination_path:
+            try:
+                if os.path.isdir(staging_path):
+                    # Need to convert this to an str - if this is a
+                    # unicode string, rmtree will use os.path.join
+                    # on the directory and the names of its children,
+                    # which can result in an attempt to join mixed encodings;
+                    # this blows up if the filename cannot be converted to
+                    # unicode
+                    shutil.rmtree(str(os.path.normpath(staging_path)))
+                elif os.path.isfile(staging_path):
+                    os.remove(os.path.normpath(staging_path))
+            except OSError:
+                logging.warning('Unable to remove %s', staging_path, exc_info=True)
+
 
     def update_package_status(self, package):
         """


### PR DESCRIPTION
These have been languishing in the Arkivum branch for a while and I'd like them in qa.
- post_move_from takes the source and destination path and does the same path munging that move_from does
- Staging copy is deleted after post_move_from
- Package staging vs uploaded set better.
