### PR TITLE
Location: disallow move based on purpose

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -372,6 +372,10 @@ class LocationResource(ModelResource):
                 destination_location.relative_path, destination_path)
 
             try:
+                if not origin_location.is_move_allowed():
+                    LOGGER.debug(
+                        'Moving files from this location is not allowed')
+                    raise PosixMoveUnsupportedError
                 origin_space.posix_move(
                     source_path=source_path,
                     destination_path=destination_path,

--- a/storage_service/locations/models/location.py
+++ b/storage_service/locations/models/location.py
@@ -41,6 +41,12 @@ class Location(models.Model):
     TRANSFER_SOURCE = 'TS'
     REPLICATOR = 'RP'
 
+    # List of purposes where moving is not allowed.
+    PURPOSES_DISALLOWED_MOVE = (
+        BACKLOG,
+        AIP_STORAGE,
+    )
+
     PURPOSE_CHOICES = (
         (AIP_RECOVERY, _('AIP Recovery')),
         (AIP_STORAGE, _('AIP Storage')),
@@ -132,6 +138,10 @@ class Location(models.Model):
     def get_description(self):
         """ Returns a user-friendly description (or the path). """
         return self.description or self.full_path
+
+    def is_move_allowed(self):
+        """Returns whether it's allowed to move contents from this location."""
+        return self.purpose not in self.PURPOSES_DISALLOWED_MOVE
 
 
 @receiver(models.signals.pre_delete, sender=Location)


### PR DESCRIPTION
The [`posix_move` op](https://github.com/artefactual/archivematica-storage-service/pull/320) should not be always allowed for certain locations. This commit ensures that it's not used when the original location is backlog or AIP storage.

Connects to https://github.com/archivematica/Issues/issues/270.