### PR TITLE
Arkivum: fix replication status (ref.#12343)

### DIFF
--- a/storage_service/locations/models/arkivum.py
+++ b/storage_service/locations/models/arkivum.py
@@ -170,7 +170,14 @@ class Arkivum(models.Model):
         if package.is_compressed:
             url = 'https://' + self.host + '/api/2/files/release/' + package.misc_attributes['arkivum_identifier']
         else:
-            url = 'https://' + self.host + '/api/3/ingest-manifest/status/' + package.misc_attributes['arkivum_identifier']
+            # To get replication status of an uncompressed package, 
+            # use files/fileInfo API call (on file bag-info.txt)
+            # instead of ingest-manifest/status call with arkivum_identifier 
+            # (which has not been reliable)
+            location = Location.objects.get(uuid=package.current_location_id)
+            url = 'https://' + self.host + '/api/2/files/fileInfo/' + \
+                   location.relative_path + '/' + \
+                   package.current_path + '/bag-info.txt'
 
         LOGGER.info('URL: %s', url)
         try:


### PR DESCRIPTION
To get replication status of an uncompressed package use fileInfo API
call (on file bag-info.txt)

The previous way to get the replication status, that used
ingest-manifest/status API call using arkivum_identifier has not been
reliable.