### PR TITLE
Package: move pointer file removal (issue 11205)

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -1148,11 +1148,12 @@ class Package(models.Model):
 
             if was_compressed:
                 reingest_pointer = os.path.join(ss_internal.full_path, reingest_pointer_name)
+                os.remove(os.path.join(ss_internal.full_path, reingest_pointer_name))
             else:
                 reingest_pointer = os.path.join(ss_internal.full_path, utils.uuid_to_path(self.uuid), reingest_pointer_name)
 
                 # Remove initial copy of pointer
-                os.remove(os.path.join(ss_internal.full_path, reingest_pointer_name))
+                #os.remove(os.path.join(ss_internal.full_path, reingest_pointer_name))
 
         # Replace METS
         reingest_mets_path = os.path.join(reingest_full_path, 'data', 'METS.' + self.uuid + '.xml')


### PR DESCRIPTION

Change made per error at CVA (cvan105) where taking an Uncompressed AIP and doing a Re-ingest as compressed (e.g. 7zip) failed. Re-ingest seemed to work with this change.

- Justin and David H.

P.S.  I note (and therefore based this branch name on) existing branch dev/issue-8893-uncompressed-aip-reingest, not immediately sure how/if it might parallel or relate to the same issue.