### PR TITLE
Add Arkivum-specific return codes

### DIFF
--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -98,20 +98,13 @@ def download_file_stream(filepath, temp_dir=None):
         return http.HttpResponseNotFound("File not found")
 
     filename = os.path.basename(filepath)
-    extension = os.path.splitext(filepath)[1].lower()
 
     wrapper = FileWrapper(file(filepath))
     response = http.HttpResponse(wrapper)
 
-    # force download for certain filetypes
-    extensions_to_download = ['.7z', '.zip']
-    if extension in extensions_to_download:
-        response['Content-Type'] = 'application/force-download'
-        response['Content-Disposition'] = 'attachment; filename="' + filename + '"'
-    else:
-        mimetype = mimetypes.guess_type(filename)[0]
-        response['Content-type'] = mimetype
-
+    mimetype = mimetypes.guess_type(filename)[0]
+    response['Content-type'] = mimetype
+    response['Content-Disposition'] = 'attachment; filename="' + filename + '"'
     response['Content-Length'] = os.path.getsize(filepath)
 
     # Delete temp dir if created

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -497,7 +497,7 @@ class PackageResource(ModelResource):
             try:
                 bundle.obj = self.obj_get(bundle=bundle, **lookup_kwargs)
             except ObjectDoesNotExist:
-                raise NotFound("A model instance matching the provided arguments could not be found.")
+                raise tastypie.exceptions.NotFound("A model instance matching the provided arguments could not be found.")
         bundle = self.full_hydrate(bundle)
         bundle = self.obj_update_hook(bundle, **kwargs)
         return self.save(bundle, skip_errors=skip_errors)

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -615,6 +615,16 @@ class PackageResource(ModelResource):
         # Get Package details
         package = bundle.obj
 
+        # Check if the package is in Arkivum and not actually there
+        if package.current_location.space.access_protocol == Space.ARKIVUM:
+            is_local = package.current_location.space.get_child_space().is_file_local(package)
+            if is_local is False:
+                # Need to fetch from tape, return 202
+                return http.HttpAccepted(json.dumps({"error": False, 'message': "File is not locally available.  Contact your storage administrator to fetch it."}))
+            if is_local is None:
+                # Arkivum error, return 502
+                return http.HttpResponse(json.dumps({"error": True, "message": "Error checking if file in Arkivum in locally available."}), content_type='application/json', status=502)
+
         # If local file exists - return that
         if not package.is_compressed:
             full_path = package.fetch_local_path()
@@ -648,6 +658,16 @@ class PackageResource(ModelResource):
         """
         # Get AIP details
         package = bundle.obj
+
+        # Check if the package is in Arkivum and not actually there
+        if package.current_location.space.access_protocol == Space.ARKIVUM:
+            is_local = package.current_location.space.get_child_space().is_file_local(package)
+            if is_local is False:
+                # Need to fetch from tape, return 202
+                return http.HttpAccepted(json.dumps({"error": False, 'message': "File is not locally available.  Contact your storage administrator to fetch it."}))
+            if is_local is None:
+                # Arkivum error, return 502
+                return http.HttpResponse(json.dumps({"error": True, "message": "Error checking if file in Arkivum in locally available."}), content_type='application/json', status=502)
 
         lockss_au_number = kwargs.get('chunk_number')
         try:

--- a/storage_service/locations/fixtures/arkivum.json
+++ b/storage_service/locations/fixtures/arkivum.json
@@ -24,7 +24,7 @@
     }
 },
 {
-    "pk": 8,
+    "pk": 10,
     "model": "locations.location", 
     "fields": {
         "used": 0, 
@@ -32,7 +32,7 @@
         "space": "6fb34c82-4222-425e-b0ea-30acfd31f52e", 
         "enabled": true, 
         "quota": null, 
-        "relative_path": "aips/", 
+        "relative_path": "",
         "purpose": "AS", 
         "uuid": "d9d7db26-f7a1-40aa-9db1-806b4d3a61cd"
     }
@@ -50,14 +50,14 @@
     }
 },
 {
-    "pk": 9,
+    "pk": 10,
     "model": "locations.package",
     "fields": {
         "status": "STAGING",
         "package_type": "AIP",
         "origin_pipeline": "7691b4bc-b76a-411c-b6a2-d16964018220",
         "uuid": "c0f8498f-b92e-4a8b-8941-1b34ba062ed8",
-        "current_path": "c0f8/498f/b92e/4a8b/8941/1b34/ba06/2ed8/ep9-c0f8498f-b92e-4a8b-8941-1b34ba062ed8.7z",
+        "current_path": "working_bag.zip",
         "misc_attributes": {},
         "current_location": "d9d7db26-f7a1-40aa-9db1-806b4d3a61cd",
         "pointer_file_location": "Why does this not work?",

--- a/storage_service/locations/fixtures/duracloud.json
+++ b/storage_service/locations/fixtures/duracloud.json
@@ -25,7 +25,7 @@
     }
 },
 {
-    "pk": 7, 
+    "pk": 10,
     "model": "locations.location", 
     "fields": {
         "used": 0, 

--- a/storage_service/locations/fixtures/swift.json
+++ b/storage_service/locations/fixtures/swift.json
@@ -28,7 +28,7 @@
     }
 },
 {
-    "pk": 7, 
+    "pk": 10,
     "model": "locations.location", 
     "fields": {
         "used": 0, 

--- a/storage_service/locations/fixtures/vcr_cassettes/api_download_package_arkivum_error.yaml
+++ b/storage_service/locations/fixtures/vcr_cassettes/api_download_package_arkivum_error.yaml
@@ -1,0 +1,16 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-54-generic]
+    method: GET
+    uri: https://198.50.244.148:8443/api/2/files/release/2e75c8ad-cded-4f7e-8ac7-85627a116e39
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      keep-alive: ['timeout=5, max=99']
+    status: {code: 404, message: Not Found}

--- a/storage_service/locations/fixtures/vcr_cassettes/api_download_package_arkivum_not_available.yaml
+++ b/storage_service/locations/fixtures/vcr_cassettes/api_download_package_arkivum_not_available.yaml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-54-generic]
+    method: GET
+    uri: https://198.50.244.148:8443/api/2/files/release/2e75c8ad-cded-4f7e-8ac7-85627a116e39
+  response:
+    body: {string: !!python/unicode '{
+  "actualChecksum" : null,
+  "actualChecksumChecksumAlgorithm" : null,
+  "actualCompressionAlgorithm" : null,
+  "actualSize" : 0,
+  "completed" : 1445549709552,
+  "fileId" : "27dd9047-59a7-41a3-b58b-9d8ca58e0c82",
+  "fileInformation" : {
+    "autoClear" : true,
+    "chunkset" : {
+      "chunks" : [ {
+        "chunkInstances" : [ {
+          "id" : "193134e4-0de4-4c46-a748-5ddca23ad8ad",
+          "storage" : {
+            "id" : "f6909253-211b-41f4-9201-73a2e20bc6a2",
+            "name" : "Arkivum Cloud Service",
+            "type" : "arkcloud"
+          }
+        }, {
+          "id" : "9770bc1d-41bc-46dd-b30d-3d891b3886d0",
+          "storage" : {
+            "id" : "887d06c5-6598-4b5d-851b-42398e5776f3",
+            "name" : "Locally Cached Data",
+            "type" : "file"
+          }
+        } ],
+        "id" : "a2809268-6696-48b9-ba2b-d6ff562f69d2",
+        "md5" : "ca378eca44bbd5e7ac963212d95c35e",
+        "offset" : 0,
+        "sequenceNumber" : 1,
+        "size" : 2342754
+      } ],
+      "encrypted" : true,
+      "escrowsetId" : "c0b1c3bb-b152-4cea-9d5a-a19297f8f902",
+      "id" : "f0c7864a-04f8-46dd-b738-59b671a58d5e",
+      "revision" : 1
+    },
+    "created" : "2015-10-19T17:49:23Z",
+    "creator" : "ASTORSERVER",
+    "dataPoolId" : "1d03259e-c1d9-4894-ad51-5593330413bc",
+    "directory" : false,
+    "escrowTapes" : [ ],
+    "file" : true,
+    "fileMode" : 33261,
+    "id" : "2e75c8ad-cded-4f7e-8ac7-85627a116e39",
+    "ingestState" : "FINAL",
+    "lastAccessed" : "2015-10-19T17:49:21Z",
+    "lastChanged" : "2015-10-19T17:49:21Z",
+    "lastModified" : "2015-10-19T17:48:28Z",
+    "local" : false,
+    "md5" : "e917f867114dedf9bdb430e838da647d",
+    "name" : "working_bag.zip",
+    "ownerGroupId" : 99,
+    "ownerUserId" : 99,
+    "parentId" : "462b837c-1307-40a9-b5ca-ca5537ba70a4",
+    "path" : "working_bag.zip",
+    "replicationState" : "amber",
+    "size" : 2342754
+  },
+  "id" : "dd90f6db-04dd-47ae-b8e1-c33227b4dba0",
+  "originalChecksum" : "e917f867114dedf9bdb430e838da647d",
+  "originalChecksumChecksumAlgorithm" : "md5",
+  "originalCompressionAlgorithm" : ".zip",
+  "originalSize" : 2342754,
+  "reason" : null,
+  "requested" : 1445549709552,
+  "status" : "Scheduled"
+}
+'}
+    headers:
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      keep-alive: ['timeout=5, max=99']
+    status: {code: 200, message: OK}

--- a/storage_service/locations/fixtures/vcr_cassettes/arkivum_post_move_from_ss.yaml
+++ b/storage_service/locations/fixtures/vcr_cassettes/arkivum_post_move_from_ss.yaml
@@ -1,16 +1,14 @@
 interactions:
 - request:
-    body: '{"compressionAlgorithm": ["c0f8/498f/b92e/4a8b/8941/1b34/ba06/2ed8/ep9-c0f8498f-b92e-4a8b-8941-1b34ba062ed8",
-      ".7z"], "checksum": "b05403212c66bdc8ccc597fedf6cd5fe", "checksumAlgorithm":
+    body: '{"compressionAlgorithm": "zip", "checksum": "b05403212c66bdc8ccc597fedf6cd5fe", "checksumAlgorithm":
       "md5", "size": "10"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
-      Content-Length: ['207']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.3.0 CPython/2.7.3 Linux/3.5.0-52-generic]
     method: POST
-    uri: https://198.50.244.148:8443/api/2/files/release/aips/c0f8/498f/b92e/4a8b/8941/1b34/ba06/2ed8/ep9-c0f8498f-b92e-4a8b-8941-1b34ba062ed8.7z
+    uri: https://198.50.244.148:8443/api/2/files/release/working_bag.zip
   response:
     body:
       string: !!binary |

--- a/storage_service/locations/tests/test_api.py
+++ b/storage_service/locations/tests/test_api.py
@@ -176,7 +176,7 @@ class TestPackageAPI(TestCase):
         """ It should return the package. """
         response = self.client.get('/api/v2/file/6aebdb24-1b6b-41ab-b4a3-df9a73726a34/download/')
         assert response.status_code == 200
-        assert response['content-type'] == 'application/force-download'
+        assert response['content-type'] == 'application/zip'
         assert response['content-disposition'] == 'attachment; filename="working_bag.zip"'
 
     def test_download_uncompressed_package(self):
@@ -184,6 +184,7 @@ class TestPackageAPI(TestCase):
         response = self.client.get('/api/v2/file/0d4e739b-bf60-4b87-bc20-67a379b28cea/download/')
         assert response.status_code == 200
         assert response['content-type'] == 'application/x-tar'
+        assert response['content-disposition'] == 'attachment; filename="working_bag.tar"'
         assert 'bag-info.txt' in response.content
         assert 'bagit.txt' in response.content
         assert 'manifest-md5.txt' in response.content
@@ -195,6 +196,7 @@ class TestPackageAPI(TestCase):
         response = self.client.get('/api/v2/file/0d4e739b-bf60-4b87-bc20-67a379b28cea/download/', data={'chunk_number': 1})
         assert response.status_code == 200
         assert response['content-type'] == 'application/x-tar'
+        assert response['content-disposition'] == 'attachment; filename="working_bag.tar"'
         assert 'bag-info.txt' in response.content
         assert 'bagit.txt' in response.content
         assert 'manifest-md5.txt' in response.content
@@ -217,6 +219,7 @@ class TestPackageAPI(TestCase):
         response = self.client.get('/api/v2/file/6aebdb24-1b6b-41ab-b4a3-df9a73726a34/extract_file/', data={'relative_path_to_file': 'working_bag/data/test.txt'})
         assert response.status_code == 200
         assert response['content-type'] == 'text/plain'
+        assert response['content-disposition'] == 'attachment; filename="test.txt"'
         assert response.content == 'test'
 
     def test_download_file_from_uncompressed(self):
@@ -224,5 +227,5 @@ class TestPackageAPI(TestCase):
         response = self.client.get('/api/v2/file/0d4e739b-bf60-4b87-bc20-67a379b28cea/extract_file/', data={'relative_path_to_file': 'working_bag/data/test.txt'})
         assert response.status_code == 200
         assert response['content-type'] == 'text/plain'
+        assert response['content-disposition'] == 'attachment; filename="test.txt"'
         assert response.content == 'test'
-


### PR DESCRIPTION
Arkivum files are NFS-mounted and have local paths but may not be immediately available locally.  Before fetching an Arkivum file (including checking if it's compressed) check if the file is locally available and return different status codes depending on Arkivum's response.

Endpoints: `/api/v1/file/<uuid>/download/` & `/api/v1/file/<uuid>/extract_file/`
- 200 package locally available (return file)
- 202 package exists but not here now (Arkivum needs to get from tape)
- 404 package doesn't exist
- 502 backend error from Arkivum (assume can't get file)

Includes #87 
