### PR TITLE
Prevent assigning replicators to non-AS locations

### DIFF
--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -234,9 +234,15 @@ class LocationForm(forms.ModelForm):
         self.fields['default'].initial = self.instance.default
 
     def clean(self):
-        # TODO: replicators can NOT have replicators
         cleaned_data = super(LocationForm, self).clean()
         purpose = cleaned_data.get('purpose')
+
+        # Only AIP Storage AS-purposed locations can have replicators
+        replicators = cleaned_data.get('replicators')
+        if purpose != models.Location.AIP_STORAGE and replicators:
+            raise forms.ValidationError(
+                _('Only AIP storage locations can have replicators'))
+
         if purpose == models.Location.AIP_RECOVERY:
             # Don't allow more than one recovery location per pipeline
             # Fetch all LocationPipelines linked to an AIP Recovery location and

--- a/storage_service/static/css/project.css
+++ b/storage_service/static/css/project.css
@@ -56,3 +56,7 @@ table.attr-val-table td {
 label.required-field:after {
     content: '*'
 }
+
+.errorlist {
+  color: red;
+}

--- a/storage_service/templates/locations/location_form.html
+++ b/storage_service/templates/locations/location_form.html
@@ -47,15 +47,15 @@
         '{% url "browse" "v2" "space" space.uuid %}'
       );
 
-      // Hide the "Replicators" field when the location being created is itself
-      // a replicator: replicators can't have replicators.
+      // Hide the "Replicators" field when the location being created is not an
+      // AIP Storage ("AS") location.
       $('select#id_purpose').change(function(event) {replicatorsVisibility();});
       function replicatorsVisibility() {
         var purpose = $('select#id_purpose').val();
-        if (purpose === 'RP') {
-            $('select#id_replicators').closest('p').hide();
-        } else {
+        if (purpose === 'AS') {
             $('select#id_replicators').closest('p').show();
+        } else {
+            $('select#id_replicators').closest('p').hide();
         }
       }
       replicatorsVisibility();


### PR DESCRIPTION
If a location is not a an AIP Storage-purposed (AS) location, then it should not be possible to assign a replicator location to it. Fixes issue #268. When merged, this should also be cherry-picked to stable/0.11.x