### PR TITLE
move db dependencies out of base requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,6 @@ bagit==1.5.4
 brotli==0.5.2  # Better compression library for WhiteNoise
 defusedxml==0.5.0
 Django>=1.8,<1.9
-dj-database-url==0.4.2
 django-annoying==0.10.3
 django-braces==1.11.0
 django-extensions==1.7.9
@@ -21,9 +20,7 @@ gunicorn==19.7.1
 jsonfield==2.0.1
 logutils==0.3.4.1
 lxml==3.7.3
-mysqlclient==1.3.8
 ndg-httpsclient==0.4.2
-psycopg2==2.7.1
 pyasn1==0.2.3
 python-keystoneclient==3.10.0
 python-swiftclient==3.3.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,5 +4,11 @@
 ipython==1.1.0
 Sphinx==1.2b1
 
+# moving these db related dependencies out of base.txt as they are not needed
+# in all cases (i.e. test.txt doesn't need them, but local and production do)
+dj-database-url==0.4.2
+mysqlclient==1.3.8
+psycopg2==2.7.1
+
 # For managing translation strings on Transifex
 transifex-client==0.12.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,9 @@
 # Pro-tip: Try not to put anything here. There should be no dependency in
 # production that isn't in development.
 -r base.txt
+
+# moving these db related dependencies out of base.txt as they are not needed
+# in all cases (i.e. test.txt doesn't need them, but local and production do)
+dj-database-url==0.4.2
+mysqlclient==1.3.8
+psycopg2==2.7.1


### PR DESCRIPTION
fixes #222

It should not be necessary to install the database pip packages
such as mysqlclient and psycopg2 in a test environment.

This commit duplicates some deps, in local.txt and production.txt
but it allows test environments to exclude these packages.

This helps reduce the size of the test environment and the time it
takes to run tests, since some of these pip packages require
operating system packages to be installed as well.