### PR TITLE
Combine user edit and password change forms

### DIFF
--- a/storage_service/administration/forms.py
+++ b/storage_service/administration/forms.py
@@ -2,6 +2,7 @@
 from django import forms
 from django.contrib import auth
 from django.utils.translation import ugettext as _, ugettext_lazy as _l
+from django.core.exceptions import ValidationError
 
 from common import utils
 
@@ -210,3 +211,9 @@ class UserChangeForm(auth.forms.UserChangeForm):
     class Meta:
         model = auth.get_user_model()
         fields = ('username', 'first_name', 'last_name', 'email', 'is_superuser')
+
+
+class SetPasswordForm(auth.forms.SetPasswordForm):
+    def is_empty(self):
+        """ Has the password form been filled in?"""
+        return not self.data['new_password1'] and not self.data['new_password2']

--- a/storage_service/administration/tests/test_edit_user.py
+++ b/storage_service/administration/tests/test_edit_user.py
@@ -4,11 +4,11 @@ from django.test import TestCase
 
 class TestEditUser(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         User.objects.create_superuser(
             username='admin', password='admin', email='admin@example.com'
         )
-        super(TestEditUser, cls).setUpClass()
+        super(TestEditUser, cls).setUpTestData()
 
     def setUp(self):
         self.client.login(username='admin', password='admin')

--- a/storage_service/administration/tests/test_edit_user.py
+++ b/storage_service/administration/tests/test_edit_user.py
@@ -1,0 +1,139 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+
+class TestEditUser(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        User.objects.create_superuser(
+            username='admin', password='admin', email='admin@example.com'
+        )
+        super(TestEditUser, cls).setUpClass()
+
+    def setUp(self):
+        self.client.login(username='admin', password='admin')
+        self.test_user = User.objects.get(username='test')
+
+    def test_get_form(self):
+        self.client.get('/administration/users/1/edit/')
+        self.assertTemplateUsed('user_form.html')
+
+    def test_change_user_details_only(self):
+        old_password = self.test_user.password
+        old_api_key = self.test_user.api_key.key
+        response = self.client.post(
+            '/administration/users/1/edit/',
+            {
+                'username': 'test',
+                'first_name': 'New first name',
+                'last_name': 'New last name',
+                'email_address': 'test@example.com',
+                'new_password1': '',
+                'new_password2': '',
+            },
+            follow=True
+        )
+
+        self.test_user.refresh_from_db()
+        self.test_user.api_key.refresh_from_db()
+
+        # User fields should be updated
+        assert self.test_user.first_name == 'New first name'
+        assert self.test_user.last_name == 'New last name'
+
+        # Password and api key should not change
+        assert self.test_user.password == old_password
+        assert self.test_user.api_key.key == old_api_key
+
+        # Should redirect back to user list
+        self.assertRedirects(response, '/administration/users/')
+
+        # Should show a messages saying the user info was saved
+        messages = {m.message for m in response.context['messages']}
+        assert 'User information saved.' in messages
+
+    def test_with_change_password(self):
+        old_password = self.test_user.password
+        old_api_key = self.test_user.api_key.key
+        response = self.client.post(
+            '/administration/users/1/edit/',
+            {
+                'username': 'test',
+                'first_name': 'first name',
+                'last_name': 'new last name',
+                'email_address': 'test@example.com',
+                'new_password1': 'mypassword',
+                'new_password2': 'mypassword',
+            },
+            follow=True
+        )
+
+        self.test_user.refresh_from_db()
+        self.test_user.api_key.refresh_from_db()
+
+        # User edits should take effect
+        assert self.test_user.last_name == 'new last name'
+
+        # Password and api key should both change
+        assert self.test_user.password != old_password
+        assert self.test_user.api_key.key != old_api_key
+
+        # Should redirect back to user list
+        self.assertRedirects(response, '/administration/users/')
+
+        # Should show a message saying the user info was saved
+        messages = {m.message for m in response.context['messages']}
+        assert 'Password changed.' in messages
+        assert 'User information saved.' in messages
+
+    def test_user_edit_form_error(self):
+        """
+        When there's an error in the edit user form, it should not
+        save the password form
+        """
+        old_password = self.test_user.password
+        response = self.client.post(
+            '/administration/users/1/edit/',
+            {
+                'username': '',     # username is missing
+                'first_name': 'first name',
+                'last_name': 'last name',
+                'email_address': 'test@example.com',
+                'new_password1': 'mypassword',
+                'new_password2': 'mypassword',
+            },
+        )
+
+        self.test_user.refresh_from_db()
+
+        # Make sure no password change
+        assert self.test_user.password == old_password
+
+        # Should display the form page again
+        self.assertTemplateUsed('user_form.html')
+        assert len(response.context['messages']) == 0
+
+    def test_password_form_error(self):
+        """
+        When there's an error in the password form, it should not
+        save the user edit form
+        """
+        response = self.client.post(
+            '/administration/users/1/edit/',
+            {
+                'username': 'test',     # username is missing
+                'first_name': 'new first name',
+                'last_name': 'last name',
+                'email_address': 'test@example.com',
+                'new_password1': 'mypassword',
+                'new_password2': 'mismatch',
+            },
+        )
+
+        # Make sure no password change
+        self.test_user.refresh_from_db()
+        assert self.test_user.first_name == ''
+
+        # Should display the form page again
+        self.assertTemplateUsed('user_form.html')
+        assert len(response.context['messages']) == 0

--- a/storage_service/administration/tests/test_forms.py
+++ b/storage_service/administration/tests/test_forms.py
@@ -1,0 +1,28 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+
+class TestSetPasswordForm(TestCase):
+    def setUp(self):
+        self.test_user = User.objects.get(username='test')
+
+    def create_form(self, data):
+        # This has to be done here because of attempted database accesses on
+        # import (DefaultLocationsForm)
+        from administration.forms import SetPasswordForm
+        return SetPasswordForm(data=data, user=self.test_user)
+
+    def test_is_empty_if_neither_field_filled_in(self):
+        form = self.create_form({
+            'new_password1': '',
+            'new_password2': '',
+        })
+        assert form.is_empty()
+
+    def test_is_non_empty_if_one_field_filled_in(self):
+        form = self.create_form({
+            'new_password1': 'something',
+            'new_password2': '',
+        })
+
+        assert not form.is_empty()

--- a/storage_service/administration/tests/test_languages.py
+++ b/storage_service/administration/tests/test_languages.py
@@ -4,11 +4,11 @@ from django.test import TestCase, override_settings
 
 class TestLanguageSwitching(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         User.objects.create_user(
             username='admin', password='admin', email='admin@example.com'
         )
-        super(TestLanguageSwitching, cls).setUpClass()
+        super(TestLanguageSwitching, cls).setUpTestData()
 
     def setUp(self):
         self.client.login(username='admin', password='admin')

--- a/storage_service/administration/views.py
+++ b/storage_service/administration/views.py
@@ -3,7 +3,6 @@ import subprocess
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
-from django.contrib.auth.forms import SetPasswordForm
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils.translation import get_language, ugettext as _
 from tastypie.models import ApiKey
@@ -54,18 +53,28 @@ def user_edit(request, id):
     action = _("Edit User")
     edit_user = get_object_or_404(get_user_model(), id=id)
     user_form = settings_forms.UserChangeForm(request.POST or None, instance=edit_user)
-    password_form = SetPasswordForm(data=request.POST or None, user=edit_user)
-    if 'user' in request.POST and user_form.is_valid():
-        user_form.save()
-        messages.success(request, _("User information saved."))
-        return redirect('user_list')
-    elif 'password' in request.POST and password_form.is_valid():
-        password_form.save()
-        api_key = ApiKey.objects.get(user=edit_user)
-        api_key.key = api_key.generate_key()
-        api_key.save()
-        messages.success(request, _("Password changed."))
-        return redirect('user_list')
+    password_form = settings_forms.SetPasswordForm(data=request.POST or None, user=edit_user)
+
+    if request.method == 'POST':
+        # This means the button was clicked.
+        if user_form.is_valid():
+            # An empty password form will not pass as valid, because the
+            # password fields are required. However, we don't want an empty
+            # form to trigger a page error - it should simply be ignored.
+            if password_form.is_empty() or password_form.is_valid():
+                if password_form.is_valid():
+                    password_form.save()
+                    api_key = ApiKey.objects.get(user=edit_user)
+                    api_key.key = api_key.generate_key()
+                    api_key.save()
+                    messages.success(request, _("Password changed."))
+
+                # User form is valid, and password form is empty or valid,
+                # so we can report success.
+                user_form.save()
+                messages.success(request, _("User information saved."))
+                return redirect('user_list')
+
     return render(request, 'administration/user_form.html', locals())
 
 def user_create(request):

--- a/storage_service/templates/administration/user_form.html
+++ b/storage_service/templates/administration/user_form.html
@@ -13,17 +13,14 @@
     {% endif %}
       {% csrf_token %}
       {{ user_form.as_p }}
-      <input type="submit" name='user' value="{{ action }}" class='btn btn-primary' />
-    </form>
 
-    {% if edit_user %}
-    <form action="{% url 'user_edit' edit_user.id %}" method="post">
-      {% csrf_token %}
-      {{ password_form.as_p }}
-      <p>{% trans "Note: if you change your password, your API key will also be changed to a new, randomly generated one." %}</p>
-      <input type="submit" name='password' value="{% trans "Change Password" %}" class='btn btn-primary' />
+      {% if edit_user %}
+        {{ password_form.as_p }}
+        <p>{% trans "Note: if you change your password, your API key will also be changed to a new, randomly generated one." %}</p>
+      {% endif %}
+
+      <input type="submit" name='user' value="{{action}}" class='btn btn-primary' />
     </form>
-    {% endif %}
 
     {% if edit_user and edit_user.api_key %}
     <p>


### PR DESCRIPTION
They are now controlled by a single button - this is to prevent users
from accidentally not saving their user data due to not realising saves
must be done separately.

The two forms remain separate (as they are based on Django forms) but
the view will treat them atomically - data will be saved on both forms
if and only if they are both correctly filled in. (Note that in the
case of the password form, correctly filled in can mean empty - the user
may choose not to change their password).

Tests also added.