### PR TITLE
Run backfill_api_keys as part of postinst

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -51,7 +51,7 @@ fi
 
 /usr/share/python/archivematica-storage-service/bin/python manage.py migrate
 /usr/share/python/archivematica-storage-service/bin/python manage.py collectstatic --noinput
-
+/usr/share/python/archivematica-storage-service/bin/python manage.py backfill_api_keys
 
 echo "updating directory permissions"
 chown -R archivematica:archivematica /var/archivematica/storage-service


### PR DESCRIPTION
This avoids the need to regenerate ss api keys by hand when updating from 0.7
