### PR TITLE
AIP re-ingest

### DIFF
--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -31,6 +31,8 @@ NSMAP = {
     'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
 }
 
+PREFIX_NS = {k: '{' + v + '}' for k, v in NSMAP.iteritems()}
+
 ############ SETTINGS ############
 
 def get_all_settings():

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -433,7 +433,7 @@ class PackageResource(ModelResource):
 
         fields = ['current_path', 'package_type', 'size', 'status', 'uuid']
         list_allowed_methods = ['get', 'post']
-        detail_allowed_methods = ['get']
+        detail_allowed_methods = ['get', 'patch']
         detail_uri_name = 'uuid'
         always_return_data = True
         filtering = {
@@ -477,6 +477,13 @@ class PackageResource(ModelResource):
         elif bundle.obj.package_type in (Package.TRANSFER) and bundle.obj.current_location.purpose in (Location.BACKLOG):
             # Move transfer to backlog
             bundle.obj.backlog_transfer(origin_location, origin_path)
+        return bundle
+
+    def hydrate(self, bundle):
+        # If reingest flag exists, this package is not being reingested anymore
+        if 'reingest' in bundle.data:
+            # Always assume this means reingest is done/terminated
+            bundle.obj.misc_attributes.update({'reingest_pipeline': None})
         return bundle
 
     @_custom_endpoint(expected_methods=['post'],

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -208,3 +208,12 @@ class CallbackForm(forms.ModelForm):
     class Meta:
         model = models.Callback
         fields = ('uri', 'event', 'method', 'expected_status')
+
+
+class ReingestForm(forms.Form):
+    pipeline = forms.ModelChoiceField(queryset=models.Pipeline.active.all())
+    REINGEST_CHOICES = (
+        (models.Package.METADATA_ONLY, 'Re-ingest metadata only'),
+        (models.Package.OBJECTS, 'Re-ingest metadata and objects')
+    )
+    reingest_type = forms.ChoiceField(choices=REINGEST_CHOICES, widget=forms.RadioSelect)

--- a/storage_service/locations/models/lockssomatic.py
+++ b/storage_service/locations/models/lockssomatic.py
@@ -272,21 +272,12 @@ class Lockssomatic(models.Model):
         if not self.keep_local and delete_elements:
             amdsec = self.pointer_root.find('mets:amdSec', namespaces=utils.NSMAP)
             # Add 'deletion' PREMIS:EVENT
-            digiprov_id = 'digiprovMD_{}'.format(len(amdsec))
-            digiprov_split = utils.mets_add_event(
-                digiprov_id=digiprov_id,
+            utils.mets_add_event(
+                amdsec,
                 event_type='deletion',
                 event_outcome_detail_note='AIP deleted from local storage',
             )
-            LOGGER.info('PREMIS:EVENT division: %s', etree.tostring(digiprov_split, pretty_print=True))
-            amdsec.append(digiprov_split)
 
-            # Add PREMIS:AGENT for storage service
-            digiprov_id = 'digiprovMD_{}'.format(len(amdsec))
-            digiprov_agent = utils.mets_ss_agent(amdsec, digiprov_id)
-            if digiprov_agent is not None:
-                LOGGER.info('PREMIS:AGENT SS: %s', etree.tostring(digiprov_agent, pretty_print=True))
-                amdsec.append(digiprov_agent)
             # If file was split
             if self.pointer_root.find(".//mets:fileGrp[@USE='LOCKSS chunk']", namespaces=utils.NSMAP) is not None:
                 # Delete fileGrp USE="AIP"
@@ -386,22 +377,12 @@ class Lockssomatic(models.Model):
             event_detail = subprocess.check_output(['tar', '--version'])
         except subprocess.CalledProcessError as e:
             event_detail = e.output or 'Error: getting tool info; probably GNU tar'
-        digiprov_id = 'digiprovMD_{}'.format(len(amdsec))
-        digiprov_split = utils.mets_add_event(
-            digiprov_id=digiprov_id,
+        utils.mets_add_event(
+            amdsec,
             event_type='division',
             event_detail=event_detail,
             event_outcome_detail_note='{} LOCKSS chunks created'.format(len(output_files)),
         )
-        LOGGER.debug('PREMIS:EVENT division: %s', etree.tostring(digiprov_split, pretty_print=True))
-        amdsec.append(digiprov_split)
-
-        # Add PREMIS:AGENT for storage service
-        digiprov_id = 'digiprovMD_{}'.format(len(amdsec))
-        digiprov_agent = utils.mets_ss_agent(amdsec, digiprov_id)
-        if digiprov_agent is not None:
-            LOGGER.debug('PREMIS:AGENT SS: %s', etree.tostring(digiprov_agent, pretty_print=True))
-            amdsec.append(digiprov_agent)
 
         # Update structMap & fileSec
         self.pointer_root.find('mets:structMap', namespaces=utils.NSMAP).set('TYPE', 'logical')

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -94,7 +94,8 @@ class Package(models.Model):
 
     PACKAGE_TYPE_CAN_DELETE = (AIP, AIC, TRANSFER)
     PACKAGE_TYPE_CAN_EXTRACT = (AIP, AIC)
-    PACKAGE_TYPE_CAN_RECOVER = (AIP)
+    PACKAGE_TYPE_CAN_RECOVER = (AIP, AIC)
+    PACKAGE_TYPE_CAN_REINGEST = (AIP, AIC)
 
     # Compression options
     COMPRESSION_7Z_BZIP = '7z with bzip'
@@ -107,6 +108,11 @@ class Package(models.Model):
         COMPRESSION_TAR,
         COMPRESSION_TAR_BZIP2,
     )
+
+    # Reingest type options
+    METADATA_ONLY = 'metadata'
+    OBJECTS = 'objects'
+    REINGEST_CHOICES = (METADATA_ONLY, OBJECTS)
 
     class Meta:
         verbose_name = "Package"
@@ -819,6 +825,29 @@ class Package(models.Model):
         self.status = self.DELETED
         self.save()
         return True, error
+
+    # REINGEST
+
+    def start_reingest(self, pipeline, reingest_type):
+        """
+        Copies this package to `pipeline` for reingest.
+
+        Fetches the AIP from storage, extracts and runs fixity on it to verify integrity.
+        If reingest_type is METADATA_ONLY, sends the METS and all files in the metadata directory.
+        If reingest_type is OBJECTS, sends METS, all files in metadata directory and all objects, preservation and original.
+        Calls Archivematica endpoint /api/ingest/reingest/ to start reingest.
+
+        :param pipeline: Pipeline object to send reingested AIP to.
+        :param reingest_type: Type of reingest to start, one of REINGEST_CHOICES.
+        :return: Dict with keys 'error', 'status_code' and 'message'
+        """
+        if self.package_type not in Package.PACKAGE_TYPE_CAN_REINGEST:
+            return {'error': True, 'status_code': 405,
+            'message': 'Package with type {} cannot be re-ingested.'.format(self.get_package_type_display())}
+
+        # TODO Stub
+
+        return {'error': False, 'status_code': 202, 'message': 'Package {} sent to pipeline {} for re-ingest'.format(self.uuid, pipeline)}
 
     # SWORD-related methods
     def has_been_submitted_for_processing(self):

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -912,7 +912,7 @@ class Package(models.Model):
             )
 
         # Delete local copy of extraction
-        if self.local_path_location != self.current_location or self.local_path != self.full_path:
+        if self.local_path != self.full_path:
             shutil.rmtree(local_path)
         if temp_dir:
             shutil.rmtree(temp_dir)
@@ -1084,6 +1084,12 @@ class Package(models.Model):
             source_path=dest_path,  # This should include Location.path
             destination_path=os.path.join(reingest_location.relative_path, dest_path),
         )
+
+        # Delete old copy of AIP if different
+        if self.current_path != dest_path or self.current_location != reingest_location:
+            LOGGER.info('Old copy of reingested AIP is at a different location.  Deleting %s', self.full_path)
+            self.current_location.space.delete_path(self.full_path)
+
         self.current_location = reingest_location
         self.current_path = dest_path
 

--- a/storage_service/locations/urls.py
+++ b/storage_service/locations/urls.py
@@ -18,12 +18,14 @@ urlpatterns = patterns('locations.views',
     # Packages
     url(r'^packages/$', 'package_list',
         name='package_list'),
-    url(r'^packages/aip_delete_request$', 'aip_delete_request',
+    url(r'^packages/aip_delete_request/$', 'aip_delete_request',
         name='aip_delete_request'),
     url(r'^packages/(?P<uuid>'+UUID+')/update_status/$', 'package_update_status',
         name='package_update_status'),
     url(r'^packages/aip_recover_request$', 'aip_recover_request',
         name='aip_recover_request'),
+    url(r'^packages/(?P<package_uuid>' + UUID + ')/reingest/$', 'aip_reingest',
+        name='aip_reingest'),
 
     # Pipelines
     url(r'^pipelines/$', 'pipeline_list',

--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -46,6 +46,16 @@ def package_list(request):
     packages = Package.objects.all()
     return render(request, 'locations/package_list.html', locals())
 
+class AIPRequestHandlerConfig:
+    event_type = ''                # Event type being handled
+    approved_status = ''           # Event status, if approved
+    reject_message = ''            # Message returned if not approved
+    execution_success_message = '' # Message returned if execution success
+    execution_fail_message = ''    # Message returned if execution failed
+
+    def execution_logic(package):  # Logic performed on package if approved
+        pass
+
 def aip_recover_request(request):
     def execution_logic(aip): 
         recover_location = LocationPipeline.objects.get(
@@ -207,15 +217,27 @@ def package_update_status(request, uuid):
     next_url = request.GET.get('next', reverse('package_list'))
     return redirect(next_url)
 
-class AIPRequestHandlerConfig:
-    event_type = ''                # Event type being handled
-    approved_status = ''           # Event status, if approved
-    reject_message = ''            # Message returned if not approved
-    execution_success_message = '' # Message returned if execution success
-    execution_fail_message = ''    # Message returned if execution failed
-
-    def execution_logic(package):  # Logic performed on package if approved
-        pass
+def aip_reingest(request, package_uuid):
+    next_url = request.GET.get('next', reverse('package_list'))
+    try:
+        package = Package.objects.get(uuid=package_uuid)
+    except Package.DoesNotExist:
+        messages.warning(request, 'Package with UUID {} does not exist.'.format(package_uuid))
+        return redirect(next_url)
+    form = forms.ReingestForm(request.POST or None)
+    if form.is_valid():
+        pipeline = form.cleaned_data['pipeline']
+        reingest_type = form.cleaned_data['reingest_type']
+        response = package.start_reingest(pipeline, reingest_type)
+        error = response.get('error', True)
+        message = response.get('message', 'An unknown error occurred')
+        if not error:
+            if message:
+                messages.success(request, message)
+        else:
+            messages.warning(request, message)
+        return redirect(next_url)
+    return render(request, 'locations/package_reingest.html', locals())
 
 
 ########################## LOCATIONS ##########################

--- a/storage_service/static/css/project.css
+++ b/storage_service/static/css/project.css
@@ -35,6 +35,15 @@ div.sidebar {
     min-width: 120px;
 }
 
+form ul {
+  margin-left: 0px;
+}
+
+form li {
+  list-style-type: none;
+  padding-left: 0px;
+}
+
 .btn {
   margin: .15em;
 }

--- a/storage_service/templates/locations/package_reingest.html
+++ b/storage_service/templates/locations/package_reingest.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block page_title %}Reingest Package{% endblock %}
+
+{% block content %}
+
+<div class='form-control'>
+  <form action="{% url 'aip_reingest' package.uuid %}" method="post">
+    {% csrf_token %}
+    <p><label>Package: {{ package.uuid }}</label> </p>
+    {{ form }}
+    <a href="{{ cancel_url }}" class='btn'>Cancel</a> <input class='btn btn-primary' type="submit" value="Re-ingest Package" />
+  </form>
+</div>
+{% endblock %}

--- a/storage_service/templates/snippets/packages_table.html
+++ b/storage_service/templates/snippets/packages_table.html
@@ -42,6 +42,9 @@
         </td>
         <td>
           <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">Download</a>
+          {% if package.package_type in 'AIP AIC' %}
+            <a href="{% url 'aip_reingest' package.uuid %}?next={{ request.path }}">Re-ingest</a>
+          {% endif %}
         </td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
Add re-ingest functionality to the storage service
- Add re-ingest button to package page
- Add endpoint for Archivematica to start a re-ingest
- Extract and copy files to Archivematica to start re-ingest
- Accept a reingested package, updates/replaces METS & metadata files, and stores
- Known bug: Does not support uncompressed AIPs.  Does support .tar.bz2 & .zip

Companion to artefactual/archivematica#257
