### PR TITLE
Docker: allow tests to run rootless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ before_install:
 
 install: true
 
+before_script:
+  # Needed by test_duracloud.py
+  - sudo mkdir -p /var/archivematica/storage_service
+  - sudo chown -R $USER /var/archivematica/storage_service
+
 script: tox
 
 notifications:

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN set -ex \
 	&& internalDirs=' \
 		/db \
 		/src/storage_service/assets \
+		/src/storage_service/locations/fixtures \
 		/var/archivematica/storage_service \
 	' \
 	&& mkdir -p $internalDirs \

--- a/storage_service/locations/tests/test_duracloud.py
+++ b/storage_service/locations/tests/test_duracloud.py
@@ -20,6 +20,13 @@ class TestDuracloud(TestCase):
         self.ds_object = models.Duracloud.objects.all()[0]
         self.auth = requests.auth.HTTPBasicAuth(self.ds_object.user, self.ds_object.password)
 
+        # Move to a location that is writeable
+        self.old_dir = os.getcwd()
+        os.chdir('/var/archivematica/storage_service')
+
+    def tearDown(self):
+        os.chdir(self.old_dir)
+
     def test_has_required_attributes(self):
         assert self.ds_object.host
         assert self.ds_object.user


### PR DESCRIPTION
After building the Docker image it was not possible to run the tests because
they make changes in the `fixtures/` folder but it wasn't writable by the
`archivematica` user.

This closes #220.