### PR TITLE
Configurable BagIt validation processes & warnings re Gunicorn gevent

### DIFF
--- a/install/storage-service.gunicorn-config.py
+++ b/install/storage-service.gunicorn-config.py
@@ -16,6 +16,10 @@ bind = os.environ.get('SS_GUNICORN_BIND', '127.0.0.1:8001')
 workers = os.environ.get('SS_GUNICORN_WORKERS', '4')
 
 # http://docs.gunicorn.org/en/stable/settings.html#worker-class
+# WARNING: if ``worker_class`` is set to ``'gevent'``, then
+# ``BAG_VALIDATION_NO_PROCESSES`` in settings/base.py *must* be set to 1.
+# Otherwise reingest will fail at bagit validate. See
+# https://github.com/artefactual/archivematica/issues/708
 worker_class = os.environ.get('SS_GUNICORN_WORKER_CLASS', 'gevent')
 
 # http://docs.gunicorn.org/en/stable/settings.html#timeout

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -12,6 +12,7 @@ import subprocess
 import tempfile
 
 # Core Django, alphabetical
+from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext as _, ugettext_lazy as _l
 
@@ -840,7 +841,7 @@ class Package(models.Model):
 
         bag = bagit.Bag(path)
         try:
-            success = bag.validate(processes=4)
+            success = bag.validate(processes=settings.BAG_VALIDATION_NO_PROCESSES)
             failures = []
             message = ""
         except bagit.BagValidationError as failure:
@@ -1195,7 +1196,8 @@ class Package(models.Model):
         bag = bagit.Bag(path)
         bag.save(manifests=True)
         bag = bagit.Bag(path)  # Workaround for bug https://github.com/LibraryOfCongress/bagit-python/pull/63
-        bag.validate(processes=4)  # Raises exception in case of problem
+        # Raises exception in case of problem
+        bag.validate(processes=settings.BAG_VALIDATION_NO_PROCESSES)
 
         # Compress if necessary
         if to_be_compressed:

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -377,3 +377,14 @@ if SHIBBOLETH_AUTHENTICATION:
     INSTALLED_APPS += ['shibboleth']
 
     ALLOW_USER_EDITS = False
+
+# WARNING: if Gunicorn is being used to serve the Storage Service and its
+# worker class is set to `gevent`, then BagIt validation must use 1 process.
+# Otherwise, calls to `validate` will hang because of the incompatibility
+# between gevent and multiprocessing (BagIt) concurrency strategies. See
+# https://github.com/artefactual/archivematica/issues/708
+try:
+    BAG_VALIDATION_NO_PROCESSES = int(
+        environ.get('SS_BAG_VALIDATION_NO_PROCESSES', 1))
+except ValueError:
+    BAG_VALIDATION_NO_PROCESSES = 1


### PR DESCRIPTION
Fixes artefactual/archivematica#708
    
Allows user to configure number of processes to use when calling BagIt-python's ``validate`` method. Using more than one when the Gunicorn worker class is 'gevent' causes BagIt validate to hang. This change warns the user/installer of Archivematica about that in two places.