### PR TITLE
Fix replication: create replica pointer file if master has one

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -847,13 +847,14 @@ class Package(models.Model):
         for replication validation or does a fixity check need to be performed
         also?
         """
-
         # 1. Set attrs and get full path to pointer file.
-        should_have_pointer = replica_package.should_have_pointer_file()
         if not master_ptr:
             master_ptr = self.get_pointer_instance()
-        if not should_have_pointer or not master_ptr:
-            return
+        if not master_ptr:
+            LOGGER.warning('Not creating a pointer file for replica package %s'
+                           ' because its master package does not have one.',
+                           replica_package.uuid)
+            return None
         uuid_path = utils.uuid_to_path(replica_package.uuid)
         replica_package.pointer_file_location = Location.active.get(
             purpose=Location.STORAGE_SERVICE_INTERNAL)


### PR DESCRIPTION
Fixes ``Package.create_replica_pointer_file`` so that replicas are given pointer files if their masters have them. Previous behaviour was to check if the replica was a file (i.e., compressed) but that is incorrect because at the time of the check the replica package is always a directory.

Fixes #307.

Confirmed fix by successfully running aip-encryption-mirror.feature at dev branch dev/issue-65-enable-encryption-features-docker:

    $ behave --tags=aip-encrypt-mirror \
      --no-skipped \
      -D am_version=1.7 \
      -D driver_name=Firefox \
      -D am_username=test \
      -D am_password=test \
      -D am_url=http://127.0.0.1:62080/ \
      -D am_api_key=test \
      -D ss_username=test \
      -D ss_password=test \
      -D ss_url=http://127.0.0.1:62081/ \
      -D home=archivematica \
      -D docker_compose_path=/path/to/compose/dir