### PR TITLE
Mirror locations and AIP replicas

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ gunicorn==19.7.1
 jsonfield==2.0.1
 logutils==0.3.4.1
 lxml==3.7.3
-git+https://github.com/artefactual-labs/mets-reader-writer.git@dev/issue-10662-write-pointer-files
+metsrw==0.2.0
 ndg-httpsclient==0.4.2
 pyasn1==0.2.3
 python-gnupg==0.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,7 @@ gunicorn==19.7.1
 jsonfield==2.0.1
 logutils==0.3.4.1
 lxml==3.7.3
+git+https://github.com/artefactual-labs/mets-reader-writer.git@dev/issue-10662-write-pointer-files
 ndg-httpsclient==0.4.2
 pyasn1==0.2.3
 python-gnupg==0.4.0

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -1,4 +1,5 @@
 import ast
+from collections import namedtuple
 import datetime
 import hashlib
 import logging
@@ -380,3 +381,8 @@ def get_ss_premis_agents(inst=True):
     if inst:
         return [metsrw.PREMISAgent(data=data) for data in agents]
     return agents
+
+
+StorageEffects = namedtuple(
+    'StorageEffects',
+    ['events', 'composition_level_updater', 'inhibitors'])

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import uuid
 
-import metsrw
+from metsrw.plugins import premisrw
 
 from django.core.exceptions import ObjectDoesNotExist
 from django import http
@@ -336,7 +336,7 @@ def add_agents_to_event_as_list(event, agents):
     """Add agents in ``agents`` to the list ``event`` which represents a
     PREMIS:EVENT.
     :param list event: a PREMIS:EVENT represented as a list
-    :param iterable agents: an iterable of metsrw.PREMISAgent instances.
+    :param iterable agents: an iterable of premisrw.PREMISAgent instances.
     """
     for agent in agents:
         event.append((
@@ -368,7 +368,7 @@ def get_ss_premis_agents(inst=True):
     """
     agents = [(
         'agent',
-        metsrw.PREMIS_META,
+        premisrw.PREMIS_META,
         (
             'agent_identifier',
             ('agent_identifier_type', 'preservation system'),
@@ -379,7 +379,7 @@ def get_ss_premis_agents(inst=True):
         ('agent_type', 'software')
     )]
     if inst:
-        return [metsrw.PREMISAgent(data=data) for data in agents]
+        return [premisrw.PREMISAgent(data=data) for data in agents]
     return agents
 
 

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -440,6 +440,11 @@ class PackageResource(ModelResource):
     current_full_path = fields.CharField(attribute='full_path', readonly=True)
     related_packages = fields.ManyToManyField('self', 'related_packages', null=True)
 
+    replicated_package = fields.ForeignKey(
+        'self', 'replicated_package', null=True, blank=True, readonly=True)
+    replicas = fields.ManyToManyField(
+        'self', 'replicas', null=True, blank=True, readonly=True)
+
     default_location_regex = re.compile(r'\/api\/v2\/location\/default\/(?P<purpose>[A-Z]{2})\/?')
 
     class Meta:
@@ -453,7 +458,9 @@ class PackageResource(ModelResource):
         # that name.
         resource_name = 'file'
 
-        fields = ['current_path', 'package_type', 'size', 'status', 'uuid', 'related_packages', 'misc_attributes']
+        fields = ['current_path', 'package_type', 'size', 'status', 'uuid',
+                  'related_packages', 'misc_attributes', 'replicated_package',
+                  'replicas']
         list_allowed_methods = ['get', 'post']
         detail_allowed_methods = ['get', 'put', 'patch']
         allowed_patch_fields = ['reingest']  # for customized update_in_place

--- a/storage_service/locations/migrations/0016_mirror_location_aip_replication.py
+++ b/storage_service/locations/migrations/0016_mirror_location_aip_replication.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locations', '0015_gpg_encrypted_space'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='location',
+            name='replicators',
+            field=models.ManyToManyField(help_text='Other locations that will be used to create replicas of the packages stored in this location', related_name='masters', verbose_name='Replicators', to='locations.Location', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='location',
+            name='purpose',
+            field=models.CharField(help_text='Purpose of the space.  Eg. AIP storage, Transfer source', max_length=2, verbose_name='Purpose', choices=[(b'AR', 'AIP Recovery'), (b'AS', 'AIP Storage'), (b'CP', 'Currently Processing'), (b'DS', 'DIP Storage'), (b'SD', 'FEDORA Deposits'), (b'SS', 'Storage Service Internal Processing'), (b'BL', 'Transfer Backlog'), (b'TS', 'Transfer Source'), (b'RP', 'Replicator')]),
+        ),
+        migrations.AddField(
+            model_name='package',
+            name='replicated_package',
+            field=models.ForeignKey(related_name='replicas', to_field=b'uuid', blank=True, to='locations.Package', null=True),
+        ),
+    ]

--- a/storage_service/locations/models/gpg.py
+++ b/storage_service/locations/models/gpg.py
@@ -15,7 +15,6 @@ from django.db import models
 from django.utils.translation import ugettext as _, ugettext_lazy as _l
 
 # Third party dependencies, alphabetical
-import gnupg
 
 # This project, alphabetical
 from common import utils
@@ -243,8 +242,6 @@ class GPG(models.Model):
         verified = os.path.isdir(self.space.path)
         self.space.verified = verified
         self.space.last_verified = datetime.datetime.now()
-
-
 
 
 def _gpg_encrypt(path, key_fingerprint):

--- a/storage_service/locations/models/gpg.py
+++ b/storage_service/locations/models/gpg.py
@@ -8,7 +8,7 @@ import subprocess
 import tarfile
 from uuid import uuid4
 
-import metsrw
+from metsrw.plugins import premisrw
 
 # Core Django, alphabetical
 from django.db import models
@@ -347,7 +347,7 @@ def create_encryption_event(encr_result, key_fingerprint):
     agents = utils.get_ss_premis_agents()
     event = [
         'event',
-        metsrw.PREMIS_META,
+        premisrw.PREMIS_META,
         (
             'event_identifier',
             ('event_identifier_type', 'UUID'),
@@ -366,7 +366,7 @@ def create_encryption_event(encr_result, key_fingerprint):
         )
     ]
     event = tuple(utils.add_agents_to_event_as_list(event, agents))
-    return metsrw.PREMISEvent(data=event)
+    return premisrw.PREMISEvent(data=event)
 
 
 def _gpg_decrypt(path):

--- a/storage_service/locations/models/local_filesystem.py
+++ b/storage_service/locations/models/local_filesystem.py
@@ -31,6 +31,7 @@ class LocalFilesystem(models.Model):
         Location.STORAGE_SERVICE_INTERNAL,
         Location.TRANSFER_SOURCE,
         Location.BACKLOG,
+        Location.REPLICATOR,
     ]
 
     def move_to_storage_service(self, src_path, dest_path, dest_space):

--- a/storage_service/locations/models/location.py
+++ b/storage_service/locations/models/location.py
@@ -39,6 +39,7 @@ class Location(models.Model):
     STORAGE_SERVICE_INTERNAL = 'SS'
     BACKLOG = 'BL'
     TRANSFER_SOURCE = 'TS'
+    REPLICATOR = 'RP'
 
     PURPOSE_CHOICES = (
         (AIP_RECOVERY, _l('AIP Recovery')),
@@ -50,6 +51,7 @@ class Location(models.Model):
         (STORAGE_SERVICE_INTERNAL, _l('Storage Service Internal Processing')),
         (BACKLOG, _l('Transfer Backlog')),
         (TRANSFER_SOURCE, _l('Transfer Source')),
+        (REPLICATOR, _l('Replicator')),
     )
     purpose = models.CharField(max_length=2,
         choices=PURPOSE_CHOICES,
@@ -75,6 +77,13 @@ class Location(models.Model):
     enabled = models.BooleanField(default=True,
         verbose_name=_l('Enabled'),
         help_text=_l("True if space can be accessed."))
+    replicators = models.ManyToManyField(
+        'Location',
+        blank=True,
+        related_name='masters',
+        verbose_name=_l('Replicators'),
+        help_text=_l('Other locations that will be used to create replicas of'
+                     ' the packages stored in this location'))
 
     class Meta:
         verbose_name = _l("Location")

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -2638,11 +2638,13 @@ def _get_replication_derivation_relationship(related_aip_uuid,
         'relationship',
         ('relationship_type', 'derivation'),
         ('relationship_sub_type', ''),
-        (related_object_identifier,
+        (
+            related_object_identifier,
             ('related_object_identifier_type', 'UUID'),
             ('related_object_identifier_value', related_aip_uuid)
         ),
-        (related_event_identifier,
+        (
+            related_event_identifier,
             ('related_event_identifier_type', 'UUID'),
             ('related_event_identifier_value', replication_event_uuid)
         ),

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -348,7 +348,7 @@ class Space(models.Model):
         source_path, destination_path = self._move_from_path_mangling(source_path, destination_path)
         child_space = self.get_child_space()
         if hasattr(child_space, 'move_from_storage_service'):
-            child_space.move_from_storage_service(
+            return child_space.move_from_storage_service(
                 source_path, destination_path, *args, **kwargs)
         else:
             raise NotImplementedError(_('%(protocol)s space has not implemented %(method)s') % {'protocol': self.get_access_protocol_display(), 'method': 'move_from_storage_service'})

--- a/storage_service/locations/tests/test_package_pointer.py
+++ b/storage_service/locations/tests/test_package_pointer.py
@@ -113,7 +113,7 @@ TEST_PREMIS_EVENT_DATE_TIME = '2017-08-15T00:30:55'
 TEST_PREMIS_EVENT_DETAIL = (
     'program=7z; '
     'version=p7zip Version 9.20 '
-        '(locale=en_US.UTF-8,Utf16=on,HugeFiles=on,2 CPUs); '
+    '(locale=en_US.UTF-8,Utf16=on,HugeFiles=on,2 CPUs); '
     'algorithm=bzip2')
 TEST_PREMIS_EVENT_OUTCOME_DETAIL_NOTE = (
     'Standard Output="..."; Standard Error=""')

--- a/storage_service/locations/tests/test_package_pointer.py
+++ b/storage_service/locations/tests/test_package_pointer.py
@@ -1,0 +1,169 @@
+import os
+from uuid import uuid4
+
+import metsrw
+from django.test import TestCase
+
+from locations import models
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+FIXTURES_DIR = os.path.abspath(os.path.join(THIS_DIR, '..', 'fixtures', ''))
+
+
+TEST_PREMIS_OBJECT_UUID = str(uuid4())
+TEST_PREMIS_OBJECT_MESSAGE_DIGEST_ALGORITHM = 'sha256'
+TEST_PREMIS_OBJECT_MESSAGE_DIGEST = (
+    '78e4509313928d2964fe877a6a82f1ba728c171eedf696e3f5b0aed61ec547f6')
+TEST_PREMIS_OBJECT_SIZE = '11854'
+TEST_PREMIS_OBJECT_FORMAT_NAME = '7Zip format'
+TEST_PREMIS_OBJECT_FORMAT_REGISTRY_KEY = 'fmt/484'
+TEST_PREMIS_OBJECT_DATE_CREATED_BY_APPLICATION = '2017-08-15T00:30:55'
+TEST_PREMIS_OBJECT_CREATING_APPLICATION_NAME = '7-Zip'
+TEST_PREMIS_OBJECT_CREATING_APPLICATION_VERSION = (
+    'p7zip Version 9.20 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,2 CPUs)')
+TEST_PREMIS_OBJECT_AIP_SUBTYPE = 'Some strange subtype'
+TEST_PREMIS_OBJECT_ATTRS = metsrw.PREMIS_META.copy()
+TEST_PREMIS_OBJECT_ATTRS['xsi:type'] = 'premis:file'
+TEST_PREMIS_OBJECT = (
+    'object',
+    TEST_PREMIS_OBJECT_ATTRS,
+    (
+        'object_identifier',
+        ('object_identifier_type', 'UUID'),
+        ('object_identifier_value', TEST_PREMIS_OBJECT_UUID)
+    ),
+    (
+        'object_characteristics',
+        ('composition_level', '1'),
+        (
+            'fixity',
+            ('message_digest_algorithm',
+                TEST_PREMIS_OBJECT_MESSAGE_DIGEST_ALGORITHM),
+            ('message_digest', TEST_PREMIS_OBJECT_MESSAGE_DIGEST)
+        ),
+        ('size', TEST_PREMIS_OBJECT_SIZE),
+        (
+            'format',
+            (
+                'format_designation',
+                ('format_name', TEST_PREMIS_OBJECT_FORMAT_NAME),
+                ('format_version', '')
+            ),
+            (
+                'format_registry',
+                ('format_registry_name', 'PRONOM'),
+                ('format_registry_key', TEST_PREMIS_OBJECT_FORMAT_REGISTRY_KEY)
+            )
+        ),
+        (
+            'creating_application',
+            ('creating_application_name',
+                TEST_PREMIS_OBJECT_CREATING_APPLICATION_NAME),
+            ('creating_application_version',
+                TEST_PREMIS_OBJECT_CREATING_APPLICATION_VERSION),
+            ('date_created_by_application',
+                TEST_PREMIS_OBJECT_DATE_CREATED_BY_APPLICATION)
+        )
+    )
+)
+
+
+TEST_PREMIS_AGENT_1_IDENTIFIER_TYPE = 'preservation system'
+TEST_PREMIS_AGENT_1_IDENTIFIER_VALUE = 'Archivematica-1.6.1'
+TEST_PREMIS_AGENT_1_NAME = 'Archivematica'
+TEST_PREMIS_AGENT_1_TYPE = 'software'
+TEST_PREMIS_AGENT_1 = (
+    'agent',
+    metsrw.PREMIS_META,
+    (
+        'agent_identifier',
+        ('agent_identifier_type', TEST_PREMIS_AGENT_1_IDENTIFIER_TYPE),
+        ('agent_identifier_value', TEST_PREMIS_AGENT_1_IDENTIFIER_VALUE)
+    ),
+    ('agent_name', TEST_PREMIS_AGENT_1_NAME),
+    ('agent_type', TEST_PREMIS_AGENT_1_TYPE)
+)
+
+TEST_PREMIS_AGENT_2_IDENTIFIER_TYPE = 'repository code'
+TEST_PREMIS_AGENT_2_IDENTIFIER_VALUE = 'username'
+TEST_PREMIS_AGENT_2_NAME = 'username'
+TEST_PREMIS_AGENT_2_TYPE = 'organization'
+TEST_PREMIS_AGENT_2 = (
+    'agent',
+    metsrw.PREMIS_META,
+    (
+        'agent_identifier',
+        ('agent_identifier_type', TEST_PREMIS_AGENT_2_IDENTIFIER_TYPE),
+        ('agent_identifier_value', TEST_PREMIS_AGENT_2_IDENTIFIER_VALUE)
+    ),
+    ('agent_name', TEST_PREMIS_AGENT_2_NAME),
+    ('agent_type', TEST_PREMIS_AGENT_2_TYPE)
+)
+
+TEST_PREMIS_EVENT_AGENTS = (
+    {'identifier_type': TEST_PREMIS_AGENT_1_IDENTIFIER_TYPE,
+     'identifier_value': TEST_PREMIS_AGENT_1_IDENTIFIER_VALUE},
+    {'identifier_type': TEST_PREMIS_AGENT_2_IDENTIFIER_TYPE,
+     'identifier_value': TEST_PREMIS_AGENT_2_IDENTIFIER_VALUE}
+)
+
+TEST_PREMIS_EVENT_IDENTIFIER_VALUE = str(uuid4())
+TEST_PREMIS_EVENT_TYPE = 'compression'
+TEST_PREMIS_EVENT_DATE_TIME = '2017-08-15T00:30:55'
+TEST_PREMIS_EVENT_DETAIL = (
+    'program=7z; '
+    'version=p7zip Version 9.20 '
+        '(locale=en_US.UTF-8,Utf16=on,HugeFiles=on,2 CPUs); '
+    'algorithm=bzip2')
+TEST_PREMIS_EVENT_OUTCOME_DETAIL_NOTE = (
+    'Standard Output="..."; Standard Error=""')
+
+TEST_PREMIS_EVENT = (
+    'event',
+    metsrw.PREMIS_META,
+    (
+        'event_identifier',
+        ('event_identifier_type', 'UUID'),
+        ('event_identifier_value', TEST_PREMIS_EVENT_IDENTIFIER_VALUE)
+    ),
+    ('event_type', TEST_PREMIS_EVENT_TYPE),
+    ('event_date_time', TEST_PREMIS_EVENT_DATE_TIME),
+    ('event_detail', TEST_PREMIS_EVENT_DETAIL),
+    (
+        'event_outcome_information',
+        ('event_outcome',),
+        (
+            'event_outcome_detail',
+            ('event_outcome_detail_note', TEST_PREMIS_EVENT_OUTCOME_DETAIL_NOTE)
+        )
+    ),
+    (
+        'linking_agent_identifier',
+        ('linking_agent_identifier_type', TEST_PREMIS_AGENT_1_IDENTIFIER_TYPE),
+        ('linking_agent_identifier_value', TEST_PREMIS_AGENT_1_IDENTIFIER_VALUE)
+    ),
+    (
+        'linking_agent_identifier',
+        ('linking_agent_identifier_type', TEST_PREMIS_AGENT_2_IDENTIFIER_TYPE),
+        ('linking_agent_identifier_value', TEST_PREMIS_AGENT_2_IDENTIFIER_VALUE)
+    )
+)
+
+
+class TestPackagePointer(TestCase):
+    """Test the package model's pointer file-related capabilities."""
+
+    fixtures = ['base.json', 'package.json']
+
+    def setUp(self):
+        self.package = models.Package.objects.all()[0]
+
+    def test_create_pointer_file(self):
+        """ It should be able to create a pointer file. """
+        pointer_file = self.package.create_pointer_file(
+            TEST_PREMIS_OBJECT, [TEST_PREMIS_EVENT],
+            premis_agents=[TEST_PREMIS_AGENT_1, TEST_PREMIS_AGENT_2],
+            validate=False)
+        is_valid, report = metsrw.validate(
+            pointer_file.serialize(), schematron=metsrw.AM_PNTR_SCT_PATH)
+        assert is_valid

--- a/storage_service/locations/tests/test_package_pointer.py
+++ b/storage_service/locations/tests/test_package_pointer.py
@@ -2,6 +2,7 @@ import os
 from uuid import uuid4
 
 import metsrw
+from metsrw.plugins import premisrw
 from django.test import TestCase
 
 from locations import models
@@ -22,7 +23,7 @@ TEST_PREMIS_OBJECT_CREATING_APPLICATION_NAME = '7-Zip'
 TEST_PREMIS_OBJECT_CREATING_APPLICATION_VERSION = (
     'p7zip Version 9.20 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,2 CPUs)')
 TEST_PREMIS_OBJECT_AIP_SUBTYPE = 'Some strange subtype'
-TEST_PREMIS_OBJECT_ATTRS = metsrw.PREMIS_META.copy()
+TEST_PREMIS_OBJECT_ATTRS = premisrw.PREMIS_META.copy()
 TEST_PREMIS_OBJECT_ATTRS['xsi:type'] = 'premis:file'
 TEST_PREMIS_OBJECT = (
     'object',
@@ -74,7 +75,7 @@ TEST_PREMIS_AGENT_1_NAME = 'Archivematica'
 TEST_PREMIS_AGENT_1_TYPE = 'software'
 TEST_PREMIS_AGENT_1 = (
     'agent',
-    metsrw.PREMIS_META,
+    premisrw.PREMIS_META,
     (
         'agent_identifier',
         ('agent_identifier_type', TEST_PREMIS_AGENT_1_IDENTIFIER_TYPE),
@@ -90,7 +91,7 @@ TEST_PREMIS_AGENT_2_NAME = 'username'
 TEST_PREMIS_AGENT_2_TYPE = 'organization'
 TEST_PREMIS_AGENT_2 = (
     'agent',
-    metsrw.PREMIS_META,
+    premisrw.PREMIS_META,
     (
         'agent_identifier',
         ('agent_identifier_type', TEST_PREMIS_AGENT_2_IDENTIFIER_TYPE),
@@ -120,7 +121,7 @@ TEST_PREMIS_EVENT_OUTCOME_DETAIL_NOTE = (
 
 TEST_PREMIS_EVENT = (
     'event',
-    metsrw.PREMIS_META,
+    premisrw.PREMIS_META,
     (
         'event_identifier',
         ('event_identifier_type', 'UUID'),

--- a/storage_service/templates/locations/location_detail.html
+++ b/storage_service/templates/locations/location_detail.html
@@ -15,6 +15,42 @@
     <dt>{% trans "Usage" %}</dt> <dd>{{ location.used|filesizeformat }} / {{ location.quota|filesizeformat }}</dd>
     <dt>{% trans "Enabled" %}</dt> <dd>{{ location.enabled|yesno:_("Enabled,Disabled") }}</dd>
     <dt>{% trans "Default" %}</dt> <dd>{{ location.default|yesno:_("Yes,No") }}</dd>
+
+    <!-- List replicators if location is non-replicator; otherwise list links to masters. -->
+    {% if location.purpose == 'RP' %}
+      {% with location.masters.all as master_locations %}
+        <dt>{% trans "Master locations" %}</dt>
+          <dd>
+          {% if master_locations %}
+            <ul>
+              {% for master in master_locations %}
+                <li><a href="{% url 'location_detail' master.uuid %}">{{ master }}</a></li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            There are none.
+          {% endif %}
+          </dd>
+        </dt>
+      {% endwith %}
+    {% else %}
+      {% with location.replicators.all as replicator_locations %}
+        <dt>{% trans "Replicator locations" %}</dt>
+          <dd>
+          {% if replicator_locations %}
+            <ul>
+              {% for replicator in replicator_locations %}
+                <li><a href="{% url 'location_detail' replicator.uuid %}">{{ replicator }}</a></li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            There are none.
+          {% endif %}
+          </dd>
+        </dt>
+      {% endwith %}
+    {% endif %}
+
     <dt>{% trans "Actions" %}</dt>
       <dd>
         <ul>

--- a/storage_service/templates/locations/location_form.html
+++ b/storage_service/templates/locations/location_form.html
@@ -46,6 +46,19 @@
         'directory_picker',
         '{% url "browse" "v2" "space" space.uuid %}'
       );
+
+      // Hide the "Replicators" field when the location being created is itself
+      // a replicator: replicators can't have replicators.
+      $('select#id_purpose').change(function(event) {replicatorsVisibility();});
+      function replicatorsVisibility() {
+        var purpose = $('select#id_purpose').val();
+        if (purpose === 'RP') {
+            $('select#id_replicators').closest('p').hide();
+        } else {
+            $('select#id_replicators').closest('p').show();
+        }
+      }
+      replicatorsVisibility();
     });
   </script>
 

--- a/storage_service/templates/snippets/locations_table.html
+++ b/storage_service/templates/snippets/locations_table.html
@@ -21,7 +21,18 @@
     <tbody>
     {% for loc in locations %}
       <tr>
-        <td>{{ loc.get_purpose_display }}</td>
+        <td>{{ loc.get_purpose_display }}
+          {% if loc.purpose == 'RP' %}
+            {% with loc.masters.all as master_locations %}
+                {% if master_locations %}
+                  of
+                  {% for master in master_locations %}
+                    <a href="{% url 'location_detail' master.uuid %}">{{ master.uuid }}</a></li>
+                  {% endfor %}
+                {% endif %}
+            {% endwith %}
+          {% endif %}
+        </td>
         {% if not no_pipeline %}
           <td>
           {% for p in loc.pipeline.all %}

--- a/storage_service/templates/snippets/packages_table.html
+++ b/storage_service/templates/snippets/packages_table.html
@@ -8,6 +8,8 @@
         <th>{% trans "Current Location" %}</th>
         <th>{% trans "Size" %}</th>
         <th>{% trans "Type" %}</th>
+        <th>{% trans "Replicas" %}</th>
+        <th>{% trans "Is Replica Of" %}</th>
         <th>{% trans "Pointer File" %}</th>
         <th>{% trans "Status" %}</th>
         <th>{% trans "Fixity Date" %}</th>
@@ -30,6 +32,25 @@
         <td><a href="{% url 'location_detail' package.current_location.uuid %}">{{ package.full_path }}</a></td>
         <td>{{ package.size|filesizeformat }}</td>
         <td>{{ package.get_package_type_display }}</td>
+
+        <td>
+        {% with package.replicas.all as replicas %}
+          {% if replicas %}
+            <ul>
+            {% for replica in replicas %}
+              <li>{{ replica.uuid }}</li>
+            {% endfor %}
+            </ul>
+          {% endif %}
+        {% endwith %}
+        </td>
+
+        <td>
+        {% if package.replicated_package %}
+          {{ package.replicated_package.uuid }}
+        {% endif %}
+        </td>
+
         <td>
           {% if package.pointer_file_location %}
           <a href="{% url 'pointer_file_request' 'v2' 'file' package.uuid %}">{% trans "Pointer File" %}</a>
@@ -51,7 +72,8 @@
         </td>
         <td>
           <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">{% trans "Download" %}</a>
-          {% if package.package_type in 'AIP AIC' %}
+          <!-- Replicas should not be re-ingestible -->
+          {% if package.package_type in 'AIP AIC' and not package.replicated_package %}
             <a href="{% url 'aip_reingest' package.uuid %}?next={{ request.path }}">{% trans "Re-ingest" %}</a>
           {% endif %}
         </td>


### PR DESCRIPTION
This PR brings AIP replication to the Storage Service. Users can now create locations with purpose `Replicator` (`RP`). A replicator location can be configured as a replicator location of any number of AIP Storage (`AS`) locations. When an AIP is stored (`Package.store_aip` is called), that AIP is now replicated to all of the replicator locations belonging to the AIP's `AS` location. The pointer files of both replica and the replicated AIPs are modified to document the replication that has occurred.

This PR uses [metsrw branch dev/issue-10662-write-pointer-files](https://github.com/artefactual-labs/mets-reader-writer/pull/27) which introduces a new way to create pointer files, including PREMIS elements. This is informed by [this draft Architectural Decision Record for unifying METS interactions in Archivematica](https://docs.google.com/a/artefactual.com/document/d/1mAOtwCxyj5i3uF3fufoBZXn2F0MYNYg-nfjUBFm6EwY/edit?usp=sharing).

# Warnings

1. This does not currently work with AIP re-ingest. That is, a re-ingested AIP will (probably) not be replicated in the cases where it should be. In addition, it will be necessary to implement logic such that when an AIP is re-ingested deletion requests are issued against its outdated replicas. See [Artefactual-internal "Estimate: AIP Encryption via Mirror Locations (and Replica Packages)"](https://docs.google.com/document/d/1PQqwgTHYEV4XXe_9et9CNTznSyb34Nk26rls-PHjaYs/edit)
2. More unit tests should be written for the new methods/functions in package.py. Related to this, these methods/functions should be refactored where possible to make them pure/side-effect-less so that unit tests creation can be facilitated.

