### PR TITLE
API: add location create endpoint

### DIFF
--- a/storage_service/locations/api/v2.py
+++ b/storage_service/locations/api/v2.py
@@ -22,7 +22,6 @@ class SpaceResource(resources.SpaceResource):
 class LocationResource(resources.LocationResource):
     space = fields.ForeignKey(SpaceResource, 'space')
     path = fields.CharField(attribute='full_path', readonly=True)
-    description = fields.CharField(attribute='get_description', readonly=True)
     pipeline = fields.ToManyField(PipelineResource, 'pipeline')
 
     def decode_path(self, path):


### PR DESCRIPTION
Add new `POST /api/v2/location/` endpoint to enable creation of Location
instances given a known space and pipeline. The following is an example on how
it could be used:

Find a pipeline:

```shell
curl -s \
    -H "Authorization: ApiKey test:test" \
    -H "Content-Type: application/json" \
        "http://127.0.0.1:62081/api/v2/pipeline/" | \
            jq -r ".objects | .[0] | .resource_uri"
```

    /api/v2/pipeline/90707555-244f-47af-8271-66496a6a965b/

Find a space:

```shell
curl -s \
    -H "Authorization: ApiKey test:test" \
    -H "Content-Type: application/json" \
        "http://127.0.0.1:62081/api/v2/space/" | \
            jq -r ".objects | .[0] | .resource_uri"
```

    /api/v2/space/141593ff-2a27-44a1-9de1-917573fa0f4a/

Create new location:

```shell
curl -s -d '{
    "pipeline": ["/api/v2/pipeline/90707555-244f-47af-8271-66496a6a965b/"],
    "purpose": "TS",
    "relative_path": "automated-workflow/foo/bar",
    "description": "automated workflow",
    "space": "/api/v2/space/141593ff-2a27-44a1-9de1-917573fa0f4a/"
}' \
    -X POST \
    -H "Authorization: ApiKey test:test" \
    -H "Content-Type: application/json" \
        "http://127.0.0.1:62081/api/v2/location/" | \
            jq -r ".resource_uri"
```

    /api/v2/location/693f8fa4-744a-4c8f-9e1f-275d422e3bad/

Inspect location:

```shell
curl -s \
    -H "Authorization: ApiKey test:test" \
    -H "Content-Type: application/json" \
        "http://127.0.0.1:62081/api/v2/location/693f8fa4-744a-4c8f-9e1f-275d422e3bad/" | jq
```

```json
{
  "description": "automated workflow",
  "enabled": true,
  "path": "/automated-workflow/foo/bar",
  "pipeline": [
    "/api/v2/pipeline/90707555-244f-47af-8271-66496a6a965b/"
  ],
  "purpose": "TS",
  "quota": null,
  "relative_path": "automated-workflow/foo/bar",
  "resource_uri": "/api/v2/location/693f8fa4-744a-4c8f-9e1f-275d422e3bad/",
  "space": "/api/v2/space/141593ff-2a27-44a1-9de1-917573fa0f4a/",
  "used": "0",
  "uuid": "693f8fa4-744a-4c8f-9e1f-275d422e3bad"
}
```

This is connected to #367.