### PR TITLE
Fixity: None is logged separately from True/False

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -748,11 +748,15 @@ class PackageResource(ModelResource):
                 response["failures"]["files"]["untracked"].append(info)
 
         report = json.dumps(response)
-        if not success:
+        if success is False:
             signals.failed_fixity_check.send(sender=self,
                 uuid=bundle.obj.uuid, location=bundle.obj.full_path,
                 report=report)
-        else:
+        elif success is None:
+            signals.fixity_check_not_run.send(sender=self,
+                uuid=bundle.obj.uuid, location=bundle.obj.full_path,
+                report=report)
+        elif success is True:
             signals.successful_fixity_check.send(sender=self,
                 uuid=bundle.obj.uuid, location=bundle.obj.full_path,
                 report=report)

--- a/storage_service/locations/migrations/0011_fixitylog_status.py
+++ b/storage_service/locations/migrations/0011_fixitylog_status.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locations', '0010_dspace_metadata_policy'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fixitylog',
+            name='success',
+            field=models.NullBooleanField(default=False),
+        ),
+    ]

--- a/storage_service/locations/models/fixity_log.py
+++ b/storage_service/locations/models/fixity_log.py
@@ -14,7 +14,7 @@ class FixityLog(models.Model):
     """ Stores fixity check success/failure and error details """
 
     package = models.ForeignKey('Package', to_field='uuid')
-    success = models.BooleanField(default=False)
+    success = models.NullBooleanField(default=False)
     error_details = models.TextField(null=True)
     datetime_reported = models.DateTimeField(auto_now=True)
 

--- a/storage_service/locations/signals.py
+++ b/storage_service/locations/signals.py
@@ -14,6 +14,7 @@ LOGGER = logging.getLogger(__name__)
 deletion_request = Signal(providing_args=["uuid", "location", "url"])
 failed_fixity_check = Signal(providing_args=["uuid", "location", "report"])
 successful_fixity_check = Signal(providing_args=["uuid", "location", "report"])
+fixity_check_not_run = Signal(providing_args=["uuid", "location", "report"])
 
 
 def _notify_administrators(subject, message):
@@ -69,6 +70,13 @@ Full failure report (in JSON format):
 @receiver(successful_fixity_check, dispatch_uid="fixity_check")
 def report_successful_fixity_check(sender, **kwargs):
     _log_report(kwargs['uuid'], True)
+
+
+@receiver(fixity_check_not_run, dispatch_uid="fixity_check")
+def report_not_run_fixity_check(sender, **kwargs):
+    """Handle a fixity not run signal."""
+    report_data = json.loads(kwargs['report'])
+    _log_report(uuid=kwargs['uuid'], success=None, message=report_data['message'])
 
 
 # Create an API key for every user, for TastyPie


### PR DESCRIPTION
If a fixity check returns None (because it didn't run because of an external condition), log that differently in the FixityLog. Update the database to handle NULL in the BooleanField, and remove email alert.

Refs Redmine #10326