### PR TITLE
Space: don't log exc_info when falling back to browse local

### DIFF
--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -187,7 +187,7 @@ class Space(models.Model):
         try:
             return self.get_child_space().browse(path, *args, **kwargs)
         except AttributeError:
-            LOGGER.debug('Falling back to default browse local', exc_info=True)
+            LOGGER.debug('Falling back to default browse local', exc_info=False)
             return self._browse_local(path)
 
     def delete_path(self, delete_path, *args, **kwargs):


### PR DESCRIPTION
The traceback isn't generally useful here, since the exception being caught is very specific already. The exception is also misleading; we've encountered a number of users having problems who believed that because an exception was printed here, it was the actual cause of their problems when it was actually unrelated.
