### PR TITLE
DSpace: stop creating .cache directory

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,5 +20,5 @@ python-dateutil==2.4.2
 python-keystoneclient==1.8.1
 python-swiftclient==2.4.0
 requests>=2.3.0
-git+https://github.com/swordapp/python-client-sword2.git@0c241438f2ced13ec3364caa03edf28d5ed5c02c#egg=sword2
+sword2==0.2.0
 msgpack-python>=0.4.0

--- a/storage_service/locations/models/dspace.py
+++ b/storage_service/locations/models/dspace.py
@@ -63,7 +63,9 @@ class DSpace(models.Model):
                 download_service_document=True,
                 user_name=self.user,
                 user_pass=self.password,
-                keep_history=True,
+                keep_history=False,
+                cache_deposit_receipts=False,
+                http_impl=sword2.http_layer.HttpLib2Layer(cache_dir=None)
                 # http_impl=sword2.http_layer.UrlLib2Layer(),  # This causes the deposit receipt to return the wrong URLs
             )
             LOGGER.debug('Getting service document')

--- a/storage_service/locations/models/lockssomatic.py
+++ b/storage_service/locations/models/lockssomatic.py
@@ -297,8 +297,14 @@ class Lockssomatic(models.Model):
 
         Returns True on success, False on error.  No updates performed on error."""
         try:
-            self.sword_connection = sword2.Connection(self.sd_iri, download_service_document=True,
-                on_behalf_of=self.content_provider_id)
+            self.sword_connection = sword2.Connection(
+                service_document_iri=self.sd_iri,
+                download_service_document=True,
+                on_behalf_of=self.content_provider_id,
+                keep_history=False,
+                cache_deposit_receipts=False,
+                http_impl=sword2.http_layer.HttpLib2Layer(cache_dir=None)
+            )
         except Exception:  # TODO make this more specific
             LOGGER.exception("Error getting service document from SWORD server.")
             return False


### PR DESCRIPTION
Remove the .cache directory that SWORD2 creates, because it is often the source of permissions errors.

Update the version of sword2 to include a fix that allows disabling the cache directory.

Edit: Updated sword2 version to install from the new pip release. It includes one extra commit from the install-from-git previously used, which is release related things and a license change (MIT->Apache)

These 2 commits may be squashed before merging.