### PR TITLE
sword: use shutil.move instead of os.rename

### DIFF
--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -409,4 +409,4 @@ def store_mets_data(mets_path, deposit, object_id):
     if os.path.exists(target):
         os.unlink(target)
 
-    os.rename(mets_path, target)
+    shutil.move(mets_path, target)


### PR DESCRIPTION
rename fails if src and dst are on different filesystems

https://docs.python.org/3/library/os.html#os.rename
