### PR TITLE
Update to support 4.5.0 Version of Dataverse

### DIFF
--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -133,9 +133,9 @@ class Dataverse(models.Model):
 
         # Fetch all files in dataset.json
         for file_entry in dataset['latestVersion']['files']:
-            entry_id = str(file_entry['datafile']['id'])
+            entry_id = str(file_entry['dataFile']['id'])
             if not file_entry['label'].endswith('.tab'):
-                download_path = os.path.join(dest_path, file_entry['datafile']['name'])
+                download_path = os.path.join(dest_path, file_entry['dataFile']['filename'])
                 url = 'https://' + self.host + '/api/access/datafile/' + entry_id
             else:
                 # If the file is the tab file, download the bundle instead


### PR DESCRIPTION
refs #8693 dataverse support

This is part of the OCUL sponsored Dataverse Integration Project.  Initial support for Dataverse as a Storage Service Space was merged into qa/0.x already.  This change is to update that support, to work with the new metadata.json files produced by Dataverse.

Dataverse >= 4.4.x made a backwards incompatible change in the way it produces metadata.json files.  The word 'datafile' was replaced with 'dataFile', and within the dataFile element, the 'name' property was changed to 'filename'.
