### PR TITLE
Package: add transfer backlog reindex

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -739,12 +739,12 @@ class Package(models.Model):
         file_data = self._parse_mets(prefix=prefix)
 
         for f in file_data['files']:
-            File.objects.create(source_id=f['file_uuid'],
-                                source_package=file_data['transfer_uuid'],
-                                accessionid=file_data['accession_id'],
-                                package=self,
-                                name=f['path'],
-                                origin=file_data['dashboard_uuid'])
+            File.objects.update_or_create(source_id=f['file_uuid'],
+                                          source_package=file_data['transfer_uuid'],
+                                          accessionid=file_data['accession_id'],
+                                          package=self,
+                                          name=f['path'],
+                                          origin=file_data['dashboard_uuid'])
 
 
     def backlog_transfer(self, origin_location, origin_path):


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/10967

It also deletes a couple of unused imports.

`Package.index_file_data_from_transfer_mets` has been updated to use `update_or_create` instead of `create` to ensure the files are only created once.

```
$ curl \
  -s \
  -XPOST \
  -H "Authorization: ApiKey test:f00b4r" \
    http://127.0.0.1:8000/api/v2/file/930f58eb-4722-4f49-b8a4-d110cfb1c6bd/reindex/
```

```json
{"message": "Files indexed: 2", "error": false}
```