### PR TITLE
Requirements: add defused 0.4.1 (tastypie)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,6 @@
 # Base requirements - for all installations
 bagit==1.5.0
+defusedxml==0.4.1
 Django>=1.7,<1.8
 django-annoying==0.7.7
 django-braces==1.0.0


### PR DESCRIPTION
As of tastypie v0.9.13, XML serialization requires both defusedxml and lxml.
See http://django-tastypie.readthedocs.org/en/latest/release_notes/v0.9.13.html.
