### PR TITLE
Reload logging configuration after sword2 is imported

### DIFF
--- a/storage_service/locations/models/lockssomatic.py
+++ b/storage_service/locations/models/lockssomatic.py
@@ -14,6 +14,11 @@ from django.db import models
 # Third party dependencies, alphabetical
 import sword2
 
+# sword2 breaks logging, we need to reload logging settings
+from django.conf import settings
+from django.utils.log import configure_logging
+configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
+
 # This project, alphabetical
 from common import utils
 


### PR DESCRIPTION
Also compatible with qa/0.x.

The version of sword2 available via pypi sets up its own handler in the root logger (see the history of [sword2_logging.py](https://github.com/swordapp/python-client-sword2/commits/master/sword2/sword2_logging.py) to see how that was addressed later), causing our logging configuration to work improperly under certain circumstances, e.g. in our package-based CentOS installation, sword2 module successes in its attempt to load its logging configuration. I haven't investigated the causes why this routine did not work on our Ubuntu-based installations.

This is a temporary fix until we start using a more recent version of sword2 that reloads our configuration right after the sword2 module is imported for the first time.
