### PR TITLE
iRODS plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *.orig
 *~
+sword2_logging.conf
 
 # Sqlite DBs
 *.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.py[co]
 *.swp
+*.orig
 *~
 
 # Sqlite DBs

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,3 +22,5 @@ python-swiftclient==2.4.0
 requests>=2.3.0
 git+https://github.com/swordapp/python-client-sword2.git@0c241438f2ced13ec3364caa03edf28d5ed5c02c#egg=sword2
 msgpack-python>=0.4.0
+#python-irodsclient. 0.5 is out but is not available on pypy, this version is known to work:
+git+git://github.com/irods/python-irodsclient.git@a3a5586a482105677045ec4af204f89fa3a96329

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -249,6 +249,18 @@ def uuid_to_path(uuid):
     LOGGER.debug("path %s", path)
     return path
 
+def dirsize(path):
+    """
+    Doe the same as unix command line "du": return the size of the
+    directory, as the sum of size of all included files, recursively.
+    """
+    total_size = 0
+    for dirpath, dirnames, filenames in os.walk(path):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            total_size += os.path.getsize(fp)
+    return total_size
+
 def removedirs(relative_path, base=None):
     """ Removes leaf directory of relative_path and all empty directories in
     relative_path, but nothing from base.

--- a/storage_service/irods.readme.rst
+++ b/storage_service/irods.readme.rst
@@ -1,0 +1,107 @@
+#
+# -*- coding: utf-8 -*-
+
+
+About the iRODS plugin
+----------------------
+
+This plugin allows the archivematica storage service to talk to an
+iRODS backend
+
+    http://irods.org/
+
+It is based on the official python bindings for irods :
+
+    https://github.com/irods/python-irodsclient
+
+Unfortunately, there hasn't been any release for very long, despite
+development being done. The last relase (0.4.0) dosn't have the required
+features needed by this plugin.
+
+This was developed and tested using
+* archivematica 1.5
+* archivematica storage service 0.8
+* python-irodsclient checkout as of april 2016
+
+Features
+--------
+All plugin methods are implemented (browse, sending files, getting files,
+deleting files).
+
+Reading/writing is streamed, which means the plugin can handle very big
+files seamlessly without clogging memory.
+
+Checksums
+---------
+iRODS can store a checksum for each file. This is not mandatory, please
+refer to iRODS documentation for more information.
+
+When reading a file from iRODS, if a checksum is provided, the plugin will
+check it once the file is read.
+
+When writing a file to iRODS, once finished, the plugin will ask iRODS for
+a checksum, and if available, will check against the source/local copy.
+
+iRODS can be configured to automatically compute and attach the checksum
+metatada when a file is written.
+
+Altogether, with iRODS properly configured, this allow end-to-end checking
+for file corruption, for both reading and writing.
+
+Performance
+-----------
+Currently, the performance of the python-irodsclient are far less good
+than, for example, the command line 'iput/iget' utilities. This is because
+features like "parallel transfer" or "automatic direct connection with
+resource server" are not implemented.
+
+This will probably only hurt people trying to send a lot of data through
+the plugin. Lot being either:
+* more than one TB
+* more that 100 000 files
+
+Callback mechanism
+------------------
+You can provide a callback URL to the plugin, this is not mandatory. An
+exemple would be "http://myservice/callback".
+
+This is used to inform another software component each time archivematica
+stores something on the iRODS backend. This is not used when reading. A
+typical use case would be to inform the preservation data management
+software when a DIP or AIP is written.
+
+If provided, the callback will be called using a POST request, with the
+following arguments:
+
+"name" : basename of the file or directory being written. This is the name of
+the destination ("iRODS path"), and not the one on the storaage service.
+For example if archivematica sends local directory /tmp/staging/foo/ to
+/home/rods/AIPs/myuuid, then name will be "myuuid".
+
+"size_in_mb": an integer providing the sum of sizes of all files contained
+within the directory sent to iRODS. If only a file is sent, this is its
+size. This doesn't take into account overheads from the filesystem or
+blocks.
+
+In the case of a directory, the plugin considers a list of files at the
+top level of this directory, and (if present), adds a checksum field to the
+POST data.
+This is mainly used for 'bagit' (https://en.wikipedia.org/wiki/BagIt), which
+is a commonly used format within archivematica or the preservation world.
+Currently two files are considered:
+
+"manifest-md5.txt": if present a field "checksum_manifest-md5.txt" is added
+with an md5 checksum of this file, in hexadecimal representation.
+
+"manifest-sha256.txt": if present a field "checksum_manifest-sha256.txt" is added
+with an sha256 checksum of this file, in hexadecimal representation.
+
+Copyright & Licence
+-------------------
+Copyright (c) 2016 Ymagis SA, http://www.ymagis.com/
+
+Author: Thomas Capricelli <capricelli@sylphide-consulting.com>
+
+The plugin is released under the GNU Affero General Public License, as is
+archivematica-storage-service.
+

--- a/storage_service/locations/constants.py
+++ b/storage_service/locations/constants.py
@@ -73,4 +73,15 @@ PROTOCOL = {
             'tenant',
             'region']
     },
+    models.Space.IRODS: {
+        'model': models.iRODS,
+        'form': forms.iRODSForm,
+        'fields': [
+	    "host",
+	    "port",
+	    "user",
+	    "password",
+	    "zone",
+        ],
+    },
 }

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -153,6 +153,19 @@ class SwiftForm(forms.ModelForm):
         fields = ('auth_url', 'auth_version', 'username', 'password', 'container', 'tenant', 'region')
 
 
+class iRODSForm(forms.ModelForm):
+    class Meta:
+        model = models.iRODS
+        fields = (
+	    "host",
+	    "port",
+	    "user",
+	    "password",
+	    "zone",
+	    "resource",
+	    "callback",
+	)
+
 class LocationForm(forms.ModelForm):
     class Meta:
         model = models.Location

--- a/storage_service/locations/migrations/0009_auto_20161006_0803.py
+++ b/storage_service/locations/migrations/0009_auto_20161006_0803.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+import django_extensions.db.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locations', '0008_fixitylog'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='iRODS',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('host', models.CharField(help_text='iRODS API server name or IP', max_length=256)),
+                ('port', models.PositiveIntegerField(default=1247, help_text='port, default is 1247')),
+                ('user', models.CharField(help_text='iRODS user', max_length=256)),
+                ('password', models.CharField(help_text='Corresponding password', max_length=256)),
+                ('zone', models.CharField(default=b'tempZone', help_text='iRODS zone (e.g. tempZone)', max_length=256)),
+                ('resource', models.CharField(help_text=b'iRODS resource used for storing objects', max_length=256)),
+                ('callback', models.CharField(help_text=b'If present a call will be made to this URL after a successful/finished move_from_storage_service() (data stored on the iRODS backend) with the destination name as argument.', max_length=512, verbose_name='Non-mandatory callback URL', blank=True)),
+            ],
+            options={
+                'verbose_name': 'iRODS',
+            },
+        ),
+    ]

--- a/storage_service/locations/models/__init__.py
+++ b/storage_service/locations/models/__init__.py
@@ -30,3 +30,5 @@ from lockssomatic import Lockssomatic
 from nfs import NFS
 from pipeline_local import PipelineLocalFS
 from swift import Swift
+from irodsplugin import iRODS
+

--- a/storage_service/locations/models/irodsplugin.py
+++ b/storage_service/locations/models/irodsplugin.py
@@ -1,0 +1,312 @@
+#
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2016 Ymagis SA, http://www.ymagis.com/
+#
+# This file is part of archivematica-storage-service.
+
+# archivematica-storage-service is free software: you can redistribute it 
+# and/or modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the License,
+# or (at your option) any later version.
+#
+# archivematica-storage-service is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with archivematica-storage-service.  If not, 
+# see <http://www.gnu.org/licenses/>.
+#
+# @author Thomas Capricelli <capricelli@sylphide-consulting.com>
+#
+
+
+# Standard
+import logging
+import os
+from base64 import b64encode
+import requests
+
+# Core Django, alphabetical
+from django.db import models
+
+# Third party dependencies, alphabetical
+import bagit
+from irods.exception import DataObjectDoesNotExist, CollectionDoesNotExist
+from irods.session import iRODSSession
+
+# This project, alphabetical
+from common.utils import generate_checksum, dirsize
+
+# This module, alphabetical
+from . import StorageException
+from location import Location
+
+LOGGER = logging.getLogger(__name__)
+
+
+class iRODS(models.Model):
+    space = models.OneToOneField('Space', to_field='uuid')
+
+    host = models.CharField(max_length=256, help_text=u"iRODS API server name or IP")
+    port = models.PositiveIntegerField(help_text=u"port, default is 1247", default=1247)
+    user = models.CharField(max_length=256, help_text=u"iRODS user")
+    password = models.CharField(max_length=256, help_text=u"Corresponding password")
+    zone = models.CharField(max_length=256, help_text=u"iRODS zone (e.g. tempZone)", default="tempZone")
+    resource = models.CharField(max_length=256, help_text="iRODS resource used for storing objects")
+    callback = models.CharField(u"Non-mandatory callback URL", max_length=512, help_text="If present a call will be made to this URL after a successful/finished move_from_storage_service() (data stored on the iRODS backend) with the destination name as argument.", blank=True)
+
+    class Meta:
+        verbose_name = "iRODS"
+        app_label = 'locations'
+
+    ALLOWED_LOCATION_PURPOSE = [
+        Location.AIP_STORAGE,
+        Location.DIP_STORAGE,
+        Location.TRANSFER_SOURCE,
+        Location.BACKLOG,
+    ]
+    CHUNK_SIZE = 1024*1024 # 1MB
+
+    # map non-standard irods checksum names to standard ones (such as those used by hashlib.new)
+    map_irods_checksum_type = {
+        "sha2": "sha256"
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(iRODS, self).__init__(*args, **kwargs)
+        self._session = None
+
+    @property
+    def session(self):
+        if self._session is None:
+            self._session = iRODSSession(
+                host = str(self.host),
+                port = str(self.port),
+                user = str(self.user),
+                password = str(self.password),
+                zone = str(self.zone),
+            )
+        return self._session
+
+    def irodspath(self, path):
+        "Clean / normalize a path, taking zone into consideration"
+	return str(os.path.normpath('/%s/%s'% ( self.zone, path)))
+
+    def browse(self, path):
+        """
+        Returns information about files and folders (called "collections" in iRODS)
+
+        See Space.browse for full documentation.
+
+        Properties provided:
+        'size': Size of the object
+        'timestamp': Last modified timestamp of the object or directory
+        """
+        properties = {}
+        coll = self.session.collections.get(self.irodspath(path))
+
+        # List folders
+        directories = [collection.name for collection in coll.subcollections]
+
+        # List files
+        objects = [obj.name for obj in coll.data_objects]
+        entries = objects + directories
+
+        # Metadata
+        # TODO: if we add a field "object count", archivematica frontend will make use of it. See the "FS" plugin for an example.
+        for obj in coll.data_objects:
+            properties[obj.name] = {
+                'size': obj.size,
+                'timestamp': obj.modify_time.isoformat(),
+            }
+        return {
+            'directories': sorted(directories, key=lambda s: s.lower()),
+            'entries': sorted(entries, key=lambda s: s.lower()),
+            'properties': properties,
+        }
+
+    def delete_path(self, path):
+        fullpath = self.irodspath(path)
+        try:
+            # Object ?
+            obj = self.session.data_objects.get(fullpath)
+            obj.unlink(force=True)
+        except DataObjectDoesNotExist:
+            # Collection ??
+            collection  = self.session.collections.get(fullpath)
+            collection.remove(force=True)
+
+    def check_checksum(self, obj, local_path):
+        if not obj.checksum: return # nothing to check
+        LOGGER.info("Checking iRODS checksum against local file %s" % local_path)
+
+        # iRODS provides a checksum: check it
+        checksum_type, checksum_value = obj.checksum.split(":")
+        checksum_type = self.map_irods_checksum_type.get(checksum_type, checksum_type)
+        checksum = generate_checksum(local_path, checksum_type=checksum_type)
+        # irods encodes the checksum whith base64
+        if checksum_value != b64encode(checksum.digest()):
+            raise StorageException("Error while checking the checksum provided by iRODS")
+
+    def _iget(self, irods_path, local_path):
+        """
+        Get a file from iRODS and store it locally.
+
+        :param str irods_path: path in iRODS.
+        :param str local_path: local destination file path.
+        """
+        fullpath = self.irodspath(irods_path)
+        LOGGER.info("_iget() %s -> %s" % (fullpath, local_path))
+        obj = self.session.data_objects.get(fullpath)
+        # Stream it
+        with open(local_path, "wb") as localfile:
+            with obj.open('r+') as irodsobject:
+                while True:
+                    chunk = irodsobject.read(iRODS.CHUNK_SIZE)
+                    if not chunk: break
+                    localfile.write(chunk)
+
+        self.check_checksum(obj, local_path)
+
+    def _iput(self, local_path, irods_path):
+        """
+        Send a local file to iRODS.
+
+        :param str local_path: local source file path.
+        :param str irods_path: path in iRODS.
+        """
+        LOGGER.info("_iput() %s -> %s" % (local_path, irods_path))
+        fullpath = self.irodspath(irods_path)
+        obj = self.session.data_objects.create(fullpath, resource=str(self.resource))
+        # Stream it
+        with open(local_path, "r+") as localfile:
+            with obj.open('w') as irodsobject:
+                while True:
+                    chunk = localfile.read(iRODS.CHUNK_SIZE)
+                    if not chunk: break
+                    irodsobject.write(chunk)
+
+        # Fetch again the iRODS object and check the checksum if available
+        obj = self.session.data_objects.get(fullpath)
+        self.check_checksum(obj, local_path)
+
+    def move_to_storage_service(self, src_path, dest_path, dest_space):
+        """ Moves src_path to dest_space.staging_path/dest_path. """
+        try:
+            # First try it as a collection
+            self._move_to_storage_service_dir(src_path, dest_path)
+        except CollectionDoesNotExist:
+            # Not a collection, try as an object
+            self._iget(src_path, dest_path)
+
+    def _move_to_storage_service_dir(self, src_path, dest_path):
+        """
+        Get recursively an iRODS collection
+        """
+        coll = self.session.collections.get(self.irodspath(src_path))
+        os.mkdir(dest_path)
+
+        # Copy objects
+        for obj in coll.data_objects:
+            self._iget(
+                os.path.join(src_path, obj.name),
+                os.path.join(dest_path, obj.name),
+            )
+        # Copy directories
+        for collection in coll.subcollections:
+            self._move_to_storage_service_dir(
+                os.path.join(src_path, collection.name),
+                os.path.join(dest_path, collection.name),
+            )
+
+    def mkdir(self, name):
+        LOGGER.info("Creating irods directory (zone:%s) %s", self.zone, name)
+        self.session.collections.create(self.irodspath(name))
+
+    def mkdir_if_needed(self, name):
+        """
+        Ensure a collection/directory exists (think "mkdir -p")
+        * create new collection only if needed / doesn't exist
+        * work at any depth
+        """
+        parentname = os.path.dirname(os.path.normpath(name))
+        # Recursively check parents. This would be surprising to reach '/',
+        # but we still want a robust stop criteria.
+        if parentname not in [u'/', '/', '']:
+            self.mkdir_if_needed(parentname) # recursion
+        try:
+            coll = self.session.collections.get(self.irodspath(name))
+        except CollectionDoesNotExist:
+            self.mkdir(name)
+
+    def move_from_storage_service(self, source_path, destination_path):
+        """
+        Called by Space parent, which is responsible for adding
+        * self.space.staging_path to source_path
+        * self.space.path to destination_path
+
+        So we don't need to do it
+        """
+
+        source_path = os.path.normpath(source_path)
+        destination_path = os.path.normpath(destination_path)
+
+        if os.path.isdir(source_path):
+            self.mkdir_if_needed(destination_path)
+            for path, directories, files in os.walk(source_path):
+                for basename in files:
+                    entry = os.path.join(path, basename)
+                    dest = entry.replace(source_path, destination_path, 1)
+                    self._iput(entry, dest)
+                for directory in directories:
+                    dirname = os.path.join(path, directory).replace(source_path, destination_path, 1)
+                    self.mkdir(dirname)
+
+        elif os.path.isfile(source_path):
+            self._iput(source_path, destination_path)
+        else:
+            raise StorageException('%s is neither a file nor a directory, may not exist' % source_path)
+
+        if os.path.isdir(source_path) and (
+            os.path.exists(os.path.join(source_path, "bagit.txt")) or
+            os.path.exists(os.path.join(source_path, "bag-info.txt"))
+        ):
+            # once all file are uploaded, check that local files haven't been
+            # corrupted
+            # We only handle the case of an uncompressed bagit
+            LOGGER.info("Peforms bagitcheck after sending files to irods")
+            bag = bagit.Bag(source_path)
+            if not bag.is_valid():
+                raise StorageException("Bagit check on the local directory failed after files were uploaded to irods")
+
+
+        # Final step : on success, if present, call some callback
+        if len(self.callback)<=0: return # nothing to do
+        LOGGER.info("move_from_storage_service() done, calling callback")
+
+        data = {
+            "name": os.path.basename(os.path.normpath(destination_path)),
+            "size_in_mb": dirsize(source_path)/(1024*1024),
+        }
+
+        # Checksum
+        if os.path.isdir(source_path):
+            # Files to consider, dictionnary mapping filename to checksum_type
+            files_checksum = {
+                "manifest-md5.txt": "md5",
+                "manifest-sha256.txt": "sha256",
+                "manifest-sha512.txt": "sha512",
+            }
+            for filename in files_checksum.keys():
+                fullpath = os.path.join(source_path, filename)
+                if not os.path.exists(fullpath): continue
+                data['checksum_%s'%filename] = generate_checksum(fullpath, checksum_type=files_checksum[filename]).hexdigest(),
+        response = requests.post(self.callback, data = data)
+        if response.status_code != 200:
+            LOGGER.warning("Error while calling the callback, error_code = %d" % response.status_code)
+            #raise StorageException("Error while calling the callback, error_code = %d" % response.status_code)
+
+

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -97,6 +97,7 @@ class Space(models.Model):
     NFS = 'NFS'
     PIPELINE_LOCAL_FS = 'PIPE_FS'
     SWIFT = 'SWIFT'
+    IRODS = 'IRODS'
     OBJECT_STORAGE = {DATAVERSE, DURACLOUD, SWIFT}
     ACCESS_PROTOCOL_CHOICES = (
         (ARKIVUM, 'Arkivum'),
@@ -108,6 +109,7 @@ class Space(models.Model):
         (NFS, "NFS"),
         (PIPELINE_LOCAL_FS, "Pipeline Local Filesystem"),
         (SWIFT, "Swift"),
+        (IRODS, "iRODS"),
     )
     access_protocol = models.CharField(max_length=8,
         choices=ACCESS_PROTOCOL_CHOICES,

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -41,7 +41,7 @@ def validate_space_path(path):
 #   Add class to import list
 #  locations/forms.py
 #   Add ModelForm for new class
-#  common/constants.py
+#  locations/constants.py
 #   Add entry to protocol
 #    'model' is the model object
 #    'form' is the ModelForm for creating the space
@@ -260,7 +260,7 @@ class Space(models.Model):
         Given a destination_path relative to this space, converts to an absolute path.
 
         :param str staging_path: Path to the staging copy relative to the SS internal location.
-        :param str destination_path: Path to the destination copy relative to this Space's path.
+        :param str destination_path: Path to the destination copy relative to this Space's path.destination_path
         :return: Tuple of absolute paths (staging_path, destination_path)
         """
         # Path pre-processing

--- a/storage_service/testirods.py
+++ b/storage_service/testirods.py
@@ -1,0 +1,120 @@
+#
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2016 Ymagis SA, http://www.ymagis.com/
+#
+# This file is part of archivematica-storage-service.
+
+# archivematica-storage-service is free software: you can redistribute it 
+# and/or modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the License,
+# or (at your option) any later version.
+#
+# archivematica-storage-service is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with archivematica-storage-service.  If not, 
+# see <http://www.gnu.org/licenses/>.
+#
+# @author Thomas Capricelli <capricelli@sylphide-consulting.com>
+#
+
+
+
+# Usage
+# source setupenv
+# python testirods.py
+
+# System
+import sys
+from os.path import join
+
+# Django
+import django
+django.setup()
+
+# Project
+from locations.models.irodsplugin import *
+
+
+# Must be present in "staging_path", typically "/tmp" for testing
+TESTFILE = "irodsplugin.testfile"
+TESTDIR_SOURCE = "irodsplugin.testdir.bagit"
+TESTDIR_IRODS = "aw/if/hw/fh/aw/oe/fa/ew/fo/awj/17256f80-8080-4b4f-9c2c-85027a39fc31"
+
+TESTFILEBACK = TESTFILE + ".back"
+TESTDIRBACK = TESTDIR_SOURCE + ".back"
+
+def browse_home(i):
+    d = i.browse("/home/rods")
+    directories = d['directories']
+    entries = d['entries']
+    properties = d['properties']
+
+    print "directories:\n\t", "\n\t".join(directories)
+    print "entries:\n\t", "\n\t".join(entries)
+    print "properties:"
+    for name,prop in properties.iteritems():
+        print "\t%s:"%name, prop
+
+def clean_test_file(warn_user=False):
+    if TESTFILE not in i.browse("/home/rods")['entries']:
+        return
+    if warn_user: print "\n%s already exists, removing ..." % TESTFILE,
+    i.delete_path(join(i.space.path, TESTFILE))
+    if warn_user: print "done"
+
+#
+# Unit Tests
+#
+def test_browse(i):
+    print "\nTesting browse: "
+    browse_home(i)
+    clean_test_file(warn_user=True)
+
+def test_iput(i):
+    print "\nTesting _iput"
+    local_path, irods_path = i.space._move_from_path_mangling(TESTFILE, TESTFILE)
+    i._iput(local_path, irods_path)
+#    browse_home(i)
+
+def test_iget(i):
+    print "\nTesting _iget"
+    local_path, irods_path = i.space._move_from_path_mangling("restored_%s" % TESTFILE, TESTFILE)
+    i._iget(irods_path, local_path)
+
+def test_move_from_storage_service_file(i):
+    print "\nTesting move_from_storage_service() with a file"
+    clean_test_file()
+    i.space.move_from_storage_service(TESTFILE, TESTFILE)
+
+def test_move_from_storage_service_dir(i):
+    print "\nTesting move_from_storage_service() with a directory"
+    i.space.move_from_storage_service(TESTDIR_SOURCE, TESTDIR_IRODS)
+
+def test_move_to_storage_service_file(i):
+    print "\nTesting move_to_storage_service() with a file"
+    # keep same space for testing
+    i.space.move_to_storage_service(TESTFILE, TESTFILEBACK, i.space)
+
+def test_move_to_storage_service_dir(i):
+    print "\nTesting move_to_storage_service() with a directory"
+    i.space.move_to_storage_service(TESTDIR_IRODS, TESTDIRBACK, i.space)
+
+#
+# Main
+#
+
+i = iRODS.objects.get(id=2)
+
+test_browse(i)
+test_iput(i)
+test_iget(i)
+test_move_from_storage_service_file(i)
+test_move_from_storage_service_dir(i)
+test_move_to_storage_service_file(i)
+test_move_to_storage_service_dir(i)
+


### PR DESCRIPTION
Hello,

We at Ymagis/Eclair (http://www.ymagis.com, http://www.eclairgroup.com/) have developped a plugin to connect the Archivematica Storage Service to an irods backend. It was tested using irods 4.1.8. Here's a patch against ass-0.8. It contains documentation and (basic) tests. You'll need a working irods instance for those tests.

We use this plugin exclusively to 'deliver' AIPs to iRODS.

iRods provides some python code to access irods, and this plugin is based on this. Unfortunately, as explained in the embedded documentation, this python wrapper misses most performance-related features.
We think that those performance issues should impact very few people. You really need to handle very big files or AIPs with a huge number of files to be hit by those issues.

The plugin is released under the same licence as ass (GNU Affero GPL). We would be happy for any feedback and even more if it was included in storage-service proper.

best regards, 
