### PR TITLE
catch oserror if unar isn't installed on system

### DIFF
--- a/storage_service/locations/models/dspace.py
+++ b/storage_service/locations/models/dspace.py
@@ -209,6 +209,9 @@ class DSpace(models.Model):
         except subprocess.CalledProcessError:
             LOGGER.error('Could not extract %s', input_path)
             raise
+        except OSError as e:
+            LOGGER.error('Is %s installed? %s', command[0], e)
+            raise
 
         # Move objects into their own directory
         objects_dir = os.path.join(output_dir, 'objects')


### PR DESCRIPTION
Unar isn't pre-installed on all systems and isn't listed as an Archivematica dependency. This checks an OSerror when an attempt is made to call it.