### PR TITLE
Backward-compatible logging

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -1,0 +1,22 @@
+## Logging configuration
+
+Storage Service 0.10.0 and earlier releases are configured by default to log to
+the `/var/log/archivematica/storage-service` directory, such as
+`/var/log/archivematica/storage-service/storage_service.log`. Starting with
+Storage Service 0.11.0, logging configuration defaults to using stdout and
+stderr for all logs. If no changes are made to the new default configuration
+logs will be handled by whichever process is managing Archivematica's services.
+For example on Ubuntu 16.04 or Centos 7, Archivematica's processes are managed by
+systemd. Logs for the Storage Service can be accessed using
+`sudo journalctl -u archivematica-storage-service`. On Ubuntu 14.04, upstart is
+used instead of systemd, so logs are usually found in `/var/log/upstart`. When
+running Archivematica using docker, `docker-compose logs` commands can be used
+to access the logs from different containers.
+
+The Storage Service will look in `/etc/archivematica` for a file called
+`storageService.logging.json`, and if found, this file will override the default
+behaviour described above.
+
+The [`logging.json`](./logging.json) file in this directory provides an example
+that implements the logging behaviour used in Storage Service 0.10.0 and
+earlier.

--- a/install/logging.json
+++ b/install/logging.json
@@ -1,0 +1,83 @@
+{
+  "disable_existing_loggers": false,
+  "filters": {
+    "require_debug_false": {
+      "()": "django.utils.log.RequireDebugFalse"
+    }
+  },
+  "formatters": {
+    "detailed": {
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "format": "%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s"
+    },
+    "simple": {
+      "format": "%(levelname)-8s  %(name)s.%(funcName)s:  %(message)s"
+    }
+  },
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "formatter": "simple",
+      "level": "DEBUG"
+    },
+    "logfile": {
+      "backupCount": 5,
+      "class": "logging.handlers.RotatingFileHandler",
+      "filename": "/var/log/archivematica/storage-service/storage_service.log",
+      "formatter": "detailed",
+      "level": "INFO",
+      "maxBytes": 20971520
+    },
+    "mail_admins": {
+      "class": "django.utils.log.AdminEmailHandler",
+      "filters": [
+        "require_debug_false"
+      ],
+      "level": "ERROR"
+    },
+    "null": {
+      "class": "logging.NullHandler",
+      "level": "DEBUG"
+    },
+    "verboselogfile": {
+      "backupCount": 5,
+      "class": "logging.handlers.RotatingFileHandler",
+      "filename": "/var/log/archivematica/storage-service/storage_service_debug.log",
+      "formatter": "detailed",
+      "level": "DEBUG",
+      "maxBytes": 104857600
+    }
+  },
+  "loggers": {
+    "administration": {
+      "level": "DEBUG"
+    },
+    "common": {
+      "level": "DEBUG"
+    },
+    "django.request": {
+      "handlers": [
+        "mail_admins"
+      ],
+      "level": "ERROR",
+      "propagate": true
+    },
+    "django.request.tastypie": {
+      "level": "ERROR"
+    },
+    "locations": {
+      "level": "DEBUG"
+    },
+    "sword2": {
+      "level": "INFO"
+    }
+  },
+  "root": {
+    "handlers": [
+      "logfile",
+      "verboselogfile"
+    ],
+    "level": "WARNING"
+  },
+  "version": 1
+}

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -2,8 +2,11 @@
 
 """Common settings and globals."""
 
+import json
+import logging
+import logging.config
 from os import environ
-from os.path import abspath, basename, dirname, join, normpath
+from os.path import abspath, basename, dirname, isfile, join, normpath
 from sys import path
 
 from django.core.exceptions import ImproperlyConfigured
@@ -259,12 +262,16 @@ LOGIN_EXEMPT_URLS = (
 
 
 # ######## LOGGING CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#logging
-# A sample logging configuration. The only tangible logging
-# performed by this configuration is to send an email to
-# the site admins on every HTTP 500 error when DEBUG=False.
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
+
+# Configure logging manually
+LOGGING_CONFIG = None
+
+# Location of the logging configuration file that we're going to pass to
+# `logging.config.fileConfig` unless it doesn't exist.
+LOGGING_CONFIG_FILE = '/etc/archivematica/storageService.logging.json'
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -325,6 +332,12 @@ LOGGING = {
         'level': 'WARNING',
     },
 }
+
+if isfile(LOGGING_CONFIG_FILE):
+    with open(LOGGING_CONFIG_FILE, 'rt') as f:
+        LOGGING = logging.config.dictConfig(json.load(f))
+else:
+    logging.config.dictConfig(LOGGING)
 # ######## END LOGGING CONFIGURATION
 
 


### PR DESCRIPTION
Optionally read logging configuration from `/etc/archivematica/storageService.logging.json`. See the included [install/README.md](https://github.com/artefactual/archivematica-storage-service/blob/dev/backward-compatible-logging/install/README.md) for more details. See also https://github.com/artefactual/archivematica/pull/782.

This closes https://github.com/artefactual/archivematica/issues/776.