### PR TITLE
Tests: pin pytest to 3.6.4

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 # Test dependencies go here.
 -r base.txt
 
-pytest
+pytest==3.6.4  # https://github.com/archivematica/Issues/issues/58
 pytest-cov==2.4.0
 coverage==4.2
 pytest-django


### PR DESCRIPTION
This is connected to https://github.com/archivematica/Issues/issues/58.