### PR TITLE
Migrations: only have one head

### DIFF
--- a/storage_service/locations/migrations/0006_package_related_packages.py
+++ b/storage_service/locations/migrations/0006_package_related_packages.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('locations', '0004_v0_7'),
+        ('locations', '0005_v0_8'),
     ]
 
     operations = [


### PR DESCRIPTION
Accidentally introduced two migrations as siblings when they should have been linearly dependent.
