### PR TITLE
Re-ingest: don't delete pointer file, refs #11356

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -1147,10 +1147,6 @@ class Package(models.Model):
             else:
                 reingest_pointer = os.path.join(ss_internal.full_path, utils.uuid_to_path(self.uuid), reingest_pointer_name)
 
-            # Remove initial copy of pointer
-            if was_compressed:
-                os.remove(os.path.join(ss_internal.full_path, reingest_pointer_name))
-
         # Replace METS
         reingest_mets_path = os.path.join(reingest_full_path, 'data', 'METS.' + self.uuid + '.xml')
         original_mets_path = os.path.join(path, 'data', 'METS.' + self.uuid + '.xml')


### PR DESCRIPTION
In #203, a change was introduced in finish_reingest() to stop deleting the
pointer file if the AIP was uncompressed (see #11205 for more details).
The change was made so the file was instead deleted when the AIP was
compressed which is causing a different issue as that file is used later in
the same function so this commit reverts that part of #203.

This should be included in `qa/0.x` and `stable/0.10.x`.