### PR TITLE
Fixes re-ingest (issue #234)

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -570,6 +570,9 @@ class Package(models.Model):
 
             LOGGER.info('Copying from: %s to %s', src, output_path)
 
+        if not relative_path:
+            self.local_path_location = ss_internal
+            self.local_path = output_path
         return (output_path, extract_path)
 
     def compress_package(self, algorithm, extract_path=None):


### PR DESCRIPTION
Fixes #234 by making sure that `Package().local_path_location` is set to
`ss_internal` in `extract_file`. Without this, `start_reingest` tries to
copy non-existent files.