### PR TITLE
Requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ Django>=1.7,<1.8
 django-braces==1.0.0
 django-model-utils==1.3.1
 logutils==0.3.3
-django-tastypie>=0.12.0
+django-tastypie==0.13.1
 django-extensions==1.1.1
 lxml==3.2.3
 django-jsonfield==0.9.12

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,20 +1,20 @@
 # Base requirements - for all installations
-Django>=1.7,<1.8
-django-braces==1.0.0
-django-model-utils==1.3.1
-logutils==0.3.3
-django-tastypie==0.13.1
-django-extensions==1.1.1
-lxml==3.2.3
-django-jsonfield==0.9.12
 bagit==1.5.0
+Django>=1.7,<1.8
 django-annoying==0.7.7
-requests>=2.3.0
+django-braces==1.0.0
+django-extensions==1.1.1
+django-jsonfield==0.9.12
+django-model-utils==1.3.1
+django-tastypie==0.13.1
 #httplib2 is a dependency of sword2
 httplib2
-sword2
-python-keystoneclient==1.8.1
-python-swiftclient==2.4.0
-pyopenssl
+logutils==0.3.3
+lxml==3.2.3
 ndg-httpsclient
 pyasn1
+pyopenssl
+python-keystoneclient==1.8.1
+python-swiftclient==2.4.0
+requests>=2.3.0
+sword2

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,8 +1,5 @@
 # Local development dependencies go here
 -r base.txt
-coverage==3.6
-django-discover-runner==0.4
-django-debug-toolbar==0.9.4
 ipython==1.1.0
 gunicorn==19.4.1
 Sphinx==1.2b1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,6 +3,6 @@
 coverage==3.6
 django-discover-runner==0.4
 django-debug-toolbar==0.9.4
-Sphinx==1.2b1
 ipython==1.1.0
 gunicorn==19.4.1
+Sphinx==1.2b1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,5 @@
 # Test dependencies go here.
 -r base.txt
-coverage==3.6
-django-discover-runner==0.4
 pytest
 pytest-django
 vcrpy>=1.0.0


### PR DESCRIPTION
Tastypie 0.13.2 has a bug in it, pinning the tastpie version to before that.  Also removed some unused test/dev reqs and sorted alphabetically to reduce duplicates.

The specific error that the bug gave was:

```
ERROR     2016-02-15 16:33:51  django.request:base:handle_uncaught_exception:231:  Internal Server Error: /login/
Traceback (most recent call last):
  File "/usr/share/python/archivematica-storage-service/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 98, in get_response
    resolver_match = resolver.resolve(request.path_info)
  File "/usr/share/python/archivematica-storage-service/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 343, in resolve
    for pattern in self.url_patterns:
  File "/usr/share/python/archivematica-storage-service/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 372, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/usr/share/python/archivematica-storage-service/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 366, in urlconf_module
    self._urlconf_module = import_module(self.urlconf_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "./storage_service/urls.py", line 8, in <module>
    import locations.api.urls
  File "./locations/api/urls.py", line 3, in <module>
    from locations.api import v1, v2
  File "./locations/api/v1.py", line 1, in <module>
    import locations.api.resources as resources
  File "./locations/api/resources.py", line 391, in <module>
    class PackageResource(ModelResource):
  File "/usr/share/python/archivematica-storage-service/local/lib/python2.7/site-packages/tastypie/resources.py", line 1763, in __new__
    new_class = super(ModelDeclarativeMetaclass, cls).__new__(cls, name, bases, attrs)
  File "/usr/share/python/archivematica-storage-service/local/lib/python2.7/site-packages/tastypie/resources.py", line 168, in __new__
    field_object.contribute_to_class(new_class, field_name)
  File "/usr/share/python/archivematica-storage-service/local/lib/python2.7/site-packages/tastypie/fields.py", line 745, in contribute_to_class
    related_field = getattr(self._resource._meta.object_class, self.attribute, None)
TypeError: Error when calling the metaclass bases
    getattr(): attribute name must be string
```
