### PR TITLE
Add Swagger documentation to API

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,7 @@ django-extensions==1.7.9
 django-model-utils==3.0.0
 #tastypie 0.13.3 has breaking changes
 django-tastypie==0.13.1
+django-tastypie-swagger
 futures==3.0.5  # used by gunicorn's async workers
 gevent==1.2.1  # used by gunicorn's async workers
 gunicorn==19.7.1

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -467,7 +467,7 @@ class PackageResource(ModelResource):
         detail_uri_name = 'uuid'
         always_return_data = True
         filtering = {
-            'location': ALL_WITH_RELATIONS,
+            'current_location': ALL_WITH_RELATIONS,
             'package_type': ALL,
             'path': ALL,
             'uuid': ALL,

--- a/storage_service/locations/api/urls.py
+++ b/storage_service/locations/api/urls.py
@@ -19,6 +19,18 @@ v2_api.register(v2.PipelineResource())
 urlpatterns = [
     url(r'', include(v1_api.urls)),
     url(r'v1/sword/$', views.service_document, name='sword_service_document'),
+    url(r'v1/doc/',
+        include('tastypie_swagger.urls', namespace='v1_api_swagger'),
+        kwargs={
+            'tastypie_api_module': v1_api,
+            'namespace': 'v1_api_swagger',
+            'version': '2.0'}),
     url(r'', include(v2_api.urls)),
     url(r'v2/sword/$', views.service_document, name='sword_service_document'),
+    url(r'v2/doc/',
+        include('tastypie_swagger.urls', namespace='v2_api_swagger'),
+        kwargs={
+            'tastypie_api_module': v2_api,
+            'namespace': 'v2_api_swagger',
+            'version': '1.0'}),
 ]

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -234,6 +234,7 @@ DJANGO_APPS = [
 
 THIRD_PARTY_APPS = [
     'tastypie',  # REST framework
+    'tastypie_swagger',
     'longerusername', # Longer (> 30 characters) username
 ]
 


### PR DESCRIPTION
Use django-tastypie-swagger to create Swagger documentation and UI,
available at '.../api/v1/doc/' and '.../api/v2/doc/'.

TODO:
- [x] - Fix file/package resource
- [ ] - Add auth. to doc pages?
- [ ] - Add custom endpoints/methods

connects to #299
  