### PR TITLE
SWORD: Save files in object ID directory

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -162,7 +162,6 @@ class SpaceResource(ModelResource):
     def prepend_urls(self):
         return [
             url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/browse%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('browse'), name="browse"),
-            url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/sword/collection%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('sword_collection'), name="sword_collection")
         ]
 
     # Is there a better place to add protocol-specific space info?

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -47,28 +47,28 @@ def deposit_list(location_uuid):
         status=models.Package.FINALIZED)
     return deposits
 
-"""
-Write HTTP request's body content to a file
-
-Return the number of bytes successfully written
-"""
 def write_file_from_request_body(request, file_path):
+    """
+    Write HTTP request's body content to a file.
+
+    Return the number of bytes successfully written
+    """
     bytes_written = 0
     new_file = open(file_path, 'ab')
     chunk = request.read()
-    if chunk != None:
+    if chunk is not None:
         new_file.write(chunk)
         bytes_written += len(chunk)
         chunk = request.read()
     new_file.close()
     return bytes_written
 
-"""
-Write HTTP request's body content to a temp file
-
-Return the temp file's path
-"""
 def write_request_body_to_temp_file(request):
+    """
+    Write HTTP request's body content to a temp file.
+
+    Return the temp file's path
+    """
     filehandle, temp_filepath = tempfile.mkstemp()
     write_file_from_request_body(request, temp_filepath)
     return temp_filepath
@@ -83,38 +83,39 @@ def parse_filename_from_content_disposition(header):
     filename = params.get('filename', '')
     return filename
 
-"""
-Pad a filename numerically, preserving the file extension, if it's a duplicate
-of an existing file. This function is recursive.
-
-Returns padded (if necessary) file path
-"""
 def pad_destination_filepath_if_it_already_exists(filepath, original=None, attempt=0):
-    if original == None:
+    """
+    Generate unique file paths.
+
+    Pad a filename numerically, preserving the file extension, if it's a duplicate of an existing file. This function is recursive.
+
+    Returns padded (if necessary) file path
+    """
+    if original is None:
         original = filepath
     attempt = attempt + 1
     if os.path.exists(filepath):
         return pad_destination_filepath_if_it_already_exists(original + '_' + str(attempt), original, attempt)
     return filepath
 
-"""
-Download a URL resource to a destination directory, using the response's
-Content-Disposition header, if available, to determine the destination
-filename (using the filename at the end of the URL otherwise)
-
-Returns filename of downloaded resource
-"""
 def download_resource(url, destination_path, filename=None, username=None, password=None):
-    LOGGER.info('downloading url: ' + url)
+    """
+    Download a resource.
+
+    Download a URL resource to a destination directory, using the response's Content-Disposition header, if available, to determine the destination filename (using the filename at the end of the URL otherwise)
+
+    Returns filename of downloaded resource
+    """
+    LOGGER.info('downloading url: %s', url)
     request = urllib2.Request(url)
 
-    if username != None and password != None:
+    if username is not None and password is not None:
         base64string = base64.encodestring('%s:%s' % (username, password)).replace('\n', '')
-        request.add_header("Authorization", "Basic %s" % base64string)   
+        request.add_header("Authorization", "Basic %s" % base64string)
 
     response = urllib2.urlopen(request)
     info = response.info()
-    if filename == None:
+    if filename is None:
         if 'content-disposition' in info:
             filename = parse_filename_from_content_disposition(info['content-disposition'])
         else:
@@ -417,6 +418,8 @@ def store_mets_data(mets_path, deposit, object_id):
     # There may be a previous METS file if the same file is being
     # re-transferred, so remove and update the METS in this case.
     if os.path.exists(target):
+        LOGGER.debug('Removing existing %s', target)
         os.unlink(target)
 
+    LOGGER.debug('Move METS file from %s to %s', mets_path, target)
     shutil.move(mets_path, target)

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -47,30 +47,15 @@ def deposit_list(location_uuid):
         status=models.Package.FINALIZED)
     return deposits
 
-def write_file_from_request_body(request, file_path):
-    """
-    Write HTTP request's body content to a file.
-
-    Return the number of bytes successfully written
-    """
-    bytes_written = 0
-    new_file = open(file_path, 'ab')
-    chunk = request.read()
-    if chunk is not None:
-        new_file.write(chunk)
-        bytes_written += len(chunk)
-        chunk = request.read()
-    new_file.close()
-    return bytes_written
-
 def write_request_body_to_temp_file(request):
     """
     Write HTTP request's body content to a temp file.
 
     Return the temp file's path
     """
-    filehandle, temp_filepath = tempfile.mkstemp()
-    write_file_from_request_body(request, temp_filepath)
+    _, temp_filepath = tempfile.mkstemp()
+    with open(temp_filepath, 'ab') as f:
+        f.write(request.body)
     return temp_filepath
 
 def parse_filename_from_content_disposition(header):

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -393,16 +393,26 @@ def sword_error_response(request, status, summary):
     return HttpResponse(error_xml, status=error_details['status'])
 
 def store_mets_data(mets_path, deposit, object_id):
-    submission_documentation_directory = os.path.join(deposit.full_path, 'submissionDocumentation')
-    if not os.path.exists(submission_documentation_directory):
-        os.mkdir(submission_documentation_directory)
+    """
+    Create transfer directory structure & store METS in it.
 
-    mods_directory = os.path.join(submission_documentation_directory, 'mods')
-    if not os.path.exists(mods_directory):
-        os.mkdir(mods_directory)
+    Creates submission documentation directory with MODS and objects subdirectories.
+    Also moves the METS into the submission documentation directory, overwriting anything already there.
+    """
+    create_dirs = [
+        os.path.join(deposit.full_path, 'submissionDocumentation', 'mods'),
+        os.path.join(deposit.full_path, object_id.replace(':', '-'))
+    ]
+    for d in create_dirs:
+        try:
+            LOGGER.debug('Creating %s', d)
+            os.makedirs(d)
+        except OSError:
+            if not os.path.isdir(d):
+                raise
 
     mets_name = object_id.replace(':', '-') + '-METS.xml'
-    target = os.path.join(submission_documentation_directory, mets_name)
+    target = os.path.join(deposit.full_path, 'submissionDocumentation', mets_name)
 
     # There may be a previous METS file if the same file is being
     # re-transferred, so remove and update the METS in this case.

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -209,7 +209,8 @@ def _spawn_batch_download_and_flag_finalization_if_requested(deposit, request, m
         deposit.save()
 
     # create subprocess so content URLs can be downloaded asynchronously
-    helpers.spawn_download_task(deposit.uuid, mets_data['objects'])
+    object_subdir = mets_data['object_id'].replace(':', '-')
+    helpers.spawn_download_task(deposit.uuid, mets_data['objects'], [object_subdir])
     helpers.spawn_download_task(deposit.uuid, mets_data['mods'], ['submissionDocumentation', 'mods'])
 
 def _parse_name_and_content_urls_from_mets_file(filepath):


### PR DESCRIPTION
Save files submitted via the FEDORA SWORD API in a directory named after the object ID.  This prevents collisions when multiple METS are submitted with the same object names.

refs #9940 in Redmine

Also, PEP8 & misc cleanup
