### PR TITLE
osdeps: add p7zip

### DIFF
--- a/osdeps/CentOS-7.json
+++ b/osdeps/CentOS-7.json
@@ -21,7 +21,8 @@
    { "name": "zlib-devel", "state": "latest"},
    { "name": "libffi-devel", "state": "latest"},
    { "name": "openssl-devel", "state": "latest"},
-   { "name": "gcc", "state": "latest"}
+   { "name": "gcc", "state": "latest"},
+   { "name": "p7zip", "state": "latest"},
+   { "name": "p7zip-plugins", "state": "latest"}
   ]
-
 }

--- a/osdeps/Ubuntu-14.json
+++ b/osdeps/Ubuntu-14.json
@@ -11,6 +11,7 @@
    { "name": "nginx", "state": "latest"},
    { "name": "unar", "state": "latest"},
    { "name": "rsync", "state": "latest"},
+   { "name": "p7zip-full", "state": "latest"},
    { "name": "python-dev", "state": "latest"},
    { "name": "libxml2-dev", "state": "latest"},
    { "name": "libxslt1-dev", "state": "latest"},


### PR DESCRIPTION
SS uses `7z` in a few places but it's not listed as a dependency in `debian/control`. I've added it to `Ubuntu-14.json`, that was easy. But I don't know what is the equivalent in CentOS - this may help but I'm not sure: https://gist.github.com/P7h/9fcccc54596ad05764128dec6f6cf78d.

Help, please! CC @scollazo @hakamine @jhsimpson 

Related: #191.