### PR TITLE
utils: serve files with http.FileResponse

### DIFF
--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -10,7 +10,6 @@ import shutil
 import uuid
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.servers.basehttp import FileWrapper
 from django import http
 
 from administration import models
@@ -100,8 +99,8 @@ def download_file_stream(filepath, temp_dir=None):
     filename = os.path.basename(filepath)
     extension = os.path.splitext(filepath)[1].lower()
 
-    wrapper = FileWrapper(file(filepath))
-    response = http.HttpResponse(wrapper)
+    # Open file in binary mode
+    response = http.FileResponse(open(filepath, 'rb'))
 
     # force download for certain filetypes
     extensions_to_download = ['.7z', '.zip']


### PR DESCRIPTION
FileResponse is a subclass of StreamingHttpResponse optimized for binary files.
It uses wsgi.file_wrapper if provided by the wsgi server, otherwise it streams
the file out in small chunks.

This class was added in Django 1.7. stable/0.7.x users will have to upgrade.

This may solve a problem where uWSGI processes crash with a timeout error.
