### PR TITLE
Space: Optionally try os.rename in move_rsync

### DIFF
--- a/storage_service/locations/models/arkivum.py
+++ b/storage_service/locations/models/arkivum.py
@@ -82,6 +82,7 @@ class Arkivum(models.Model):
 
     def move_from_storage_service(self, source_path, destination_path):
         """ Moves self.staging_path/src_path to dest_path. """
+        try_mv_local = False
         # Rsync to Arkivum watched directory
         if self.remote_user and self.remote_name:
             self.space.create_rsync_directory(destination_path, self.remote_user, self.remote_name)
@@ -89,7 +90,8 @@ class Arkivum(models.Model):
         else:
             rsync_dest = destination_path
             self.space.create_local_directory(destination_path)
-        self.space.move_rsync(source_path, rsync_dest)
+            try_mv_local = True
+        self.space.move_rsync(source_path, rsync_dest, try_mv_local=try_mv_local)
 
     def post_move_from_storage_service(self, staging_path, destination_path, package):
         """ POST to Arkivum with information about the newly stored Package. """

--- a/storage_service/locations/models/local_filesystem.py
+++ b/storage_service/locations/models/local_filesystem.py
@@ -40,7 +40,7 @@ class LocalFilesystem(models.Model):
     def move_from_storage_service(self, source_path, destination_path):
         """ Moves self.staging_path/src_path to dest_path. """
         self.space.create_local_directory(destination_path)
-        return self.space.move_rsync(source_path, destination_path)
+        return self.space.move_rsync(source_path, destination_path, try_mv_local=True)
 
     def verify(self):
         """ Verify that the space is accessible to the storage service. """

--- a/storage_service/locations/models/nfs.py
+++ b/storage_service/locations/models/nfs.py
@@ -53,9 +53,8 @@ class NFS(models.Model):
 
     def move_from_storage_service(self, source_path, destination_path):
         """ Moves self.staging_path/src_path to dest_path. """
-        # TODO optimization - check if the staging path and destination path are on the same device and use os.rename/self.space._move_locally if so
         self.space.create_local_directory(destination_path)
-        return self.space.move_rsync(source_path, destination_path)
+        return self.space.move_rsync(source_path, destination_path, try_mv_local=True)
 
     def save(self, *args, **kwargs):
         self.verify()


### PR DESCRIPTION
Add try_mv_local flag to move_rsync. If true, it will try to os.rename source to destination, possibly normalizing the path. This will do a move, not a copy like rsync does by default. This will fail in several cases, notably if crossing filesystem boundaries, and falls back to the normal rsync.

move_from_storage_service calls that use move_rsync locally have been updated to use try_mv_local.
