### PR TITLE
Package: disable smart strings for xpath() calls

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -660,7 +660,7 @@ class Package(models.Model):
             # If the filename has been sanitized, the path in the fileSec
             # may be outdated; check for a cleanup event and use that,
             # if present.
-            cleanup_events = mets.xpath('m:amdSec[@ID="digiprov-{}"]/m:digiprovMD/m:mdWrap/m:xmlData/p:event/p:eventType[text()="name cleanup"]/../p:eventOutcomeInformation/p:eventOutcomeDetail/p:eventOutcomeDetailNote/text()'.format(uuid), namespaces=namespaces)
+            cleanup_events = mets.xpath('m:amdSec[@ID="digiprov-{}"]/m:digiprovMD/m:mdWrap/m:xmlData/p:event/p:eventType[text()="name cleanup"]/../p:eventOutcomeInformation/p:eventOutcomeDetail/p:eventOutcomeDetailNote/text()'.format(uuid), namespaces=namespaces, smart_strings=False)
             if cleanup_events:
                 cleaned_up_name = re.match(r'.*cleaned up name="(.*)"$', cleanup_events[0])
                 if cleaned_up_name:


### PR DESCRIPTION
lxml's xpath() method returns "smart strings" if the XPath expression returns a string, for example if the expression terminates in text(). These smart strings are extended from the core types by including getparent() methods which know their originating element:
http://lxml.de/xpathxslt.html

This has a couple of disadvantages:
1. Memory performance is worse, since it means that the tree is being unnecessarily kept in memory even if it's not being used.
2. When using PyPy and lxml before 3.5.0, PyPy will crash with a stack overflow: http://permalink.gmane.org/gmane.comp.python.lxml.devel/7572

Since we're not using the extra behaviour of these strings, it's better for us to disable it and just return a raw string.
