### PR TITLE
Package: move pointer file removal

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -1151,7 +1151,8 @@ class Package(models.Model):
             else:
                 reingest_pointer = os.path.join(ss_internal.full_path, utils.uuid_to_path(self.uuid), reingest_pointer_name)
 
-                # Remove initial copy of pointer
+            # Remove initial copy of pointer
+            if was_compressed:
                 os.remove(os.path.join(ss_internal.full_path, reingest_pointer_name))
 
         # Replace METS


### PR DESCRIPTION

Per testing for CVA Archivematica dev site (cvan105) discussed in https://projects.artefactual.com/issues/11205

Looked at with Justin, related to Kelly's Re-ingest test (Uncompressed AIP created, then Re-ingest to compressed as 7zip), getting errors not finding compression pointer file (due to it being removed in all conditions). Making this change, re-ingest Kelly did the other day now worked.

I note (and based the name off) branch dev/issue-8893-uncompressed-aip-reingest by mcantelon, seems to be some divergence there that might be worth looking into along with this change?

- David H.