### PR TITLE
Add errors to flake8 ignore list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
 [flake8]
 exclude = .tox, .git, __pycache__, .cache, build, dist, *.pyc, *.egg-info, .eggs
 application-import-names = flake8
-ignore = E501, E128
+ignore = E501, E128, E722, E741
 max-line-length = 160
 
 ; Report: $ .tox/flake8/bin/flake8 --isolated -qq --statistics --count --max-line-length=160


### PR DESCRIPTION
- E722: do not use bare except.
- E741: ambiguous variable name 'l'.