### PR TITLE
Enable re-login after Shibboleth logout

### DIFF
--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -251,7 +251,6 @@ LOGIN_REDIRECT_URL = '/'
 LOGIN_EXEMPT_URLS = (
     r'^api/',
     r'^admin/',
-    r'^logged-out',
     r'^Shibboleth.sso/',
     r'^login/',
 )
@@ -348,7 +347,6 @@ def is_true(env_str):
 SHIBBOLETH_AUTHENTICATION = is_true(environ.get('SS_SHIBBOLETH_AUTHENTICATION', ''))
 if SHIBBOLETH_AUTHENTICATION:
     SHIBBOLETH_LOGOUT_URL = '/Shibboleth.sso/Logout?target=%s'
-    SHIBBOLETH_LOGOUT_REDIRECT_URL = '/logged-out'
 
     SHIBBOLETH_REMOTE_USER_HEADER = 'HTTP_EPPN'
     SHIBBOLETH_ATTRIBUTE_MAP = {

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -28,8 +28,6 @@ urlpatterns = [
 
     url(r'^jsi18n/$', views.cached_javascript_catalog, {'domain': 'djangojs'}, name='javascript-catalog'),
     url(r'^i18n/', include('django.conf.urls.i18n', namespace='i18n')),
-
-    url(r'^logged-out/', TemplateView.as_view(template_name='logged_out.html')),
 ]
 
 

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -32,8 +32,16 @@ urlpatterns = [
 
 
 if 'shibboleth' in settings.INSTALLED_APPS:
+    # Simulate a shibboleth urls module (so our custom Shibboleth logout view
+    # matches the same namespaced URL name as the standard logout view from
+    # the shibboleth lib)
+    class shibboleth_urls:
+        urlpatterns = [
+            url(r'^logout/$', views.CustomShibbolethLogoutView.as_view(), name='logout'),
+        ]
+
     urlpatterns += [
-        url(r'^shib/', include('shibboleth.urls', namespace='shibboleth')),
+        url(r'^shib/', include(shibboleth_urls, namespace='shibboleth')),
     ]
 
 

--- a/storage_service/storage_service/views.py
+++ b/storage_service/storage_service/views.py
@@ -3,9 +3,22 @@ from django.utils import timezone
 from django.views.decorators.cache import cache_page
 from django.views.decorators.http import last_modified
 from django.views.i18n import javascript_catalog
+from shibboleth.views import ShibbolethLogoutView, LOGOUT_SESSION_KEY
 
 
 @cache_page(86400, key_prefix='js18n-%s' % get_language())
 @last_modified(lambda req, **kw: timezone.now())
 def cached_javascript_catalog(request, domain='djangojs', packages=None):
     return javascript_catalog(request, domain, packages)
+
+
+class CustomShibbolethLogoutView(ShibbolethLogoutView):
+    def get(self, request, *args, **kwargs):
+        response = super(CustomShibbolethLogoutView, self).get(request, *args, **kwargs)
+        # LOGOUT_SESSION_KEY is set by the standard logout to prevent re-login
+        # which is useful to prevent bouncing straight back to login under
+        # certain setups, but not here where we want the Django session state
+        # to reflect the SP session state
+        if LOGOUT_SESSION_KEY in request.session:
+            del request.session[LOGOUT_SESSION_KEY]
+        return response


### PR DESCRIPTION
django-shibboleth-user sets a session flag to prevent immediate bounce back to logged in state after logout. This is useful in some setups but is unnecessary here, and it prevents logging back in again until cookies are cleared.

I've added a custom logout which unsets that session flag after the standard logout. This should enable users to log back in.

Fixes #238 

See also https://github.com/artefactual/archivematica/pull/754 (AM PR)