### PR TITLE
Stop using JSON headers in DSpace login request

### DIFF
--- a/storage_service/locations/tests/test_dspace_rest.py
+++ b/storage_service/locations/tests/test_dspace_rest.py
@@ -434,7 +434,7 @@ def test_move_from_storage_service(mocker, package, ds_aip_collection,
         cookies=None,
         data={'password': DS_PASSWORD,
               'email': DS_EMAIL},
-        headers=JSON_HEADERS,
+        headers=None,
         verify=VERIFY_SSL)
     assert actual_logout_call == mocker.call(
         DS_REST_LOGOUT_URL,


### PR DESCRIPTION
Stops using 'application/json' headers in the login request to DSpace in the DSpace REST space. Use of these headers was preventing login from working. Also improves DSpace REST exception messages for debugging.

Connected to archivematica/Issues#123