### PR TITLE
Locations: Associated with all enabled pipelines by default

### DIFF
--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -165,6 +165,8 @@ class LocationForm(forms.ModelForm):
             self.whitelist = all_
         blacklist = all_ - set(self.whitelist)
         self.fields['purpose'].widget.disabled_choices = blacklist
+        # Associated with all enabled pipelines by default
+        self.fields['pipeline'].initial = models.Pipeline.active.values_list('pk', flat=True)
 
     def clean(self):
         cleaned_data = super(LocationForm, self).clean()


### PR DESCRIPTION
This makes all pipelines selected by default when creating a Location.

It was unclear when there was only one item in the MultiSelectField if it was selected or not.  Select all pipelines by default, so even if it's unclear the expected behavior still happens.
