### PR TITLE
Fix `Package.should_have_pointer_file()`

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -562,7 +562,7 @@ class Package(models.Model):
             package_type = self.package_type
         isfile = os.path.isfile(package_full_path)
         isaip = package_type in (Package.AIP, Package.AIC)
-        ret = isfile or isaip
+        ret = isfile and isaip
         if not ret:
             if not isfile:
                 LOGGER.info('Package should not have a pointer file because %s'


### PR DESCRIPTION
Before this, this method was incorrectly returning `True` if the package
was an AIP (or AIC) even if it was not a file (i.e., was not
compressed).

This should fix (or should contribute to the fixing of) https://github.com/artefactual/archivematica/issues/809