### PR TITLE
Add check for migrations to travis/tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
     - python: "2.7"
       env: TOXENV=flake8
     - python: "2.7"
+      env: TOXENV=checkformigrations
+    - python: "2.7"
       env: TOXENV=py27
     - python: "3.6"
       env: TOXENV=py36

--- a/scripts/checkformigrations.sh
+++ b/scripts/checkformigrations.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+function count_migrations() {
+    ls storage_service/locations/migrations/*.py | wc -l
+}
+
+MIGRATIONS_COUNT_BEFORE=$(count_migrations)
+storage_service/manage.py makemigrations
+MIGRATIONS_COUNT_AFTER=$(count_migrations)
+
+if [ $MIGRATIONS_COUNT_BEFORE -ne $MIGRATIONS_COUNT_AFTER ]; then
+    echo "Migrations are needed"
+    exit 1
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,19 @@
 [tox]
 skipsdist = True
 minversion = 2.7.0
-envlist = py{27,36}, flake8
+envlist = py{27,36}, flake8, checkformigrations
 skip_missing_interpreters = true
+
+[testenv:checkformigrations]
+basepython = python2
+skip_install = true
+deps = -rrequirements/test.txt
+whitelist_externals = bash
+commands = bash ./scripts/checkformigrations.sh
+setenv =
+    PYTHONPATH = ./storage_service
+    DJANGO_SETTINGS_MODULE = storage_service.settings.test
+    DJANGO_SECRET_KEY = 1234
 
 [testenv:py27]
 basepython = python2


### PR DESCRIPTION
This PR modifies tox.ini and the Travis config file so that Travis CI will fail if the SS needs migrations. This is expected to fail when merged into qa/0.x because a migration is needed.