### PR TITLE
DSpace REST form: mark HTML as safe

### DIFF
--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -155,7 +155,8 @@ class DSpaceRESTForm(forms.ModelForm):
               ' being sent, unless the metadata is included in the packages'
               ' METS file in a dmdSec.'),
             needle)
-        return content.replace(needle, as_fields_alert)
+        return django.utils.safestring.mark_safe(
+            content.replace(needle, as_fields_alert))
 
 
 def get_gpg_key_choices():


### PR DESCRIPTION
Adds `django.utils.safestring.mark_safe` so that `DSpaceRESTForm.as_p` returns a `django.utils.safestring.SafeText` instance instead of a string. Previously (before this was implemented), if the form had to be re-rendered because it was invalid or if the user were trying to edit an existing DSpace REST space, then the HTML would be escaped and would be displayed to the user as unusable text.

Connected to archivematica/Issues#124