### PR TITLE
Ignore errors in shutil.rmtree

### DIFF
--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -132,7 +132,7 @@ def download_file_stream(filepath, temp_dir=None):
 
     # Delete temp dir if created
     if temp_dir and os.path.exists(temp_dir):
-        shutil.rmtree(temp_dir)
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
     return response
 


### PR DESCRIPTION
Using `shutil.rmtree` was problematic in NFS drives (see "silly rename")
because we're trying to delete files that are still being used, i.e. Django
doesn't close the file until the response is fully returned to the browser.

The long-term solution should be to defer the cleanup.

This fixes #269. Read the issue for more details.

It should also be included in qa/0.x.