### PR TITLE
Dev/issue 8635 fixity logging

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -714,6 +714,10 @@ class PackageResource(ModelResource):
             signals.failed_fixity_check.send(sender=self,
                 uuid=bundle.obj.uuid, location=bundle.obj.full_path,
                 report=report)
+        else:
+            signals.successful_fixity_check.send(sender=self,
+                uuid=bundle.obj.uuid, location=bundle.obj.full_path,
+                report=report)
 
         return http.HttpResponse(
             report,

--- a/storage_service/locations/fixtures/fixity_log.json
+++ b/storage_service/locations/fixtures/fixity_log.json
@@ -1,0 +1,12 @@
+[
+{
+    "pk": 1, 
+    "model": "locations.fixitylog", 
+    "fields": {
+        "package": "e0a41934-c1d7-45ba-9a95-a7531c063ed1",
+        "success": true,
+        "error_details": "Checksum failed.",
+        "datetime_reported": "2015-12-15 03:00:05.020871"
+    }
+}
+]

--- a/storage_service/locations/migrations/0008_fixitylog.py
+++ b/storage_service/locations/migrations/0008_fixitylog.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locations', '0007_dataverse'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='FixityLog',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('success', models.BooleanField(default=False)),
+                ('error_details', models.TextField(null=True)),
+                ('datetime_reported', models.DateTimeField(auto_now=True)),
+                ('package', models.ForeignKey(to='locations.Package', to_field=b'uuid')),
+            ],
+            options={
+                'verbose_name': 'Fixity Log',
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/storage_service/locations/models/__init__.py
+++ b/storage_service/locations/models/__init__.py
@@ -16,6 +16,7 @@ from location import *
 from package import *
 from pipeline import *
 from space import *
+from fixity_log import *
 # not importing managers as that is internal
 
 # Protocol Spaces

--- a/storage_service/locations/models/fixity_log.py
+++ b/storage_service/locations/models/fixity_log.py
@@ -1,0 +1,27 @@
+# stdlib, alphabetical
+
+# Core Django, alphabetical
+from django.db import models
+
+# Third party dependencies, alphabetical
+
+# This project, alphabetical
+
+# This module, alphabetical
+
+
+class FixityLog(models.Model):
+    """ Stores fixity check success/failure and error details """
+
+    package = models.ForeignKey('Package', to_field='uuid')
+    success = models.BooleanField(default=False)
+    error_details = models.TextField(null=True)
+    datetime_reported = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "Fixity Log"
+        app_label = 'locations'
+
+    def __unicode__(self):
+        return u"Fixity check of {package}".format(
+            package=self.package)

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -27,6 +27,7 @@ from . import StorageException
 from location import Location
 from space import Space
 from event import File
+from fixity_log import FixityLog
 
 __all__ = ('Package', )
 
@@ -162,6 +163,22 @@ class Package(models.Model):
             else:
                 message = "{} is neither a file nor a directory".format(full_path)
             raise StorageException(message)
+
+    @property
+    def latest_fixity_check_datetime(self):
+        latest_check = self._latest_fixity_check()
+        return latest_check.datetime_reported if latest_check is not None else None
+
+    @property
+    def latest_fixity_check_result(self):
+        latest_check = self._latest_fixity_check()
+        return latest_check.success if latest_check is not None else None
+
+    def _latest_fixity_check(self):
+        try:
+            return FixityLog.objects.filter(package=self).order_by('-datetime_reported')[0]  # limit 1
+        except IndexError:
+            return None
 
     def get_download_path(self, lockss_au_number=None):
         full_path = self.fetch_local_path()

--- a/storage_service/locations/signals.py
+++ b/storage_service/locations/signals.py
@@ -1,12 +1,16 @@
+import json
 import logging
 from django.dispatch import receiver, Signal
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 
+import models
+
 LOGGER = logging.getLogger(__name__)
 
 deletion_request = Signal(providing_args=["uuid", "location", "url"])
 failed_fixity_check = Signal(providing_args=["uuid", "location", "report"])
+successful_fixity_check = Signal(providing_args=["uuid", "location", "report"])
 
 
 def _notify_administrators(subject, message):
@@ -35,8 +39,16 @@ To approve this deletion request, visit: {}{}
     _notify_administrators(subject, message)
 
 
+def _log_report(uuid, success, message=None):
+    package = models.Package.objects.get(uuid=uuid)
+    models.FixityLog.objects.create(package=package, success=success, error_details=message)
+
+
 @receiver(failed_fixity_check, dispatch_uid="fixity_check")
 def report_failed_fixity_check(sender, **kwargs):
+    report_data = json.loads(kwargs['report'])
+    _log_report(kwargs['uuid'], False, report_data['message'])
+
     subject = "Fixity check failed for package {}".format(kwargs["uuid"])
     message = """
 A fixity check failed for the package with UUID {}. This package is currently stored at: {}
@@ -44,4 +56,10 @@ A fixity check failed for the package with UUID {}. This package is currently st
 Full failure report (in JSON format):
 {}
 """.format(kwargs["uuid"], kwargs["location"], kwargs["report"])
+
     _notify_administrators(subject, message)
+
+
+@receiver(successful_fixity_check, dispatch_uid="fixity_check")
+def report_successful_fixity_check(sender, **kwargs):
+    _log_report(kwargs['uuid'], True)

--- a/storage_service/locations/tests/test_fixity_log.py
+++ b/storage_service/locations/tests/test_fixity_log.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+
+from locations import models
+
+
+class TestFixityLog(TestCase):
+
+    fixtures = ['base.json', 'fixity_log.json']
+
+    def setUp(self):
+        self.fl_object = models.FixityLog.objects.all()[0]
+        #self.auth = requests.auth.HTTPBasicAuth(self.ds_object.user, self.ds_object.password)
+
+    def test_has_required_attributes(self):
+        assert self.fl_object.package
+        assert self.fl_object.success
+        assert self.fl_object.error_details
+        assert self.fl_object.datetime_reported

--- a/storage_service/locations/urls.py
+++ b/storage_service/locations/urls.py
@@ -28,6 +28,10 @@ urlpatterns = [
     url(r'^packages/(?P<package_uuid>' + UUID + ')/reingest/$', views.aip_reingest,
         name='aip_reingest'),
 
+    # Fixity check results
+    url(r'^fixity/(?P<package_uuid>'+UUID+')/$', views.package_fixity,
+        name='package_fixity'),
+
     # Pipelines
     url(r'^pipelines/$', views.pipeline_list,
         name='pipeline_list'),

--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -14,7 +14,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from common import decorators
 from common import utils
-from .models import Callback, Space, Location, Package, Event, Pipeline, LocationPipeline, StorageException
+from .models import Callback, Space, Location, Package, Event, Pipeline, LocationPipeline, StorageException, FixityLog
 from . import forms
 from .constants import PROTOCOL
 
@@ -43,8 +43,13 @@ def get_delete_context_dict(request, model, object_uuid, default_cancel='/'):
 ########################## FILES ##########################
 
 def package_list(request):
-    packages = Package.objects.all()
-    return render(request, 'locations/package_list.html', locals())
+    context = {'packages': Package.objects.all()}
+    return render(request, 'locations/package_list.html', context)
+
+def package_fixity(request, package_uuid):
+    log_entries = FixityLog.objects.filter(package__uuid=package_uuid).order_by('-datetime_reported')
+    context = {'log_entries': log_entries}
+    return render(request, 'locations/fixity_results.html', context)
 
 class PackageRequestHandlerConfig:
     event_type = ''                # Event type being handled

--- a/storage_service/templates/locations/fixity_results.html
+++ b/storage_service/templates/locations/fixity_results.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block page_title %}Fixity Checks{% endblock %}
+
+{% block content %}
+
+{% if log_entries %}
+  <table class="datatable">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Error</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for entry in log_entries %}
+      <tr>
+        <td>{{ entry.datetime_reported }}</td>
+        <td>{{ entry.error_details }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% else %}
+  <p>No fixity checks found.</p>
+{% endif %}
+
+{% endblock %}

--- a/storage_service/templates/snippets/packages_table.html
+++ b/storage_service/templates/snippets/packages_table.html
@@ -9,6 +9,8 @@
         <th>Type</th>
         <th>Pointer File</th>
         <th>Status</th>
+        <th>Fixity Date</th>
+        <th>Fixity Status</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -39,6 +41,12 @@
           {% if package.status != 'DELETED' and package.status != 'FAIL'%}
           (<a href="{% url 'package_update_status' package.uuid %}?next={{ request.path }}">Update Status</a>)
           {% endif %}
+        </td>
+        <td>
+          {{ package.latest_fixity_check_datetime|default_if_none:"" }}
+        </td>
+        <td>
+          <a href="{% url 'package_fixity' package.uuid %}">{{ package.latest_fixity_check_result|yesno:"Success,Failed," }}</a>
         </td>
         <td>
           <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">Download</a>


### PR DESCRIPTION
This adds:
- failure handling if the fixity check doesn't complete because of an exception
- per-AIP log model of fixity attempts (time, whether they're successful, and error/failure details)
- two columns to package model for latest fixity attempt datetime/result
- two columns in package hitlist for latest fixity attempt datetime/result
- a fixity failures page where fixity check history for a package can be viewed

I'm not sure how you folk merge (whether you squash or merge individual commits), but I can clean up the history and put in better commit messages if individual commits are merged.
