### PR TITLE
Allow new metadata files to be POSTed to storage service (re-ingest), refs #9059

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -802,8 +802,9 @@ class PackageResource(ModelResource):
             response = {'error': True, 'message': 'Pipeline UUID {} failed to return a pipeline'.format(bundle.data['pipeline'])}
             return self.create_response(request, response, response_class=http.HttpBadRequest)
         reingest_type = bundle.data['reingest_type']
+        processing_config = bundle.data.get('processing_config', 'default')
 
-        response = bundle.obj.start_reingest(pipeline, reingest_type)
+        response = bundle.obj.start_reingest(pipeline, reingest_type, processing_config)
         status_code = response.get('status_code', 500)
 
         return self.create_response(request, response, status=status_code)

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -213,8 +213,8 @@ class CallbackForm(forms.ModelForm):
 
 class ReingestForm(forms.Form):
     REINGEST_CHOICES = (
-        (models.Package.METADATA_ONLY, 'Re-ingest metadata only'),
-        (models.Package.OBJECTS, 'Re-ingest metadata and objects for DIP generation'),
+        (models.Package.METADATA_ONLY, 'Metadata re-ingest'),
+        (models.Package.OBJECTS, 'Partial re-ingest'),
         (models.Package.FULL, 'Full re-ingest'),
     )
 

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -204,6 +204,7 @@ class ConfirmEventForm(forms.ModelForm):
         super(ConfirmEventForm, self).__init__(*args, **kwargs)
         self.fields['status_reason'].required = True
 
+
 class CallbackForm(forms.ModelForm):
     class Meta:
         model = models.Callback
@@ -211,9 +212,14 @@ class CallbackForm(forms.ModelForm):
 
 
 class ReingestForm(forms.Form):
-    pipeline = forms.ModelChoiceField(queryset=models.Pipeline.active.all())
     REINGEST_CHOICES = (
         (models.Package.METADATA_ONLY, 'Re-ingest metadata only'),
-        (models.Package.OBJECTS, 'Re-ingest metadata and objects')
+        (models.Package.OBJECTS, 'Re-ingest metadata and objects for DIP generation'),
+        (models.Package.FULL, 'Full re-ingest'),
     )
+
+    pipeline = forms.ModelChoiceField(queryset=models.Pipeline.active.all())
     reingest_type = forms.ChoiceField(choices=REINGEST_CHOICES, widget=forms.RadioSelect)
+    processing_config = forms.CharField(required=False, initial='default',
+        help_text='Only needed in full re-ingest',
+        widget=forms.TextInput(attrs={'placeholder': 'default'}))

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -27,6 +27,7 @@ from . import StorageException
 from location import Location
 from space import Space
 from event import File
+from pipeline import PipelineClientException
 
 __all__ = ('Package', )
 
@@ -113,9 +114,10 @@ class Package(models.Model):
     )
 
     # Reingest type options
-    METADATA_ONLY = 'metadata'
-    OBJECTS = 'objects'
-    REINGEST_CHOICES = (METADATA_ONLY, OBJECTS)
+    METADATA_ONLY = 'metadata' # Re-ingest metadata only
+    OBJECTS = 'objects'        # Re-ingest metadata and objects for DIP generation
+    FULL = 'full'              # Full re-ingest
+    REINGEST_CHOICES = (METADATA_ONLY, OBJECTS, FULL)
 
     class Meta:
         verbose_name = "Package"
@@ -372,7 +374,7 @@ class Package(models.Model):
         temp_aip.delete()
 
         # Do fixity check of AIP with recovered files
-        return self.check_fixity() 
+        return self.check_fixity()
 
     def store_aip(self, origin_location, origin_path):
         """ Stores an AIP in the correct Location.
@@ -835,13 +837,14 @@ class Package(models.Model):
 
     # REINGEST
 
-    def start_reingest(self, pipeline, reingest_type):
+    def start_reingest(self, pipeline, reingest_type, processing_config='default'):
         """
         Copies this package to `pipeline` for reingest.
 
         Fetches the AIP from storage, extracts and runs fixity on it to verify integrity.
         If reingest_type is METADATA_ONLY, sends the METS and all files in the metadata directory.
         If reingest_type is OBJECTS, sends METS, all files in metadata directory and all objects, preservation and original.
+        If reingest_type is FULL, we do like in OBJECTS but sending the package to the transfer source location.
         Calls Archivematica endpoint /api/ingest/reingest/ to start reingest.
 
         :param pipeline: Pipeline object to send reingested AIP to.
@@ -855,7 +858,7 @@ class Package(models.Model):
         # Check and set reingest pipeline
         if self.misc_attributes.get('reingest_pipeline', None):
             return {'error': True, 'status_code': 409,
-                'message': 'This AIP already being reingested on {}'.format(self.misc_attributes['reingest_pipeline'])}
+                'message': 'This AIP is already being reingested on {}'.format(self.misc_attributes['reingest_pipeline'])}
         self.misc_attributes.update({'reingest_pipeline': pipeline.uuid})
 
         # Fetch and extract if needed
@@ -880,7 +883,7 @@ class Package(models.Model):
         reingest_files = [
             os.path.join(relative_path, 'data', 'METS.' + self.uuid + '.xml')
         ]
-        if reingest_type == self.OBJECTS:
+        if reingest_type in (self.OBJECTS, self.FULL):
             # All in objects except submissionDocumentation dir
             for f in os.listdir(os.path.join(local_path, 'data', 'objects')):
                 if f in ('submissionDocumentation'):
@@ -893,6 +896,27 @@ class Package(models.Model):
                     reingest_files.append(os.path.join(relative_path, 'data', 'objects', f, ''))
         elif reingest_type == self.METADATA_ONLY:
             reingest_files.append(os.path.join(relative_path, 'data', 'objects', 'metadata', ''))
+
+        # Fetch processing configuration, put it in the root of the package and
+        # include the file in reingest_files.
+        if reingest_type == self.FULL and processing_config != 'default':
+            try:
+                config = pipeline.get_processing_config(processing_config)
+            except PipelineClientException:
+                LOGGER.exception('Reingest: processing configuration %s could not be loaded, error: %s', processing_config, e)
+                pass
+            else:
+                config_path = os.path.join(local_path, 'processingMCP.xml')
+                try:
+                    # It's not expected to find an existing processingMCP.xml
+                    # file in the original AIP, but we are using the w+ mode
+                    # just in case.
+                    with open(config_path, 'w+') as f:
+                        f.write(config)
+                    LOGGER.debug('Reingest: processing configuration %s written, location: %s', processing_config, config_path)
+                    reingest_files.append(os.path.join(relative_path, 'processingMCP.xml'))
+                except IOError as e:
+                    LOGGER.exception('Reingest: processing configuration %s could not be written, error: %s', processing_config, e)
 
         LOGGER.info('Reingest: files: %s', reingest_files)
 
@@ -921,31 +945,21 @@ class Package(models.Model):
         if temp_dir:
             shutil.rmtree(temp_dir)
 
-        # Call reingest AIP API
-        reingest_url = 'http://' + pipeline.remote_name + '/api/ingest/reingest'
-        params = {
-            'username': pipeline.api_username,
-            'api_key': pipeline.api_key,
-            'name': relative_path,
-            'uuid': self.uuid,
-        }
-        LOGGER.debug('Reingest: URL: %s; params: %s', reingest_url, params)
+        # Call reingest API
+        reingest_target = 'transfer' if self.FULL else 'ingest'
+        reingest_api_error = 'Error in approve reingest API.'
         try:
-            response = requests.post(reingest_url, data=params, allow_redirects=True)
-        except requests.exceptions.RequestException:
-            LOGGER.exception('Unable to connect to pipeline %s', pipeline)
-            return {'error': True, 'status_code': 502,
-                'message': 'Unable to connect to pipeline'}
-        LOGGER.debug('Response: %s %s', response.status_code, response.text)
-        if response.status_code != requests.codes.ok:
+            resp = pipeline.reingest(relative_path, self.uuid, reingest_target)
+        except PipelineClientException:
+            LOGGER.exception(reingest_api_error)
+            return {'error': True, 'status_code': 405, 'message': reingest_api_error}
+        else:
             try:
-                json_error = response.json().get('message',
-                    'Error in approve reingest API.')
+                json_error = resp.json().get('message', reingest_api_error)
             except ValueError:  # Failed to decode JSON
-                json_error = 'Error in approve reingest API.'
+                json_error = reingest_api_error
             LOGGER.error(json_error)
-            return {'error': True, 'status_code': 502,
-                'message': 'Error from pipeline: %s' % json_error}
+            return {'error': True, 'status_code': 502, 'message': 'Error from pipeline: %s: %s' % (self, json_error)}
 
         self.save()
 

--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -228,7 +228,8 @@ def aip_reingest(request, package_uuid):
     if form.is_valid():
         pipeline = form.cleaned_data['pipeline']
         reingest_type = form.cleaned_data['reingest_type']
-        response = package.start_reingest(pipeline, reingest_type)
+        processing_config = form.cleaned_data.get('processing_config', 'default')
+        response = package.start_reingest(pipeline, reingest_type, processing_config)
         error = response.get('error', True)
         message = response.get('message', 'An unknown error occurred')
         if not error:

--- a/storage_service/templates/locations/package_reingest.html
+++ b/storage_service/templates/locations/package_reingest.html
@@ -4,12 +4,16 @@
 
 {% block content %}
 
-<div class='form-control'>
-  <form action="{% url 'aip_reingest' package.uuid %}" method="post">
-    {% csrf_token %}
-    <p><label>Package: {{ package.uuid }}</label> </p>
-    {{ form }}
-    <a href="{{ cancel_url }}" class='btn'>Cancel</a> <input class='btn btn-primary' type="submit" value="Re-ingest Package" />
-  </form>
-</div>
+  <div class="form-control">
+    <form action="{% url 'aip_reingest' package.uuid %}" method="post">
+      {% csrf_token %}
+      <p><label>Package: {{ package.uuid }}</label> </p>
+      {{ form }}
+      <div class="form-actions">
+        <input class='btn btn-primary' type="submit" value="Re-ingest"/>
+        <a class="btn" href="{{ cancel_url }}">Cancel</a>
+      </div>
+    </form>
+  </div>
+
 {% endblock %}

--- a/storage_service/templates/snippets/packages_table.html
+++ b/storage_service/templates/snippets/packages_table.html
@@ -24,14 +24,16 @@
           None
           {% endif %}
         </td>
-        <td><a href="{% url 'location_detail' package.current_location.uuid %}">{{ package.full_path }}</a></td>
+        <td style="max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+          <a href="{% url 'location_detail' package.current_location.uuid %}">{{ package.full_path }}</a>
+        </td>
         <td>{{ package.size|filesizeformat }}</td>
         <td>{{ package.get_package_type_display }}</td>
         <td>
           {% if package.pointer_file_location %}
             <a href="{% url 'pointer_file_request' 'v2' 'file' package.uuid %}">Pointer File</a>
           {% else %}
-          None
+            None
           {% endif %}
         </td>
         <td>


### PR DESCRIPTION
Redmine ticket: https://projects.artefactual.com/issues/9059

This pull request updates the reingest choices to:
- Full re-ingest aka `full` (**NEW**).
- Metadata re-ingest aka `metadata`.
- Partial re-ingest `partial`.

If the re-ingest is `full`, the user has the option to indicate a processing configuration different that the default.

---

A new parameter `target` is sent to the [pipeline's reingest API](https://github.com/artefactual/archivematica/blob/qa/1.x/src/dashboard/src/components/api/views.py#L395-L436) indicating whether the packages should go to `ingest` or `transfer`.

| Re-ingest | `/api/reingest`'s field `target` |
| --- | --- |
| full | transfer |
| metadata | ingest |
| partial | ingest |
