### PR TITLE
Fix incompatibility with pytest 3.7

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 # Test dependencies go here.
 -r base.txt
 
-pytest==3.6.4  # https://github.com/archivematica/Issues/issues/58
+pytest==3.8.0
 pytest-cov==2.4.0
 coverage==4.2
 pytest-django

--- a/storage_service/__init__.py
+++ b/storage_service/__init__.py
@@ -1,5 +1,0 @@
-"""
-:mod:`storage_service`
-
-Main Django Project package
-"""


### PR DESCRIPTION
The presence of `__init__.py` in the `storage_service` directory is causing
pytest to break with the following error:

    _pytest.nodes.Collector.CollectError: ImportError while importing test module
    Hint: make sure your test modules/packages have valid Python names.

Removing the file solved the problem. I think that pytest does not
expect `storage_service` to be a package. We don't treat it as a package
as far as I know.

This is connected to https://github.com/archivematica/Issues/issues/118.