### PR TITLE
Make replicators deselectable

### DIFF
--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -282,6 +282,7 @@ def location_edit(request, space_uuid, location_uuid=None):
         for pipeline in form.cleaned_data['pipeline']:
             LocationPipeline.objects.get_or_create(
                 location=location, pipeline=pipeline)
+        location.replicators.clear()
         for replicator_loc in form.cleaned_data['replicators']:
             location.replicators.add(replicator_loc)
         # Delete relationships between the location and pipelines not in the form


### PR DESCRIPTION
Prior to this commit, deselecting a replicator location for a master location would not remove the deselected replicator from the list of the location's replicators. Now replicator deselection should function as expected.

Fixes #309.