### PR TITLE
Correct Dataverse issues discovered post proof-of-concept (PoC)

### DIFF
--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -103,14 +103,6 @@ class DataverseForm(forms.ModelForm):
         model = models.Dataverse
         fields = ('host', 'api_key', 'agent_name', 'agent_type', 'agent_identifier')
 
-    def as_p(self):
-        # Add a warning to the Dataverse-specific section of the form
-        # FIXME this may not be the best way to add Space-specific warnings
-        content = super(DataverseForm, self).as_p()
-        content += '\n<div class="alert">{}</div>'.format(
-            _('Integration with Dataverse is currently a beta feature'))
-        return content
-
 
 class DuracloudForm(forms.ModelForm):
     class Meta:

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -5,6 +5,7 @@ from django import forms
 import django.utils
 import django.core.exceptions
 from django.db.models import Count
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _, ugettext_lazy as _l
 
 from common import gpgutils
@@ -39,14 +40,14 @@ class DisableableSelectWidget(forms.Select):
     def render_option(self, selected_choices, option_value, option_label):
         option_value = django.utils.encoding.force_text(option_value)
         if option_value in selected_choices:
-            selected_html = django.utils.safestring.mark_safe(' selected="selected"')
+            selected_html = mark_safe(' selected="selected"')
             if not self.allow_multiple_selected:
                 # Only allow for a single selection.
                 selected_choices.remove(option_value)
         else:
             selected_html = ''
         if option_value in self.disabled_choices:
-            disabled_html = django.utils.safestring.mark_safe(' disabled="disabled"')
+            disabled_html = mark_safe(' disabled="disabled"')
         else:
             disabled_html = ''
         return django.utils.html.format_html(
@@ -102,6 +103,13 @@ class DataverseForm(forms.ModelForm):
     class Meta:
         model = models.Dataverse
         fields = ('host', 'api_key', 'agent_name', 'agent_type', 'agent_identifier')
+
+    def as_p(self):
+        # Add a warning to the Dataverse-specific section of the form
+        content = super(DataverseForm, self).as_p()
+        content += '\n<div class="alert">{}</div>'.format(
+            ('Integration with Dataverse is currently a beta feature'))
+        return mark_safe(content)
 
 
 class DuracloudForm(forms.ModelForm):

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -22,6 +22,7 @@ from .location import Location  # noqa: E402
 
 class Dataverse(models.Model):
     space = models.OneToOneField("Space", to_field="uuid")
+
     host = models.CharField(
         max_length=256,
         verbose_name=_l("Host"),
@@ -63,13 +64,25 @@ class Dataverse(models.Model):
 
     def browse(self, path):
         """
-        Fetch a list of datasets from Dataverse based on the query in the location path.
+        Fetch a list of datasets from Dataverse based on the query in the
+        location path.
 
         Datasets are considered directories when browsing.
         """
         # Remove things earlier layers added
         path = path.rstrip("/")
-        # Use http://guides.dataverse.org/en/latest/api/search.html to search and return datasets
+
+        # Because we are using a field that is described as being 'relative to
+        # the storage space' as a query string filter for Dataverse; but the
+        # string created is unrelated to 'storage' itself we also need to strip
+        # this from the location. The string will look something like the
+        # following:
+        #
+        # /var/archivematica/storage_service/dataverse/space/
+        path = path.replace(self.space.path, "")
+
+        # Use http://guides.dataverse.org/en/latest/api/search.html to search
+        # and return datasets
         # Location path is query string
         # FIXME only browse one layer deep
         url = "https://{}/api/search/".format(self.host)

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 # stdlib, alphabetical
 import json
 import logging
@@ -20,31 +21,45 @@ from .location import Location  # noqa: E402
 
 
 class Dataverse(models.Model):
-    space = models.OneToOneField('Space', to_field='uuid')
-    host = models.CharField(max_length=256,
-        verbose_name=_l('Host'),
-        help_text=_l('Hostname of the Dataverse instance. Eg. apitest.dataverse.org'))
-    api_key = models.CharField(max_length=50,
-        verbose_name=_l('API key'),
-        help_text=_l('API key for Dataverse instance. Eg. b84d6b87-7b1e-4a30-a374-87191dbbbe2d'))
-    agent_name = models.CharField(max_length=50,
-        verbose_name=_l('Agent name'),
-        help_text=_l('Agent name for premis:agentName in Archivematica'))
-    agent_type = models.CharField(max_length=50,
-        verbose_name=_l('Agent type'),
-        help_text=_l('Agent type for premis:agentType in Archivematica'))
-    agent_identifier = models.CharField(max_length=256,
-        verbose_name=_l('Agent identifier'),
-        help_text=_l('URI agent identifier for premis:agentIdentifierValue in Archivematica'))
+    space = models.OneToOneField("Space", to_field="uuid")
+    host = models.CharField(
+        max_length=256,
+        verbose_name=_l("Host"),
+        help_text=_l(
+            "Hostname of the Dataverse instance. Eg. apitest.dataverse.org"
+        ),
+    )
+    api_key = models.CharField(
+        max_length=50,
+        verbose_name=_l("API key"),
+        help_text=_l(
+            "API key for Dataverse instance. Eg. b84d6b87-7b1e-4a30-a374-87191dbbbe2d"
+        ),
+    )
+    agent_name = models.CharField(
+        max_length=50,
+        verbose_name=_l("Agent name"),
+        help_text=_l("Agent name for premis:agentName in Archivematica"),
+    )
+    agent_type = models.CharField(
+        max_length=50,
+        verbose_name=_l("Agent type"),
+        help_text=_l("Agent type for premis:agentType in Archivematica"),
+    )
+    agent_identifier = models.CharField(
+        max_length=256,
+        verbose_name=_l("Agent identifier"),
+        help_text=_l(
+            "URI agent identifier for premis:agentIdentifierValue in Archivematica"
+        ),
+    )
     # FIXME disallow string in space.path
 
     class Meta:
         verbose_name = _l("Dataverse")
-        app_label = 'locations'
+        app_label = "locations"
 
-    ALLOWED_LOCATION_PURPOSE = [
-        Location.TRANSFER_SOURCE,
-    ]
+    ALLOWED_LOCATION_PURPOSE = [Location.TRANSFER_SOURCE]
 
     def browse(self, path):
         """
@@ -53,57 +68,67 @@ class Dataverse(models.Model):
         Datasets are considered directories when browsing.
         """
         # Remove things earlier layers added
-        path = path.rstrip('/')
+        path = path.rstrip("/")
         # Use http://guides.dataverse.org/en/latest/api/search.html to search and return datasets
         # Location path is query string
         # FIXME only browse one layer deep
-        url = 'https://' + self.host + '/api/search/'
+        url = "https://{}/api/search/".format(self.host)
         params = {
-            'key': self.api_key,
-            'q': path,
-            'type': 'dataset',
-            'sort': 'name',
-            'order': 'asc',
-            'start': 0,
-            'per_page': 10,
-            'show_entity_ids': True,
+            "key": self.api_key,
+            "q": path,
+            "type": "dataset",
+            "sort": "name",
+            "order": "asc",
+            "start": 0,
+            "per_page": 10,
+            "show_entity_ids": True,
         }
         entries = []
         properties = {}
         while True:
-            LOGGER.debug('URL: %s, params: %s', url, params)
+            LOGGER.debug("URL: %s, params: %s", url, params)
             response = requests.get(url, params=params)
-            LOGGER.debug('Response: %s', response)
+            LOGGER.debug("Response: %s", response)
             if response.status_code != 200:
-                LOGGER.warning('%s: Response: %s', response, response.text)
+                LOGGER.warning("%s: Response: %s", response, response.text)
                 raise StorageException(
-                    _('Unable to fetch datasets from %(url)s with query %(path)s') %
-                    {'url': url, 'path': path})
+                    _(
+                        "Unable to fetch datasets from %(url)s with query %(path)s"
+                    )
+                    % {"url": url, "path": path}
+                )
             try:
-                data = response.json()['data']
+                data = response.json()["data"]
             except json.JSONDecodeError:
-                LOGGER.error('Could not parse JSON from response to %s', url)
+                LOGGER.error("Could not parse JSON from response to %s", url)
                 raise StorageException(
-                    _('Unable parse JSON from response to %(url)s with query %(path)s') %
-                    {'url': url, 'path': path})
+                    _(
+                        "Unable parse JSON from response to %(url)s with query %(path)s"
+                    )
+                    % {"url": url, "path": path}
+                )
 
-            entries += [str(x['entity_id']) for x in data['items']]
+            entries += [str(x["entity_id"]) for x in data["items"]]
 
-            properties.update({
-                str(x['entity_id']): {'verbose name': x['name']}
-                for x in data['items']
-            })
+            properties.update(
+                {
+                    str(x["entity_id"]): {"verbose name": x["name"]}
+                    for x in data["items"]
+                }
+            )
 
-            if params['start'] + data['count_in_response'] < data['total_count']:
-                params['start'] += data['count_in_response']
+            if (
+                params["start"] + data["count_in_response"] < data["total_count"]
+            ):
+                params["start"] += data["count_in_response"]
             else:
                 break
 
         directories = entries
         return {
-            'directories': directories,
-            'entries': entries,
-            'properties': properties,
+            "directories": directories,
+            "entries": entries,
+            "properties": properties,
         }
 
     def move_to_storage_service(self, src_path, dest_path, dest_space):
@@ -112,63 +137,77 @@ class Dataverse(models.Model):
         """
         # TODO how to strip location path if location isn't passed in?
         # HACK strip everything that isn't a number
-        src_path = ''.join(c for c in src_path if c.isdigit())
+        src_path = "".join(c for c in src_path if c.isdigit())
         # Verify src_path has to be a number
         if not src_path.isdigit():
-            raise StorageException(_('Invalid value for src_path: %(value)s. Must be a numberic entity_id') % {'value': src_path})
-        # Fetch dataset info
-        url = 'https://' + self.host + '/api/datasets/' + src_path
-        params = {
-            'key': self.api_key,
-        }
-        LOGGER.debug('URL: %s, params: %s', url, params)
-        response = requests.get(url, params=params)
-        LOGGER.debug('Response: %s', response)
-        if response.status_code != 200:
-            LOGGER.warning('%s: Response: %s', response, response.text)
             raise StorageException(
-                _('Unable to fetch dataset %(path)s from %(url)s') %
-                {'path': src_path, 'url': url})
+                _(
+                    "Invalid value for src_path: %(value)s. Must be a numberic entity_id"
+                )
+                % {"value": src_path}
+            )
+        # Fetch dataset info
+        url = "https://{}/api/datasets/{}".format(self.host, src_path)
+        params = {"key": self.api_key}
+        LOGGER.debug("URL: %s, params: %s", url, params)
+        response = requests.get(url, params=params)
+        LOGGER.debug("Response: %s", response)
+        if response.status_code != 200:
+            LOGGER.warning("%s: Response: %s", response, response.text)
+            raise StorageException(
+                _("Unable to fetch dataset %(path)s from %(url)s")
+                % {"path": src_path, "url": url}
+            )
         try:
-            dataset = response.json()['data']
+            dataset = response.json()["data"]
         except json.JSONDecodeError:
-            LOGGER.error('Could not parse JSON from response to %s', url)
-            raise StorageException('Unable parse JSON from response to %s' % url,)
+            LOGGER.error("Could not parse JSON from response to %s", url)
+            raise StorageException(
+                "Unable parse JSON from response to %s" % url
+            )
 
         # Create directories
         self.space.create_local_directory(dest_path)
 
         # Write out dataset info as dataset.json to the metadata directory
-        os.makedirs(os.path.join(dest_path, 'metadata'))
-        datasetjson_path = os.path.join(dest_path, 'metadata', 'dataset.json')
-        with open(datasetjson_path, 'w') as f:
+        os.makedirs(os.path.join(dest_path, "metadata"))
+        datasetjson_path = os.path.join(dest_path, "metadata", "dataset.json")
+        with open(datasetjson_path, "w") as f:
             json.dump(dataset, f)
 
         # Fetch all files in dataset.json
-        for file_entry in dataset['latestVersion']['files']:
-            entry_id = str(file_entry['dataFile']['id'])
-            if not file_entry['label'].endswith('.tab'):
-                download_path = os.path.join(dest_path, file_entry['dataFile']['filename'])
-                url = 'https://' + self.host + '/api/access/datafile/' + entry_id
+        for file_entry in dataset["latestVersion"]["files"]:
+            entry_id = str(file_entry["dataFile"]["id"])
+            if not file_entry["label"].endswith(".tab"):
+                download_path = os.path.join(
+                    dest_path, file_entry["dataFile"]["filename"]
+                )
+                url = "https://{}/api/access/datafile/{}".format(
+                    self.host, entry_id
+                )
             else:
                 # If the file is the tab file, download the bundle instead
-                download_path = os.path.join(dest_path, file_entry['label'][:-4] + '.zip')
-                url = 'https://' + self.host + '/api/access/datafile/bundle/' + entry_id
-            LOGGER.debug('URL: %s, params: %s', url, params)
+                download_path = os.path.join(
+                    dest_path, file_entry["label"][:-4] + ".zip"
+                )
+                url = "https://{}/api/access/datafile/bundle/{}".format(
+                    self.host, entry_id
+                )
+            LOGGER.debug("URL: %s, params: %s", url, params)
             response = requests.get(url, params=params)
-            LOGGER.debug('Response: %s', response)
-            with open(download_path, 'wb') as f:
+            LOGGER.debug("Response: %s", response)
+            with open(download_path, "wb") as f:
                 f.write(response.content)
 
         # Add Agent info
         agent_info = [
             {
-                'agentIdentifierType': 'URI',
-                'agentIdentifierValue': self.agent_identifier,
-                'agentName': self.agent_name,
-                'agentType': self.agent_type,
+                "agentIdentifierType": "URI",
+                "agentIdentifierValue": self.agent_identifier,
+                "agentName": self.agent_name,
+                "agentType": self.agent_type,
             }
         ]
-        agentjson_path = os.path.join(dest_path, 'metadata', 'agents.json')
-        with open(agentjson_path, 'w') as f:
+        agentjson_path = os.path.join(dest_path, "metadata", "agents.json")
+        with open(agentjson_path, "w") as f:
             json.dump(agent_info, f)

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -34,7 +34,8 @@ class Dataverse(models.Model):
         max_length=50,
         verbose_name=_l("API key"),
         help_text=_l(
-            "API key for Dataverse instance. Eg. b84d6b87-7b1e-4a30-a374-87191dbbbe2d"
+            "API key for Dataverse instance. Eg. "
+            "b84d6b87-7b1e-4a30-a374-87191dbbbe2d"
         ),
     )
     agent_name = models.CharField(
@@ -51,7 +52,8 @@ class Dataverse(models.Model):
         max_length=256,
         verbose_name=_l("Agent identifier"),
         help_text=_l(
-            "URI agent identifier for premis:agentIdentifierValue in Archivematica"
+            "URI agent identifier for premis:agentIdentifierValue "
+            "in Archivematica"
         ),
     )
     # FIXME disallow string in space.path
@@ -106,7 +108,8 @@ class Dataverse(models.Model):
                 LOGGER.warning("%s: Response: %s", response, response.text)
                 raise StorageException(
                     _(
-                        "Unable to fetch datasets from %(url)s with query %(path)s"
+                        "Unable to fetch datasets from %(url)s with "
+                        "query %(path)s"
                     )
                     % {"url": url, "path": path}
                 )
@@ -116,7 +119,8 @@ class Dataverse(models.Model):
                 LOGGER.error("Could not parse JSON from response to %s", url)
                 raise StorageException(
                     _(
-                        "Unable parse JSON from response to %(url)s with query %(path)s"
+                        "Unable parse JSON from response to %(url)s with "
+                        "query %(path)s"
                     )
                     % {"url": url, "path": path}
                 )
@@ -131,7 +135,8 @@ class Dataverse(models.Model):
             )
 
             if (
-                params["start"] + data["count_in_response"] < data["total_count"]
+                params["start"] + data["count_in_response"] <
+                data["total_count"]
             ):
                 params["start"] += data["count_in_response"]
             else:
@@ -155,7 +160,8 @@ class Dataverse(models.Model):
         if not src_path.isdigit():
             raise StorageException(
                 _(
-                    "Invalid value for src_path: %(value)s. Must be a numberic entity_id"
+                    "Invalid value for src_path: %(value)s. Must be a "
+                    "numberic entity_id"
                 )
                 % {"value": src_path}
             )

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -141,7 +141,7 @@ class Space(models.Model):
     OBJECT_STORAGE = {DATAVERSE, DSPACE, DURACLOUD, SWIFT, S3}
     ACCESS_PROTOCOL_CHOICES = (
         (ARKIVUM, _l('Arkivum')),
-        (DATAVERSE, _l('Dataverse')),
+        (DATAVERSE, _l('Dataverse (Beta)')),
         (DURACLOUD, _l('DuraCloud')),
         (DSPACE, _l('DSpace via SWORD2 API')),
         (FEDORA, _l("FEDORA via SWORD2")),

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -141,7 +141,7 @@ class Space(models.Model):
     OBJECT_STORAGE = {DATAVERSE, DSPACE, DURACLOUD, SWIFT, S3}
     ACCESS_PROTOCOL_CHOICES = (
         (ARKIVUM, _l('Arkivum')),
-        (DATAVERSE, _l('Dataverse (Beta)')),
+        (DATAVERSE, _l('Dataverse')),
         (DURACLOUD, _l('DuraCloud')),
         (DSPACE, _l('DSpace via SWORD2 API')),
         (FEDORA, _l("FEDORA via SWORD2")),


### PR DESCRIPTION
This PR brings the Dataverse proof-of-concept work back inline with the most recent updates to the storage service. The two main issues experienced were around the incorrect manipulation of a Django form that enabled the selection of Dataverse as a transfer source. Secondly, the proof of concept co-opted the relative path field of the Locations model to create a filter that restricted the data-sets available as a transfer source. The issues were #352 and #355 respectively.

* Resolves #352 
* Resolves #355 
