### PR TITLE
Remove unused environment variable

### DIFF
--- a/install/.storage-service
+++ b/install/.storage-service
@@ -1,6 +1,5 @@
 alias sspy="/usr/share/python/archivematica-storage-service/bin/python"
 export DJANGO_SECRET_KEY=<replace-with-key>
-export DJANGO_STATIC_ROOT=/var/archivematica/storage-service/assets
 export DJANGO_SETTINGS_MODULE=storage_service.settings.production
 export EMAIL_HOST=localhost
 export EMAIL_HOST_PASSWORD=

--- a/install/storage-service.gunicorn-config.py
+++ b/install/storage-service.gunicorn-config.py
@@ -26,7 +26,6 @@ chdir = "/usr/lib/archivematica/storage-service"
 raw_env = [
     "EMAIL_HOST_PASSWORD=",
     "SS_DB_NAME=/var/archivematica/storage-service/storage.db",
-    "DJANGO_STATIC_ROOT=/usr/lib/archivematica/storage-service/assets",
     "SS_DB_PASSWORD=",
     "SS_DB_USER=",
     "SS_DB_HOST=",


### PR DESCRIPTION
DJANGO_STATIC_ROOT was set during installation, but never used.

This commit removes the lines that set the env var.

fixes #179