### PR TITLE
osdeps: use rsync v3.1.1

### DIFF
--- a/osdeps/CentOS-7.json
+++ b/osdeps/CentOS-7.json
@@ -14,7 +14,7 @@
   "osdeps_packages_2": [
    { "name": "nginx", "state": "latest"},
    { "name": "unar", "state": "latest"},
-   { "name": "rsync", "state": "latest"},
+   { "name": "rsync", "state": "latest", "version": "3.1.1"},
    { "name": "python-devel", "state": "latest"},
    { "name": "libxml2-devel", "state": "latest"},
    { "name": "libxslt-devel", "state": "latest"},

--- a/osdeps/RedHat-7.json
+++ b/osdeps/RedHat-7.json
@@ -14,7 +14,7 @@
   "osdeps_packages_2": [
    { "name": "nginx", "state": "latest"},
    { "name": "unar", "state": "latest"},
-   { "name": "rsync", "state": "latest"},
+   { "name": "rsync", "state": "latest", "version": "3.1.1"},
    { "name": "python-devel", "state": "latest"},
    { "name": "libxml2-devel", "state": "latest"},
    { "name": "libxslt-devel", "state": "latest"},

--- a/osdeps/Ubuntu-14.json
+++ b/osdeps/Ubuntu-14.json
@@ -11,7 +11,7 @@
   "osdeps_packages": [
    { "name": "nginx", "state": "latest"},
    { "name": "unar", "state": "latest"},
-   { "name": "rsync", "state": "latest"},
+   { "name": "rsync", "state": "latest", "version": "3.1.1"},
    { "name": "p7zip-full", "state": "latest"},
    { "name": "python-dev", "state": "latest"},
    { "name": "build-essential", "state": "latest"},

--- a/osdeps/Ubuntu-16.json
+++ b/osdeps/Ubuntu-16.json
@@ -11,7 +11,7 @@
   "osdeps_packages": [
    { "name": "nginx", "state": "latest"},
    { "name": "unar", "state": "latest"},
-   { "name": "rsync", "state": "latest"},
+   { "name": "rsync", "state": "latest", "version": "3.1.1"},
    { "name": "p7zip-full", "state": "latest"},
    { "name": "python-dev", "state": "latest"},
    { "name": "build-essential", "state": "latest"},


### PR DESCRIPTION
This is the first time that we use the `version` attribute. It's the minimum
version that we know it works.

Distributions (rpms/debs/etc) must take this into account.

This is connected to #345.