### PR TITLE
Mark public Space methods as public

### DIFF
--- a/storage_service/locations/models/arkivum.py
+++ b/storage_service/locations/models/arkivum.py
@@ -51,9 +51,9 @@ class Arkivum(models.Model):
         if self.remote_user and self.remote_name:
             path = os.path.join(path, '')
             ssh_path = "{}@{}:{}".format(self.remote_user, self.remote_name, utils.coerce_str(path))
-            return self.space._browse_rsync(ssh_path)
+            return self.space.browse_rsync(ssh_path)
         else:
-            return self.space._browse_local(path)
+            return self.space.browse_local(path)
 
     def delete_path(self, delete_path):
         # Can this be done by just deleting the file on disk?
@@ -74,19 +74,19 @@ class Arkivum(models.Model):
                 user=self.remote_user,
                 host=self.remote_name,
                 path=src_path)
-        self.space._create_local_directory(dest_path)
-        self.space._move_rsync(src_path, dest_path)
+        self.space.create_local_directory(dest_path)
+        self.space.move_rsync(src_path, dest_path)
 
     def move_from_storage_service(self, source_path, destination_path):
         """ Moves self.staging_path/src_path to dest_path. """
         # Rsync to Arkivum watched directory
         if self.remote_user and self.remote_name:
-            self.space._create_rsync_directory(destination_path, self.remote_user, self.remote_name)
+            self.space.create_rsync_directory(destination_path, self.remote_user, self.remote_name)
             rsync_dest = "{}@{}:{}".format(self.remote_user, self.remote_name, utils.coerce_str(destination_path))
         else:
             rsync_dest = destination_path
-            self.space._create_local_directory(destination_path)
-        self.space._move_rsync(source_path, rsync_dest)
+            self.space.create_local_directory(destination_path)
+        self.space.move_rsync(source_path, rsync_dest)
 
     def post_move_from_storage_service(self, staging_path, destination_path, package):
         """ POST to Arkivum with information about the newly stored Package. """

--- a/storage_service/locations/models/duracloud.py
+++ b/storage_service/locations/models/duracloud.py
@@ -197,7 +197,7 @@ class Duracloud(models.Model):
             checksum = root.findtext('header/sourceContent/md5')
             chunk_elements = [e for e in root.findall('chunks/chunk')]
             # Download each chunk and append to original file
-            self.space._create_local_directory(download_path)
+            self.space.create_local_directory(download_path)
             LOGGER.debug('Writing to %s', download_path)
             with open(download_path, 'wb') as output_f:
                 for e in chunk_elements:
@@ -221,7 +221,7 @@ class Duracloud(models.Model):
             LOGGER.warning('Response text: %s', response.text)
             raise StorageException('Unable to fetch %s' % url)
         else:  # Status code 200 - file exists
-            self.space._create_local_directory(download_path)
+            self.space.create_local_directory(download_path)
             LOGGER.debug('Writing to %s', download_path)
             with open(download_path, 'wb') as f:
                 f.write(response.content)

--- a/storage_service/locations/models/local_filesystem.py
+++ b/storage_service/locations/models/local_filesystem.py
@@ -34,13 +34,13 @@ class LocalFilesystem(models.Model):
     def move_to_storage_service(self, src_path, dest_path, dest_space):
         """ Moves src_path to dest_space.staging_path/dest_path. """
         # Archivematica expects the file to still be on disk even after stored
-        self.space._create_local_directory(dest_path)
-        return self.space._move_rsync(src_path, dest_path)
+        self.space.create_local_directory(dest_path)
+        return self.space.move_rsync(src_path, dest_path)
 
     def move_from_storage_service(self, source_path, destination_path):
         """ Moves self.staging_path/src_path to dest_path. """
-        self.space._create_local_directory(destination_path)
-        return self.space._move_rsync(source_path, destination_path)
+        self.space.create_local_directory(destination_path)
+        return self.space.move_rsync(source_path, destination_path)
 
     def verify(self):
         """ Verify that the space is accessible to the storage service. """

--- a/storage_service/locations/models/lockssomatic.py
+++ b/storage_service/locations/models/lockssomatic.py
@@ -68,8 +68,8 @@ class Lockssomatic(models.Model):
 
     def move_from_storage_service(self, source_path, destination_path):
         """ Moves self.staging_path/source_path to destination_path. """
-        self.space._create_local_directory(destination_path)
-        return self.space._move_rsync(source_path, destination_path)
+        self.space.create_local_directory(destination_path)
+        return self.space.move_rsync(source_path, destination_path)
 
     def post_move_from_storage_service(self, staging_path, destination_path, package):
         # LOCKSS can only save packages in the storage service, since it needs

--- a/storage_service/locations/models/nfs.py
+++ b/storage_service/locations/models/nfs.py
@@ -44,8 +44,8 @@ class NFS(models.Model):
 
     def move_to_storage_service(self, src_path, dest_path, dest_space):
         """ Moves src_path to dest_space.staging_path/dest_path. """
-        self.space._create_local_directory(dest_path)
-        return self.space._move_rsync(src_path, dest_path)
+        self.space.create_local_directory(dest_path)
+        return self.space.move_rsync(src_path, dest_path)
 
     def post_move_to_storage_service(self, *args, **kwargs):
         # TODO delete original file?
@@ -54,8 +54,8 @@ class NFS(models.Model):
     def move_from_storage_service(self, source_path, destination_path):
         """ Moves self.staging_path/src_path to dest_path. """
         # TODO optimization - check if the staging path and destination path are on the same device and use os.rename/self.space._move_locally if so
-        self.space._create_local_directory(destination_path)
-        return self.space._move_rsync(source_path, destination_path)
+        self.space.create_local_directory(destination_path)
+        return self.space.move_rsync(source_path, destination_path)
 
     def save(self, *args, **kwargs):
         self.verify()

--- a/storage_service/locations/models/pipeline_local.py
+++ b/storage_service/locations/models/pipeline_local.py
@@ -58,7 +58,7 @@ class PipelineLocalFS(models.Model):
     def browse(self, path):
         path = os.path.join(path, '')
         ssh_path = self._format_host_path(path)
-        return self.space._browse_rsync(ssh_path)
+        return self.space.browse_rsync(ssh_path)
 
     def delete_path(self, delete_path):
         # Sync from an empty directory to delete the contents of delete_path;
@@ -101,8 +101,8 @@ class PipelineLocalFS(models.Model):
         #         raise
         # else:
         src_path = self._format_host_path(src_path)
-        self.space._create_local_directory(dest_path)
-        return self.space._move_rsync(src_path, dest_path)
+        self.space.create_local_directory(dest_path)
+        return self.space.move_rsync(src_path, dest_path)
 
     def post_move_to_storage_service(self, *args, **kwargs):
         # TODO delete original file?
@@ -111,10 +111,10 @@ class PipelineLocalFS(models.Model):
     def move_from_storage_service(self, source_path, destination_path):
         """ Moves self.staging_path/src_path to dest_path. """
 
-        self.space._create_rsync_directory(destination_path, self.remote_user, self.remote_name)
+        self.space.create_rsync_directory(destination_path, self.remote_user, self.remote_name)
 
         # Prepend user and host to destination
         destination_path = self._format_host_path(destination_path)
 
         # Move file
-        return self.space._move_rsync(source_path, destination_path)
+        return self.space.move_rsync(source_path, destination_path)

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -188,7 +188,7 @@ class Space(models.Model):
             return self.get_child_space().browse(path, *args, **kwargs)
         except AttributeError:
             LOGGER.debug('Falling back to default browse local', exc_info=False)
-            return self._browse_local(path)
+            return self.browse_local(path)
 
     def delete_path(self, delete_path, *args, **kwargs):
         """
@@ -359,16 +359,16 @@ class Space(models.Model):
         LOGGER.info("Moving from %s to %s", source_path, destination_path)
 
         # Create directories
-        self._create_local_directory(destination_path, mode)
+        self.create_local_directory(destination_path, mode)
 
         # Move the file
         os.rename(source_path, destination_path)
 
-    def _move_rsync(self, source, destination):
+    def move_rsync(self, source, destination):
         """ Moves a file from source to destination using rsync.
 
         All directories leading to destination must exist.
-        Space._create_local_directory may be useful.
+        Space.create_local_directory may be useful.
         """
         source = utils.coerce_str(source)
         destination = utils.coerce_str(destination)
@@ -389,7 +389,7 @@ class Space(models.Model):
             LOGGER.warning(s)
             raise StorageException(s)
 
-    def _create_local_directory(self, path, mode=None):
+    def create_local_directory(self, path, mode=None):
         """
         Creates directory structure for `path` with `mode` (default 775).
         :param path: path to create the directories for.  Should end with a / or
@@ -421,7 +421,7 @@ class Space(models.Model):
         except os.error as e:
             LOGGER.warning(e)
 
-    def _create_rsync_directory(self, destination_path, user, host):
+    def create_rsync_directory(self, destination_path, user, host):
         """
         Creates a remote directory structure for destination_path.
 
@@ -470,7 +470,7 @@ class Space(models.Model):
                 return '5000+'
         return total_files
 
-    def _browse_local(self, path):
+    def browse_local(self, path):
         """
         Returns browse results for a locally accessible filesystem.
 
@@ -496,7 +496,7 @@ class Space(models.Model):
                 properties[name]['object count'] = self._count_objects_in_directory(full_path)
         return {'directories': directories, 'entries': entries, 'properties': properties}
 
-    def _browse_rsync(self, path, ssh_key=None):
+    def browse_rsync(self, path, ssh_key=None):
         """
         Returns browse results for a ssh (rsync) accessible space.
 

--- a/storage_service/locations/models/swift.py
+++ b/storage_service/locations/models/swift.py
@@ -130,7 +130,7 @@ class Swift(models.Model):
         """
         # TODO find a way to stream content to dest_path, instead of having to put it in memory
         headers, content = self.connection.get_object(self.container, remote_path)
-        self.space._create_local_directory(download_path)
+        self.space.create_local_directory(download_path)
         with open(download_path, 'wb') as f:
             f.write(content)
         # Check ETag matches checksum of this file


### PR DESCRIPTION
Several instance methods of Space were marked as being public, but were primarily, or entirely, called by outside objects. This changes their names to mark them as public.
