### PR TITLE
Delete media block from nginx sample

### DIFF
--- a/install/storage
+++ b/install/storage
@@ -11,10 +11,6 @@ server {
     # Adjust to taste
     client_max_body_size 256M;
 
-    location /static {
-        alias /usr/lib/archivematica/storage-service/assets;
-    }
-
     location / {
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Unneeded since we started using WhiteNoise.