### PR TITLE
Add Dataverse Space

### DIFF
--- a/storage_service/locations/constants.py
+++ b/storage_service/locations/constants.py
@@ -13,6 +13,11 @@ PROTOCOL = {
                    'remote_user',
                    'remote_name']
     },
+    models.Space.DATAVERSE: {
+        'model': models.Dataverse,
+        'form': forms.DataverseForm,
+        'fields': ['host'],
+    },
     models.Space.DURACLOUD: {
         'model': models.Duracloud,
         'form': forms.DuracloudForm,

--- a/storage_service/locations/constants.py
+++ b/storage_service/locations/constants.py
@@ -16,7 +16,7 @@ PROTOCOL = {
     models.Space.DATAVERSE: {
         'model': models.Dataverse,
         'form': forms.DataverseForm,
-        'fields': ['host'],
+        'fields': ['host', 'agent_name', 'agent_type', 'agent_identifier'],
     },
     models.Space.DURACLOUD: {
         'model': models.Duracloud,

--- a/storage_service/locations/fixtures/dataverse.json
+++ b/storage_service/locations/fixtures/dataverse.json
@@ -1,0 +1,39 @@
+[
+{
+    "fields": {
+        "host": "apitest.dataverse.org",
+        "api_key": "testkeys-77a8-49a3-874e-be1148e7c970",
+        "space": "216bec3b-c4c1-4eff-97ef-728244e58dd0"
+    },
+    "model": "locations.dataverse",
+    "pk": 2
+},
+{
+    "fields": {
+        "last_verified": null,
+        "used": 0,
+        "verified": false,
+        "uuid": "216bec3b-c4c1-4eff-97ef-728244e58dd0",
+        "access_protocol": "DV",
+        "staging_path": "/var/archivematica/storage_service/",
+        "path": "",
+        "size": null
+    },
+    "model": "locations.space",
+    "pk": 3
+},
+{
+    "fields": {
+        "used": 0,
+        "description": "",
+        "space": "216bec3b-c4c1-4eff-97ef-728244e58dd0",
+        "enabled": true,
+        "quota": null,
+        "relative_path": "*",
+        "purpose": "TS",
+        "uuid": "da1c729d-0b17-4c48-91d5-127f38f7542d"
+    },
+    "model": "locations.location",
+    "pk": 8
+}
+]

--- a/storage_service/locations/fixtures/dataverse.json
+++ b/storage_service/locations/fixtures/dataverse.json
@@ -3,7 +3,10 @@
     "fields": {
         "host": "apitest.dataverse.org",
         "api_key": "testkeys-77a8-49a3-874e-be1148e7c970",
-        "space": "216bec3b-c4c1-4eff-97ef-728244e58dd0"
+        "space": "216bec3b-c4c1-4eff-97ef-728244e58dd0",
+        "agent_name": "Example Dataverse Network",
+        "agent_type": "organization",
+        "agent_identifier": "http://dataverse.example.com/dvn/"
     },
     "model": "locations.dataverse",
     "pk": 2

--- a/storage_service/locations/fixtures/vcr_cassettes/dataverse_browse_all.yaml
+++ b/storage_service/locations/fixtures/vcr_cassettes/dataverse_browse_all.yaml
@@ -1,0 +1,109 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-43-generic]
+    method: GET
+    uri: https://apitest.dataverse.org/api/search/?sort=name&show_entity_ids=True&q=%2A&start=0&key=testkeys-77a8-49a3-874e-be1148e7c970&per_page=10&type=dataset&order=asc
+  response:
+    body: {string: !!python/unicode '{"status":"OK","data":{"q":"*","total_count":15,"start":0,"spelling_alternatives":{},"items":[{"name":"Ad
+        hoc observational study of the trees outside my window","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/D3B38B","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/39","global_id":"doi:10.5072/FK2/D3B38B","description":"Very
+        few parameters were used for this highly subjective study.","published_at":"2015-08-06T20:56:12Z","citation":"McLellan,
+        Evelyn, 2015, \"Ad hoc observational study of the trees outside my window\",
+        <a href=\"http://dx.doi.org/10.5072/FK2/D3B38B\">http://dx.doi.org/10.5072/FK2/D3B38B</a>,  API
+        Test Dataverse,  V5","entity_id":82,"authors":["McLellan, Evelyn"]},{"name":"Constitive
+        leaf ORAC","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/RDL8U6","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/6","global_id":"doi:10.5072/FK2/RDL8U6","description":"ORAC","published_at":"2015-07-01T01:50:08Z","citation":"barboza,
+        dags, 2015, \"Constitive leaf ORAC\", <a href=\"http://dx.doi.org/10.5072/FK2/RDL8U6\">http://dx.doi.org/10.5072/FK2/RDL8U6</a>,  API
+        Test Dataverse,  V1","entity_id":25,"authors":["barboza, dags"]},{"name":"Leaf
+        Anatomy C4","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/BPFFAK","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/7","global_id":"doi:10.5072/FK2/BPFFAK","description":"C4
+        dataset","published_at":"2015-07-02T01:37:51Z","citation":"barboza, dags,
+        2015, \"Leaf Anatomy C4\", <a href=\"http://dx.doi.org/10.5072/FK2/BPFFAK\">http://dx.doi.org/10.5072/FK2/BPFFAK</a>,  API
+        Test Dataverse,  V1","entity_id":27,"authors":["barboza, dags"]},{"name":"Massachusetts
+        Archives Collection. v.188-Revolution Petitions, 1782-1783. SC1/series 45X,
+        Petition of John Holmes","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/JZ1DHU","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/21","global_id":"doi:10.5072/FK2/JZ1DHU","description":"Petition:
+        Property Original: http://nrs.harvard.edu/urn-3:FHCL:13909122 Date of creation:
+        1782-10-01 Petition location: Berkshire Top signatures: John Holmes Elnathan
+        Bush Thomas Webb Pomp Benjamin Pomp Benjamin Jr. Total signatures: 60 Legal
+        voter signatures (males not identified as non-legal): 60 Identifications of
+        signatories: inhabitants of the county of Berkshire, [males of color] Prayer
+        format was printed vs. manuscript: Manuscript Additional archivist notes:
+        Berkshire County, New York, Indian tribes, wilderness, township, land, east
+        side, emigration, emigrate, Senango alias Ossenango, Susquehanna River Acknowledgements:
+        Supported by the National Endowment for the Humanities (PW-5105612), Massachusetts
+        Archives of the Commonwealth, Radcliffe Institute for Advanced Study at Harvard
+        University, Center for American Political Studies at Harvard University, Institutional
+        Development Initiative at Harvard University, and Harvard University Library.","published_at":"2015-07-02T20:07:09Z","citation":"Digital
+        Archive of Massachusetts Anti-Slavery and Anti-Segregation Petitions, Massachusetts
+        Archives, Boston MA, 2015, \"Massachusetts Archives Collection. v.188-Revolution
+        Petitions, 1782-1783. SC1/series 45X, Petition of John Holmes\", <a href=\"http://dx.doi.org/10.5072/FK2/JZ1DHU\">http://dx.doi.org/10.5072/FK2/JZ1DHU</a>,  API
+        Test Dataverse,  V1","entity_id":41,"authors":["Digital Archive of Massachusetts
+        Anti-Slavery and Anti-Segregation Petitions, Massachusetts Archives, Boston
+        MA"]},{"name":"Metadata mapping test study","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/0MOPJM","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/40","global_id":"doi:10.5072/FK2/0MOPJM","description":"This
+        study tests the types of metadata that are exported from Dataverse and how
+        they can be mapped to standard schemas.","published_at":"2015-08-24T16:32:00Z","citation":"McLellan,
+        Evelyn, 2015, \"Metadata mapping test study\", <a href=\"http://dx.doi.org/10.5072/FK2/0MOPJM\">http://dx.doi.org/10.5072/FK2/0MOPJM</a>,  API
+        Test Dataverse,  V1 [UNF:6:r5Z8n0CKSeRcAvjcTINpmQ==]","entity_id":90,"authors":["McLellan,
+        Evelyn"]},{"name":"Nature Sounds","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/BVDPO5","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/33","global_id":"doi:10.5072/FK2/BVDPO5","description":"This
+        is the first Nature Sounds dataset on dataverse.","published_at":"2015-08-06T00:10:48Z","citation":"Simpson,
+        Justin, 2015, \"Nature Sounds\", <a href=\"http://dx.doi.org/10.5072/FK2/BVDPO5\">http://dx.doi.org/10.5072/FK2/BVDPO5</a>,  API
+        Test Dataverse,  V2","entity_id":74,"authors":["Simpson, Justin"]},{"name":"new
+        title","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/WWB3ZE","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/15","global_id":"doi:10.5072/FK2/WWB3ZE","description":"This
+        is a description 2015-07-02 20:00:38.989753","published_at":"2015-07-02T20:00:39Z","citation":"Dataverse
+        API creator, 2015, \"new title\", <a href=\"http://dx.doi.org/10.5072/FK2/WWB3ZE\">http://dx.doi.org/10.5072/FK2/WWB3ZE</a>,  API
+        Test Dataverse,  V1","entity_id":38,"authors":["Dataverse API creator"]},{"name":"new
+        title","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/VSSWOU","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/16","global_id":"doi:10.5072/FK2/VSSWOU","description":"This
+        is a description 2015-07-02 20:01:21.388552","published_at":"2015-07-02T20:01:20Z","citation":"Dataverse
+        API creator, 2015, \"new title\", <a href=\"http://dx.doi.org/10.5072/FK2/VSSWOU\">http://dx.doi.org/10.5072/FK2/VSSWOU</a>,  API
+        Test Dataverse,  V1","entity_id":39,"authors":["Dataverse API creator"]},{"name":"new
+        title","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/LIWAIR","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/18","global_id":"doi:10.5072/FK2/LIWAIR","description":"This
+        is a description 2015-07-02 20:02:36.138609","published_at":"2015-07-02T20:02:35Z","citation":"Dataverse
+        API creator, 2015, \"new title\", <a href=\"http://dx.doi.org/10.5072/FK2/LIWAIR\">http://dx.doi.org/10.5072/FK2/LIWAIR</a>,  API
+        Test Dataverse,  V1","entity_id":40,"authors":["Dataverse API creator"]},{"name":"ORAC
+        COLD STRESS","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/4T5QYS","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/23","global_id":"doi:10.5072/FK2/4T5QYS","description":"test
+        ORAC, Right Format","published_at":"2015-07-07T00:56:10Z","citation":"barboza,
+        dags, 2015, \"ORAC COLD STRESS\", <a href=\"http://dx.doi.org/10.5072/FK2/4T5QYS\">http://dx.doi.org/10.5072/FK2/4T5QYS</a>,  API
+        Test Dataverse,  V1","entity_id":43,"authors":["barboza, dags"]}],"count_in_response":10}}'}
+    headers:
+      connection: [close]
+      content-length: ['6714']
+      content-type: [application/json]
+      date: ['Tue, 15 Sep 2015 22:31:40 GMT']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-43-generic]
+    method: GET
+    uri: https://apitest.dataverse.org/api/search/?sort=name&show_entity_ids=True&q=%2A&start=10&key=testkeys-77a8-49a3-874e-be1148e7c970&per_page=10&type=dataset&order=asc
+  response:
+    body: {string: !!python/unicode '{"status":"OK","data":{"q":"*","total_count":15,"start":10,"spelling_alternatives":{},"items":[{"name":"Phenotyping
+        for root water extraction potential, IRRI 2013","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/GN7A6I","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/26","global_id":"doi:10.5072/FK2/GN7A6I","description":"test","published_at":"2015-07-13T07:33:38Z","citation":"Dingkuhn,
+        Michael, 2015, \"Phenotyping for root water extraction potential, IRRI 2013\",
+        <a href=\"http://dx.doi.org/10.5072/FK2/GN7A6I\">http://dx.doi.org/10.5072/FK2/GN7A6I</a>,  API
+        Test Dataverse,  V1","entity_id":49,"authors":["Dingkuhn, Michael"]},{"name":"Restricted
+        Studies Test","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/IRSXYF","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/41","global_id":"doi:10.5072/FK2/IRSXYF","description":"test","published_at":"2015-08-25T01:30:18Z","citation":"barboza,
+        dags, 2015, \"Restricted Studies Test\", <a href=\"http://dx.doi.org/10.5072/FK2/IRSXYF\">http://dx.doi.org/10.5072/FK2/IRSXYF</a>,  API
+        Test Dataverse,  V1","entity_id":93,"authors":["barboza, dags"]},{"name":"Spruce
+        Goose","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/SRKJXU","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/1","global_id":"doi:10.5072/FK2/SRKJXU","description":"What
+        the Spruce Goose was really made of.","published_at":"2015-06-23T16:31:56Z","citation":"Spruce,
+        Sabrina, 2015, \"Spruce Goose\", <a href=\"http://dx.doi.org/10.5072/FK2/SRKJXU\">http://dx.doi.org/10.5072/FK2/SRKJXU</a>,  API
+        Test Dataverse,  V1","entity_id":10,"authors":["Spruce, Sabrina"]},{"name":"testdocx","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/ECUYCX","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/35","global_id":"doi:10.5072/FK2/ECUYCX","description":"test
+        docx","published_at":"2015-08-06T16:46:05Z","citation":"Liu, Susan, 2015,
+        \"testdocx\", <a href=\"http://dx.doi.org/10.5072/FK2/ECUYCX\">http://dx.doi.org/10.5072/FK2/ECUYCX</a>,  API
+        Test Dataverse,  V5","entity_id":16,"authors":["Liu, Susan"]},{"name":"testjpg","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/TPNDZ2","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/3","global_id":"doi:10.5072/FK2/TPNDZ2","description":"test
+        jpg","published_at":"2015-06-29T08:27:24Z","citation":"Liu, Susan, 2015, \"testjpg\",
+        <a href=\"http://dx.doi.org/10.5072/FK2/TPNDZ2\">http://dx.doi.org/10.5072/FK2/TPNDZ2</a>,  API
+        Test Dataverse,  V1","entity_id":14,"authors":["Liu, Susan"]}],"count_in_response":5}}'}
+    headers:
+      connection: [close]
+      content-length: ['2574']
+      content-type: [application/json]
+      date: ['Tue, 15 Sep 2015 22:31:41 GMT']
+    status: {code: 200, message: OK}
+version: 1

--- a/storage_service/locations/fixtures/vcr_cassettes/dataverse_browse_filter.yaml
+++ b/storage_service/locations/fixtures/vcr_cassettes/dataverse_browse_filter.yaml
@@ -1,0 +1,33 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-43-generic]
+    method: GET
+    uri: https://apitest.dataverse.org/api/search/?sort=name&show_entity_ids=True&q=title%3Atest%2A&start=0&key=testkeys-77a8-49a3-874e-be1148e7c970&per_page=10&type=dataset&order=asc
+  response:
+    body: {string: !!python/unicode '{"status":"OK","data":{"q":"title:test*","total_count":4,"start":0,"spelling_alternatives":{},"items":[{"name":"Metadata
+        mapping test study","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/0MOPJM","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/40","global_id":"doi:10.5072/FK2/0MOPJM","description":"This
+        study tests the types of metadata that are exported from Dataverse and how
+        they can be mapped to standard schemas.","published_at":"2015-08-24T16:32:00Z","citation":"McLellan,
+        Evelyn, 2015, \"Metadata mapping test study\", <a href=\"http://dx.doi.org/10.5072/FK2/0MOPJM\">http://dx.doi.org/10.5072/FK2/0MOPJM</a>,  API
+        Test Dataverse,  V1 [UNF:6:r5Z8n0CKSeRcAvjcTINpmQ==]","entity_id":90,"authors":["McLellan,
+        Evelyn"]},{"name":"Restricted Studies Test","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/IRSXYF","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/41","global_id":"doi:10.5072/FK2/IRSXYF","description":"test","published_at":"2015-08-25T01:30:18Z","citation":"barboza,
+        dags, 2015, \"Restricted Studies Test\", <a href=\"http://dx.doi.org/10.5072/FK2/IRSXYF\">http://dx.doi.org/10.5072/FK2/IRSXYF</a>,  API
+        Test Dataverse,  V1","entity_id":93,"authors":["barboza, dags"]},{"name":"testdocx","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/ECUYCX","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/35","global_id":"doi:10.5072/FK2/ECUYCX","description":"test
+        docx","published_at":"2015-08-06T16:46:05Z","citation":"Liu, Susan, 2015,
+        \"testdocx\", <a href=\"http://dx.doi.org/10.5072/FK2/ECUYCX\">http://dx.doi.org/10.5072/FK2/ECUYCX</a>,  API
+        Test Dataverse,  V5","entity_id":16,"authors":["Liu, Susan"]},{"name":"testjpg","type":"dataset","url":"http://dx.doi.org/10.5072/FK2/TPNDZ2","image_url":"https://apitest.dataverse.org/api/access/dsCardImage/3","global_id":"doi:10.5072/FK2/TPNDZ2","description":"test
+        jpg","published_at":"2015-06-29T08:27:24Z","citation":"Liu, Susan, 2015, \"testjpg\",
+        <a href=\"http://dx.doi.org/10.5072/FK2/TPNDZ2\">http://dx.doi.org/10.5072/FK2/TPNDZ2</a>,  API
+        Test Dataverse,  V1","entity_id":14,"authors":["Liu, Susan"]}],"count_in_response":4}}'}
+    headers:
+      connection: [close]
+      content-length: ['2163']
+      content-type: [application/json]
+      date: ['Tue, 15 Sep 2015 22:34:52 GMT']
+    status: {code: 200, message: OK}
+version: 1

--- a/storage_service/locations/fixtures/vcr_cassettes/dataverse_move_to.yaml
+++ b/storage_service/locations/fixtures/vcr_cassettes/dataverse_move_to.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-43-generic]
+    method: GET
+    uri: https://apitest.dataverse.org/api/datasets/90?key=testkeys-77a8-49a3-874e-be1148e7c970
+  response:
+    body: {string: !!python/unicode '{"status":"OK","data":{"id":90,"identifier":"0MOPJM","persistentUrl":"http://dx.doi.org/10.5072/FK2/0MOPJM","protocol":"doi","authority":"10.5072/FK2","latestVersion":{"id":40,"versionNumber":1,"versionMinorNumber":0,"versionState":"RELEASED","productionDate":"Production
+        Date","UNF":"UNF:6:r5Z8n0CKSeRcAvjcTINpmQ==","lastUpdateTime":"2015-08-24T16:32:00Z","releaseTime":"2015-08-24T16:32:00Z","createTime":"2015-08-24T16:28:11Z","metadataBlocks":{"citation":{"displayName":"Citation
+        Metadata","fields":[{"typeName":"title","multiple":false,"typeClass":"primitive","value":"Metadata
+        mapping test study"},{"typeName":"author","multiple":true,"typeClass":"compound","value":[{"authorName":{"typeName":"authorName","multiple":false,"typeClass":"primitive","value":"McLellan,
+        Evelyn"}}]},{"typeName":"datasetContact","multiple":true,"typeClass":"compound","value":[{"datasetContactName":{"typeName":"datasetContactName","multiple":false,"typeClass":"primitive","value":"McLellan,
+        Evelyn"},"datasetContactEmail":{"typeName":"datasetContactEmail","multiple":false,"typeClass":"primitive","value":"info@artefactual.com"}}]},{"typeName":"dsDescription","multiple":true,"typeClass":"compound","value":[{"dsDescriptionValue":{"typeName":"dsDescriptionValue","multiple":false,"typeClass":"primitive","value":"This
+        study tests the types of metadata that are exported from Dataverse and how
+        they can be mapped to standard schemas."},"dsDescriptionDate":{"typeName":"dsDescriptionDate","multiple":false,"typeClass":"primitive","value":"2015-08-24"}}]},{"typeName":"subject","multiple":true,"typeClass":"controlledVocabulary","value":["Computer
+        and Information Science"]},{"typeName":"depositor","multiple":false,"typeClass":"primitive","value":"McLellan,
+        Evelyn"},{"typeName":"dateOfDeposit","multiple":false,"typeClass":"primitive","value":"2015-08-24"}]}},"files":[{"description":"Lake
+        Chelan North side launch.","label":"chelan 052.jpg","version":1,"datasetVersionId":40,"datafile":{"id":92,"name":"chelan
+        052.jpg","contentType":"image/jpeg","filename":"14f608c3f9e-b80e0b388755","originalFormatLabel":"UNKNOWN","md5":"c77cea64f072d317bf7a9c8a9ed03b0f","description":"Lake
+        Chelan North side launch."}},{"description":"YVR weather data information
+        for Jan - June 2015","label":"Weather_data.tab","version":2,"datasetVersionId":40,"datafile":{"id":91,"name":"Weather_data.tab","contentType":"text/tab-separated-values","filename":"14f60894788-dc91b9fdb34b","originalFileFormat":"application/x-spss-sav","originalFormatLabel":"SPSS
+        SAV","UNF":"UNF:6:r5Z8n0CKSeRcAvjcTINpmQ==","md5":"755a502c757e1e2aa4bcaebd687fa102","description":"YVR
+        weather data information for Jan - June 2015"}}]}}}'}
+    headers:
+      connection: [close]
+      content-length: ['2673']
+      content-type: [application/json]
+      date: ['Wed, 16 Sep 2015 01:01:23 GMT']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-43-generic]
+    method: GET
+    uri: https://apitest.dataverse.org/api/access/datafile/92?key=testkeys-77a8-49a3-874e-be1148e7c970
+  response:
+    body:
+      string: !!python/unicode chelen 052
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [close]
+      content-disposition: [attachment; filename="chelan 052.jpg"]
+      content-length: ['76934']
+      content-type: [image/jpeg; name="chelan 052.jpg"]
+      date: ['Wed, 16 Sep 2015 01:01:23 GMT']
+      set-cookie: [JSESSIONID=3ab9d548095e90573a4bf5672ce8; Path=/; Secure; HttpOnly]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-43-generic]
+    method: GET
+    uri: https://apitest.dataverse.org/api/access/datafile/bundle/91?key=testkeys-77a8-49a3-874e-be1148e7c970
+  response:
+    body:
+      string: !!python/unicode Test bundle
+    headers:
+      connection: [close]
+      content-disposition: [attachment; filename="Weather_data-bundle.zip"]
+      content-type: [application/zip; name="Weather_data-bundle.zip"]
+      date: ['Wed, 16 Sep 2015 01:01:24 GMT']
+      set-cookie: [JSESSIONID=3aba03f86b1676161f9710ba4595; Path=/; Secure; HttpOnly]
+    status: {code: 200, message: OK}
+version: 1

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -94,7 +94,7 @@ class ArkivumForm(forms.ModelForm):
 class DataverseForm(forms.ModelForm):
     class Meta:
         model = models.Dataverse
-        fields = ('host', 'api_key')
+        fields = ('host', 'api_key', 'agent_name', 'agent_type', 'agent_identifier')
 
 
 class DuracloudForm(forms.ModelForm):

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -91,6 +91,12 @@ class ArkivumForm(forms.ModelForm):
         fields = ('host', 'remote_user', 'remote_name')
 
 
+class DataverseForm(forms.ModelForm):
+    class Meta:
+        model = models.Dataverse
+        fields = ('host', 'api_key')
+
+
 class DuracloudForm(forms.ModelForm):
     class Meta:
         model = models.Duracloud

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -96,6 +96,13 @@ class DataverseForm(forms.ModelForm):
         model = models.Dataverse
         fields = ('host', 'api_key', 'agent_name', 'agent_type', 'agent_identifier')
 
+    def as_p(self):
+        # Add a warning to the Dataverse-specific section of the form
+        # FIXME this may not be the best way to add Space-specific warnings
+        content = super(DataverseForm, self).as_p()
+        content += '\n<div class="alert">Integration with Dataverse is currently a beta feature</div>'
+        return content
+
 
 class DuracloudForm(forms.ModelForm):
     class Meta:

--- a/storage_service/locations/migrations/0007_dataverse.py
+++ b/storage_service/locations/migrations/0007_dataverse.py
@@ -17,6 +17,9 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('host', models.CharField(help_text=b'Hostname of the Dataverse instance. Eg. apitest.dataverse.org', max_length=256)),
                 ('api_key', models.CharField(help_text=b'API key for Dataverse instance. Eg. b84d6b87-7b1e-4a30-a374-87191dbbbe2d', max_length=50)),
+                ('agent_name', models.CharField(help_text=b'Agent name for premis:agentName in Archivematica', max_length=50)),
+                ('agent_type', models.CharField(help_text=b'Agent type for premis:agentType in Archivematica', max_length=50)),
+                ('agent_identifier', models.CharField(help_text=b'URI agent identifier for premis:agentIdentifierValue in Archivematica', max_length=256)),
                 ('space', models.OneToOneField(to='locations.Space', to_field=b'uuid')),
             ],
             options={

--- a/storage_service/locations/migrations/0007_dataverse.py
+++ b/storage_service/locations/migrations/0007_dataverse.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locations', '0006_package_related_packages'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Dataverse',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('host', models.CharField(help_text=b'Hostname of the Dataverse instance. Eg. apitest.dataverse.org', max_length=256)),
+                ('api_key', models.CharField(help_text=b'API key for Dataverse instance. Eg. b84d6b87-7b1e-4a30-a374-87191dbbbe2d', max_length=50)),
+                ('space', models.OneToOneField(to='locations.Space', to_field=b'uuid')),
+            ],
+            options={
+                'verbose_name': 'Dataverse',
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AlterField(
+            model_name='space',
+            name='access_protocol',
+            field=models.CharField(help_text=b'How the space can be accessed.', max_length=8, choices=[(b'ARKIVUM', b'Arkivum'), (b'DV', b'Dataverse'), (b'DC', b'DuraCloud'), (b'FEDORA', b'FEDORA via SWORD2'), (b'FS', b'Local Filesystem'), (b'LOM', b'LOCKSS-o-matic'), (b'NFS', b'NFS'), (b'PIPE_FS', b'Pipeline Local Filesystem'), (b'SWIFT', b'Swift')]),
+            preserve_default=True,
+        ),
+    ]

--- a/storage_service/locations/models/__init__.py
+++ b/storage_service/locations/models/__init__.py
@@ -21,6 +21,7 @@ from space import *
 # Protocol Spaces
 # Will only have one model, so import that directly
 from arkivum import Arkivum
+from dataverse import Dataverse
 from duracloud import Duracloud
 from fedora import Fedora, PackageDownloadTask, PackageDownloadTaskFile
 from local_filesystem import LocalFilesystem

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -1,15 +1,18 @@
 # stdlib, alphabetical
+import json
 import logging
 
 # Core Django, alphabetical
 from django.db import models
 
 # Third party dependencies, alphabetical
+import requests
 
 # This project, alphabetical
 LOGGER = logging.getLogger(__name__)
 
 # This module, alphabetical
+from . import StorageException
 from location import Location
 
 
@@ -19,6 +22,7 @@ class Dataverse(models.Model):
         help_text='Hostname of the Dataverse instance. Eg. apitest.dataverse.org')
     api_key = models.CharField(max_length=50,
         help_text='API key for Dataverse instance. Eg. b84d6b87-7b1e-4a30-a374-87191dbbbe2d')
+    # FIXME disallow string in space.path
 
     class Meta:
         verbose_name = "Dataverse"
@@ -29,7 +33,54 @@ class Dataverse(models.Model):
     ]
 
     def browse(self, path):
-        pass
+        """
+        Fetch a list of datasets from Dataverse based on the query in the location path.
+
+        Datasets are considered directories when browsing.
+        """
+        # Use http://guides.dataverse.org/en/latest/api/search.html to search and return datasets
+        # Location path is query string
+        # FIXME only browse one layer deep
+        url = 'https://' + self.host + '/api/search/'
+        params = {
+            'key': self.api_key,
+            'q': path,
+            'type': 'dataset',
+            'sort': 'name',
+            'order': 'asc',
+            'start': 0,
+            'per_page': 10,
+            'show_entity_ids': True,
+        }
+        entries = []
+        properties = {}
+        while True:
+            LOGGER.debug('URL: %s, params: %s', url, params)
+            response = requests.get(url, params=params)
+            LOGGER.debug('Response: %s', response)
+            if response.status_code != 200:
+                LOGGER.warning('%s: Response: %s', response, response.text)
+                raise StorageException('Unable to fetch datasets from %s with query %s' % (url, path))
+            try:
+                data = response.json()['data']
+            except json.JSONDecodeError:
+                LOGGER.error('Could not parse JSON from response to %s', url)
+                raise StorageException('Unable parse JSON from response to %s with query %s' % (url, path))
+
+            # WARNING 'name' is not unique - may generate incorrect properties
+            entries += [x['name'] for x in data['items']]
+
+            if params['start'] + data['count_in_response'] < data['total_count']:
+                params['start'] += data['count_in_response']
+            else:
+                break
+
+        directories = entries
+        return {
+            'directories': directories,
+            'entries': entries,
+            'properties': properties,
+        }
 
     def move_to_storage_service(self, src_path, dest_path, dest_space):
         """ Moves src_path to dest_space.staging_path/dest_path. """

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -1,0 +1,36 @@
+# stdlib, alphabetical
+import logging
+
+# Core Django, alphabetical
+from django.db import models
+
+# Third party dependencies, alphabetical
+
+# This project, alphabetical
+LOGGER = logging.getLogger(__name__)
+
+# This module, alphabetical
+from location import Location
+
+
+class Dataverse(models.Model):
+    space = models.OneToOneField('Space', to_field='uuid')
+    host = models.CharField(max_length=256,
+        help_text='Hostname of the Dataverse instance. Eg. apitest.dataverse.org')
+    api_key = models.CharField(max_length=50,
+        help_text='API key for Dataverse instance. Eg. b84d6b87-7b1e-4a30-a374-87191dbbbe2d')
+
+    class Meta:
+        verbose_name = "Dataverse"
+        app_label = 'locations'
+
+    ALLOWED_LOCATION_PURPOSE = [
+        Location.TRANSFER_SOURCE,
+    ]
+
+    def browse(self, path):
+        pass
+
+    def move_to_storage_service(self, src_path, dest_path, dest_space):
+        """ Moves src_path to dest_space.staging_path/dest_path. """
+        pass

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -23,6 +23,12 @@ class Dataverse(models.Model):
         help_text='Hostname of the Dataverse instance. Eg. apitest.dataverse.org')
     api_key = models.CharField(max_length=50,
         help_text='API key for Dataverse instance. Eg. b84d6b87-7b1e-4a30-a374-87191dbbbe2d')
+    agent_name = models.CharField(max_length=50,
+        help_text='Agent name for premis:agentName in Archivematica')
+    agent_type = models.CharField(max_length=50,
+        help_text='Agent type for premis:agentType in Archivematica')
+    agent_identifier = models.CharField(max_length=256,
+        help_text='URI agent identifier for premis:agentIdentifierValue in Archivematica')
     # FIXME disallow string in space.path
 
     class Meta:
@@ -139,3 +145,17 @@ class Dataverse(models.Model):
             LOGGER.debug('Response: %s', response)
             with open(download_path, 'wb') as f:
                 f.write(response.content)
+
+        # Add Agent info
+        agent_info = [
+            {
+                'agentIdentifierType': 'URI',
+                'agentIdentifierValue': self.agent_identifier,
+                'agentName': self.agent_name,
+                'agentType': self.agent_type,
+            }
+        ]
+        os.mkdir(os.path.join(dest_path, 'metadata'))
+        agentjson_path = os.path.join(dest_path, 'metadata', 'agents.json')
+        with open(agentjson_path, 'w') as f:
+            json.dump(agent_info, f)

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -125,8 +125,9 @@ class Dataverse(models.Model):
         # Create directories
         self.space.create_local_directory(dest_path)
 
-        # Write out dataset info as dataset.json
-        datasetjson_path = os.path.join(dest_path, 'dataset.json')
+        # Write out dataset info as dataset.json to the metadata directory
+        os.makedirs(os.path.join(dest_path, 'metadata'))
+        datasetjson_path = os.path.join(dest_path, 'metadata', 'dataset.json')
         with open(datasetjson_path, 'w') as f:
             json.dump(dataset, f)
 
@@ -155,7 +156,6 @@ class Dataverse(models.Model):
                 'agentType': self.agent_type,
             }
         ]
-        os.mkdir(os.path.join(dest_path, 'metadata'))
         agentjson_path = os.path.join(dest_path, 'metadata', 'agents.json')
         with open(agentjson_path, 'w') as f:
             json.dump(agent_info, f)

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -39,6 +39,8 @@ class Dataverse(models.Model):
 
         Datasets are considered directories when browsing.
         """
+        # Remove things earlier layers added
+        path = path.rstrip('/')
         # Use http://guides.dataverse.org/en/latest/api/search.html to search and return datasets
         # Location path is query string
         # FIXME only browse one layer deep
@@ -91,6 +93,9 @@ class Dataverse(models.Model):
         """
         Fetch dataset with ID `src_path` to dest_space.staging_path/dest_path.
         """
+        # TODO how to strip location path if location isn't passed in?
+        # HACK strip everything that isn't a number
+        src_path = ''.join(c for c in src_path if c.isdigit())
         # Verify src_path has to be a number
         if not src_path.isdigit():
             raise StorageException('Invalid value for src_path: %s. Must be a numberic entity_id' % src_path)

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -67,8 +67,12 @@ class Dataverse(models.Model):
                 LOGGER.error('Could not parse JSON from response to %s', url)
                 raise StorageException('Unable parse JSON from response to %s with query %s' % (url, path))
 
-            # WARNING 'name' is not unique - may generate incorrect properties
-            entries += [x['name'] for x in data['items']]
+            entries += [str(x['entity_id']) for x in data['items']]
+
+            properties.update({
+                str(x['entity_id']): {'verbose name': x['name']}
+                for x in data['items']
+            })
 
             if params['start'] + data['count_in_response'] < data['total_count']:
                 params['start'] += data['count_in_response']

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -87,7 +87,9 @@ class Space(models.Model):
     uuid = UUIDField(editable=False, unique=True, version=4,
         help_text="Unique identifier")
 
+    # Max length 8 (see access_protocol definition)
     ARKIVUM = 'ARKIVUM'
+    DATAVERSE = 'DV'
     DURACLOUD = 'DC'
     FEDORA = 'FEDORA'
     LOCAL_FILESYSTEM = 'FS'
@@ -95,9 +97,10 @@ class Space(models.Model):
     NFS = 'NFS'
     PIPELINE_LOCAL_FS = 'PIPE_FS'
     SWIFT = 'SWIFT'
-    OBJECT_STORAGE = {DURACLOUD, SWIFT}
+    OBJECT_STORAGE = {DATAVERSE, DURACLOUD, SWIFT}
     ACCESS_PROTOCOL_CHOICES = (
         (ARKIVUM, 'Arkivum'),
+        (DATAVERSE, 'Dataverse'),
         (DURACLOUD, 'DuraCloud'),
         (FEDORA, "FEDORA via SWORD2"),
         (LOCAL_FILESYSTEM, "Local Filesystem"),

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -181,6 +181,7 @@ class Space(models.Model):
         'size': Size of the object
         'object count': Number of objects in the directory, including children
         'timestamp': Last modified timestamp.
+        'verbose name': Verbose name of the object
         See each Space's browse for details.
 
         :param str path: Full path to return info for

--- a/storage_service/locations/tests/test_dataverse.py
+++ b/storage_service/locations/tests/test_dataverse.py
@@ -77,8 +77,8 @@ class TestDataverse(TestCase):
         """
         assert os.path.exists(self.dest_path) is False
         self.dataverse.space.move_to_storage_service('90', 'dataverse/', self.space)
-        assert 'dataset.json' in os.listdir(self.dest_path)
         assert 'chelan 052.jpg' in os.listdir(self.dest_path)
         assert 'Weather_data.zip' in os.listdir(self.dest_path)
         assert 'metadata' in os.listdir(self.dest_path)
         assert 'agents.json' in os.listdir(os.path.join(self.dest_path, 'metadata'))
+        assert 'dataset.json' in os.listdir(os.path.join(self.dest_path, 'metadata'))

--- a/storage_service/locations/tests/test_dataverse.py
+++ b/storage_service/locations/tests/test_dataverse.py
@@ -80,3 +80,5 @@ class TestDataverse(TestCase):
         assert 'dataset.json' in os.listdir(self.dest_path)
         assert 'chelan 052.jpg' in os.listdir(self.dest_path)
         assert 'Weather_data.zip' in os.listdir(self.dest_path)
+        assert 'metadata' in os.listdir(self.dest_path)
+        assert 'agents.json' in os.listdir(os.path.join(self.dest_path, 'metadata'))

--- a/storage_service/locations/tests/test_dataverse.py
+++ b/storage_service/locations/tests/test_dataverse.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase
+import os
+import vcr
+
+from locations import models
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+FIXTURES_DIR = os.path.abspath(os.path.join(THIS_DIR, '..', 'fixtures'))
+
+class TestDataverse(TestCase):
+
+    fixtures = ['base.json', 'dataverse.json']
+
+    def setUp(self):
+        self.dataverse = models.Dataverse.objects.all()[0]
+
+    def test_has_required_attributes(self):
+        assert self.dataverse.host
+        assert self.dataverse.api_key

--- a/storage_service/locations/tests/test_dataverse.py
+++ b/storage_service/locations/tests/test_dataverse.py
@@ -14,7 +14,39 @@ class TestDataverse(TestCase):
 
     def setUp(self):
         self.dataverse = models.Dataverse.objects.all()[0]
+        self.dataverse_location = models.Location.objects.get(space=self.dataverse.space)
 
     def test_has_required_attributes(self):
         assert self.dataverse.host
         assert self.dataverse.api_key
+
+    @vcr.use_cassette(os.path.join(FIXTURES_DIR, 'vcr_cassettes', 'dataverse_browse_all.yaml'))
+    def test_browse_all(self):
+        """
+        It should fetch a list of datasets.
+        It should handle iteration.
+        """
+        resp = self.dataverse.browse('*')
+        assert len(resp['directories']) == 15
+        assert len(resp['entries']) == 15
+        assert resp['entries'] == resp['directories']
+        assert resp['entries'][0] == 'Ad hoc observational study of the trees outside my window'
+        assert resp['entries'][1] == 'Constitive leaf ORAC'
+        assert resp['entries'][14] == 'testjpg'
+        assert len(resp['properties']) == 0
+
+    @vcr.use_cassette(os.path.join(FIXTURES_DIR, 'vcr_cassettes', 'dataverse_browse_filter.yaml'))
+    def test_browse_filter(self):
+        """
+        It should fetch a list of datasets.
+        It should filter based on the provided query
+        """
+        resp = self.dataverse.browse('title:test*')
+        assert len(resp['directories']) == 4
+        assert len(resp['entries']) == 4
+        assert resp['entries'] == resp['directories']
+        assert resp['entries'][0] == 'Metadata mapping test study'
+        assert resp['entries'][1] == 'Restricted Studies Test'
+        assert resp['entries'][2] == 'testdocx'
+        assert resp['entries'][3] == 'testjpg'
+        assert len(resp['properties']) == 0

--- a/storage_service/locations/tests/test_dataverse.py
+++ b/storage_service/locations/tests/test_dataverse.py
@@ -30,10 +30,13 @@ class TestDataverse(TestCase):
         assert len(resp['directories']) == 15
         assert len(resp['entries']) == 15
         assert resp['entries'] == resp['directories']
-        assert resp['entries'][0] == 'Ad hoc observational study of the trees outside my window'
-        assert resp['entries'][1] == 'Constitive leaf ORAC'
-        assert resp['entries'][14] == 'testjpg'
-        assert len(resp['properties']) == 0
+        assert resp['entries'][0] == '82'
+        assert resp['entries'][1] == '25'
+        assert resp['entries'][14] == '14'
+        assert len(resp['properties']) == 15
+        assert resp['properties']['82']['verbose name'] == 'Ad hoc observational study of the trees outside my window'
+        assert resp['properties']['25']['verbose name'] == 'Constitive leaf ORAC'
+        assert resp['properties']['14']['verbose name'] == 'testjpg'
 
     @vcr.use_cassette(os.path.join(FIXTURES_DIR, 'vcr_cassettes', 'dataverse_browse_filter.yaml'))
     def test_browse_filter(self):
@@ -45,8 +48,12 @@ class TestDataverse(TestCase):
         assert len(resp['directories']) == 4
         assert len(resp['entries']) == 4
         assert resp['entries'] == resp['directories']
-        assert resp['entries'][0] == 'Metadata mapping test study'
-        assert resp['entries'][1] == 'Restricted Studies Test'
-        assert resp['entries'][2] == 'testdocx'
-        assert resp['entries'][3] == 'testjpg'
-        assert len(resp['properties']) == 0
+        assert resp['entries'][0] == '90'
+        assert resp['entries'][1] == '93'
+        assert resp['entries'][2] == '16'
+        assert resp['entries'][3] == '14'
+        assert len(resp['properties']) == 4
+        assert resp['properties']['90']['verbose name'] == 'Metadata mapping test study'
+        assert resp['properties']['93']['verbose name'] == 'Restricted Studies Test'
+        assert resp['properties']['16']['verbose name'] == 'testdocx'
+        assert resp['properties']['14']['verbose name'] == 'testjpg'


### PR DESCRIPTION
- Transfer Source only
- Space.path should be empty
- Location.path is a search query for Dataverse
- Saves the dataset information as `dataset.json`
- Reads the `dataset.json` to fetch all the files in the dataset
  *\* Tabfiles are the access copies of the original, so fetch the original as a bundle
- Dataverse Agent info is written as an `agents.json`
