### PR TITLE
Settings: Set ALLOWED_HOSTS in base.py

### DIFF
--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -118,7 +118,7 @@ SECRET_KEY = get_env_variable('DJANGO_SECRET_KEY')
 ########## SITE CONFIGURATION
 # Hosts/domain names that are valid for this site
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 ########## END SITE CONFIGURATION
 
 


### PR DESCRIPTION
`ALLOWED_HOSTS` was only specified in production.py, so when running with any other settings file it generated an error.