### PR TITLE
Add gunicorn to production.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,7 @@ django-extensions==1.1.1
 django-jsonfield==0.9.12
 django-model-utils==1.3.1
 django-tastypie==0.13.1
+gunicorn==19.4.5
 #httplib2 is a dependency of sword2
 httplib2
 logutils==0.3.3

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,5 @@
 # Local development dependencies go here
 -r base.txt
+
 ipython==1.1.0
-gunicorn==19.4.1
 Sphinx==1.2b1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
 # Test dependencies go here.
 -r base.txt
+
 pytest
 pytest-django
 vcrpy>=1.0.0


### PR DESCRIPTION
We are using it in RPM installations and Docker. You may still not need it in today's production environments but the alternatives that we are building are also built off `production.txt`.

Still, it's harmless if you don't use it. So environments built with Ansible and others should be fine even if they end up installing gunicorn.

Related: https://github.com/artefactual-labs/am-packbuild/pull/2
