### PR TITLE
Comment out DSpace REST

### DIFF
--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -79,10 +79,21 @@ class SpaceForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(SpaceForm, self).__init__(*args, **kwargs)
         instance = getattr(self, 'instance', None)
+        self.filter_beta_protocols()
         if instance and instance.uuid:
             # If editing (not creating a new object) access protocol shouldn't
             # be changed.  Remove from fields, print in template
             del self.fields['access_protocol']
+
+    def filter_beta_protocols(self):
+        """Remove the Space.BETA_PROTOCOLS from the "Access protocol:" field's
+        choices.
+        """
+        filtered_protocols = [
+            choice for choice in list(self.fields['access_protocol'].choices) if
+            choice[0] not in self._meta.model.BETA_PROTOCOLS]
+        self.fields['access_protocol'].choices = filtered_protocols
+        self.fields['access_protocol'].widget.choices = filtered_protocols
 
     def clean_access_protocol(self):
         instance = getattr(self, 'instance', None)

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -139,6 +139,8 @@ class Space(models.Model):
     SWIFT = 'SWIFT'
     GPG = 'GPG'
     S3 = 'S3'
+    # These will not be displayed in the Space Create GUI (see locations/forms.py)
+    BETA_PROTOCOLS = {DSPACE_REST}
     OBJECT_STORAGE = {DATAVERSE, DSPACE, DSPACE_REST, DURACLOUD, SWIFT, S3}
     ACCESS_PROTOCOL_CHOICES = (
         (ARKIVUM, _l('Arkivum')),


### PR DESCRIPTION
The DSpace REST-type space is not ready to be released. This commit comments out the relevant lines of code so that it will no longer be possible to create DSpace REST spaces either via the GUI or the API.

Connected to archivematica/Issues#126