### PR TITLE
Stop logging OSError when falling back to rsync

### DIFF
--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -449,7 +449,7 @@ class Space(models.Model):
                 subprocess.call(chmod_command)
                 return
             except OSError:
-                LOGGER.debug('os.rename failed, trying with normalized paths', exc_info=True)
+                LOGGER.debug('os.rename failed, trying with normalized paths')
             source_norm = os.path.normpath(source)
             dest_norm = os.path.normpath(destination)
             try:
@@ -458,7 +458,7 @@ class Space(models.Model):
                 subprocess.call(chmod_command)
                 return
             except OSError:
-                LOGGER.debug('os.rename failed, falling back to rsync. Source: %s; Destination: %s', source_norm, dest_norm, exc_info=True)
+                LOGGER.debug('os.rename failed, falling back to rsync. Source: %s; Destination: %s', source_norm, dest_norm)
 
         # Rsync file over
         # TODO Do this asyncronously, with restarting failed attempts


### PR DESCRIPTION
Removes the kwarg that was causing us to log a traceback when a local move fails and triggers a fallback to moving using rsync.

Fixes #336