### PR TITLE
ospdeps: update RH/CentOS dependencies

### DIFF
--- a/osdeps/CentOS-7.json
+++ b/osdeps/CentOS-7.json
@@ -22,6 +22,7 @@
    { "name": "libffi-devel", "state": "latest"},
    { "name": "openssl-devel", "state": "latest"},
    { "name": "gcc", "state": "latest"},
+   { "name": "gcc-c++", "state": "latest"},
    { "name": "p7zip", "state": "latest"},
    { "name": "p7zip-plugins", "state": "latest"}
   ]

--- a/osdeps/RedHat-7.json
+++ b/osdeps/RedHat-7.json
@@ -22,6 +22,7 @@
    { "name": "libffi-devel", "state": "latest"},
    { "name": "openssl-devel", "state": "latest"},
    { "name": "gcc", "state": "latest"},
+   { "name": "gcc-c++", "state": "latest"},
    { "name": "p7zip", "state": "latest"},
    { "name": "p7zip-plugins", "state": "latest"}
   ]


### PR DESCRIPTION
Added gcc-c++ dependency.

It closes #290