### PR TITLE
Pipeline local filesystem: x permission on folders

### DIFF
--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -462,7 +462,7 @@ class Space(models.Model):
 
         # Rsync file over
         # TODO Do this asyncronously, with restarting failed attempts
-        command = ['rsync', '-t', '-O', '--protect-args', '-vv', '--chmod=ugo+rw', '-r', source, destination]
+        command = ['rsync', '-t', '-O', '--protect-args', '-vv', '--chmod=F660,D770', '-r', source, destination]
         LOGGER.info("rsync command: %s", command)
         kwargs = {'stdout': subprocess.PIPE, 'stderr': subprocess.STDOUT}
         if assume_rsync_daemon:
@@ -532,7 +532,7 @@ class Space(models.Model):
         for directory in directories:
             path = os.path.join(os.path.dirname(directory), '')
             path = "{}@{}:{}".format(user, host, utils.coerce_str(path))
-            cmd = ['rsync', '-vv', '--protect-args', '--chmod=ugo+rw', '--recursive', temp_dir, path]
+            cmd = ['rsync', '-vv', '--protect-args', '--chmod=ug=rwx,o=rx', '--recursive', temp_dir, path]
             LOGGER.info("rsync path creation command: %s", cmd)
             try:
                 subprocess.check_call(cmd)


### PR DESCRIPTION
- add the "execute" permission on folders so users can see what is inside.
- restrictive permission for other users

Replaces https://github.com/artefactual/archivematica-storage-service/pull/227.