### PR TITLE
Version display should work even if git not installed

### DIFF
--- a/storage_service/administration/views.py
+++ b/storage_service/administration/views.py
@@ -33,7 +33,7 @@ def settings_edit(request):
 def get_git_commit():
     try:
         return subprocess.check_output(['git', 'rev-parse', 'HEAD'])
-    except subprocess.CalledProcessError:
+    except (OSError, subprocess.CalledProcessError):
         return None
 
 def version_view(request):


### PR DESCRIPTION
Run `sudo apt-get purge git` in your VM and then be amazed that you can still see the SS version page!