### PR TITLE
Replace -a flag in rsync to avoid CIFS errors ref. #8124

### DIFF
--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -321,7 +321,7 @@ class Space(models.Model):
 
         # Rsync file over
         # TODO Do this asyncronously, with restarting failed attempts
-        command = ['rsync', '-a', '--protect-args', '-vv', '--chmod=ugo+rw', '-r', source, destination]
+        command = ['rsync', '-t', '-O', '--protect-args', '-vv', '--chmod=ugo+rw', '-r', source, destination]
         LOGGER.info("rsync command: %s", command)
 
         p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
The purpose of using rsync with -a was to preserve file
timestamps when copying files from/to the storage service.
rsync -a attemps to preserve timestamps and permissions of copied
files and directories. However, on a CIFS mounted volume it
seems not possible to set timestamps and permissions of
copied directories, producing a non-zero return code.
Replace -a with -t and -O. -t will preserve modification
times. -O will avoid to preserve modification times in
copied directories.
