### PR TITLE
Nginx: use HTTP 1.1 in proxy

### DIFF
--- a/install/storage
+++ b/install/storage
@@ -19,6 +19,7 @@ server {
 
     proxy_read_timeout 172800s;
     proxy_pass http://archivematica_storage_service_backend;
+    proxy_http_version 1.1;
 
     }
 


### PR DESCRIPTION
This commits sets the HTTP protocol version for proxying to 1.1. Nginx
uses 1.0 by default.

This seems to mitigate the problem described in the original issue. However,
the reasons are still being investigated.

This is connected to https://github.com/archivematica/Issues/issues/280.

Similar updates may be required in am-packbuild and ansible-archivematica-src repos.