### PR TITLE
 Support multiple GnuPG binary names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex \
 	&& apt-get update -qq \
 	&& apt-get install -qq -y --no-install-recommends \
 		gettext \
+		gnupg \
 		p7zip-full \
 		rsync \
 		unar \
@@ -23,8 +24,8 @@ RUN set -ex \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Set the locale
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 ADD requirements/ /src/requirements/

--- a/osdeps/Ubuntu-18.json
+++ b/osdeps/Ubuntu-18.json
@@ -8,6 +8,9 @@
     "virtualenv installed with pip, do not install package python-virtualenv",
     "build-essential is needed to compile brotli (cc1plus)"
   ],
+  "osdeps_repos": [
+    "deb http://archive.ubuntu.com/ubuntu/ bionic universe"
+  ],
   "osdeps_packages": [
    { "name": "nginx", "state": "latest"},
    { "name": "unar", "state": "latest"},
@@ -22,7 +25,7 @@
    { "name": "libffi-dev", "state": "latest"},
    { "name": "libssl-dev", "state": "latest"},
    { "name": "gcc", "state": "latest"},
-   { "name": "gnupg", "state": "latest"},
+   { "name": "gnupg1", "state": "latest"},
    { "name": "rng-tools", "state": "latest"}
   ]
 }

--- a/storage_service/common/tests/test_shutil.py
+++ b/storage_service/common/tests/test_shutil.py
@@ -1,0 +1,185 @@
+"""Extracted from Python's ``Lib/test/test_shutil.py``."""
+
+import collections
+import contextlib
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+
+from common.which import which
+
+
+@contextlib.contextmanager
+def change_cwd(path, quiet=False):
+    """Return a context manager that changes the current working directory.
+    Arguments:
+      path: the directory to use as the temporary current working directory.
+      quiet: if False (the default), the context manager raises an exception
+        on error.  Otherwise, it issues only a warning and keeps the current
+        working directory the same.
+    """
+    saved_dir = os.getcwd()
+    try:
+        os.chdir(path)
+    except OSError:
+        if not quiet:
+            raise
+    try:
+        yield os.getcwd()
+    finally:
+        os.chdir(saved_dir)
+
+
+class EnvironmentVarGuard(collections.MutableMapping):
+    """Class to help protect the environment variable properly.
+
+    It can be used as a context manager.
+    """
+    def __init__(self):
+        self._environ = os.environ
+        self._changed = {}
+
+    def __getitem__(self, envvar):
+        return self._environ[envvar]
+
+    def __setitem__(self, envvar, value):
+        # Remember the initial value on the first access
+        if envvar not in self._changed:
+            self._changed[envvar] = self._environ.get(envvar)
+        self._environ[envvar] = value
+
+    def __delitem__(self, envvar):
+        # Remember the initial value on the first access
+        if envvar not in self._changed:
+            self._changed[envvar] = self._environ.get(envvar)
+        if envvar in self._environ:
+            del self._environ[envvar]
+
+    def keys(self):
+        return self._environ.keys()
+
+    def __iter__(self):
+        return iter(self._environ)
+
+    def __len__(self):
+        return len(self._environ)
+
+    def set(self, envvar, value):
+        self[envvar] = value
+
+    def unset(self, envvar):
+        del self[envvar]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *ignore_exc):
+        for (k, v) in self._changed.items():
+            if v is None:
+                if k in self._environ:
+                    del self._environ[k]
+            else:
+                self._environ[k] = v
+        os.environ = self._environ
+
+
+class TestWhich(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="Tmp")
+        self.addCleanup(shutil.rmtree, self.temp_dir, True)
+        # Give the temp_file an ".exe" suffix for all.
+        # It's needed on Windows and not harmful on other platforms.
+        self.temp_file = tempfile.NamedTemporaryFile(dir=self.temp_dir,
+                                                     prefix="Tmp",
+                                                     suffix=".Exe")
+        os.chmod(self.temp_file.name, stat.S_IXUSR)
+        self.addCleanup(self.temp_file.close)
+        self.dir, self.file = os.path.split(self.temp_file.name)
+
+    def test_basic(self):
+        # Given an EXE in a directory, it should be returned.
+        rv = which(self.file, path=self.dir)
+        self.assertEqual(rv, self.temp_file.name)
+
+    def test_absolute_cmd(self):
+        # When given the fully qualified path to an executable that exists,
+        # it should be returned.
+        rv = which(self.temp_file.name, path=self.temp_dir)
+        self.assertEqual(rv, self.temp_file.name)
+
+    def test_relative_cmd(self):
+        # When given the relative path with a directory part to an executable
+        # that exists, it should be returned.
+        base_dir, tail_dir = os.path.split(self.dir)
+        relpath = os.path.join(tail_dir, self.file)
+        with change_cwd(path=base_dir):
+            rv = which(relpath, path=self.temp_dir)
+            self.assertEqual(rv, relpath)
+        # But it shouldn't be searched in PATH directories (issue #16957).
+        with change_cwd(path=self.dir):
+            rv = which(relpath, path=base_dir)
+            self.assertIsNone(rv)
+
+    def test_cwd(self):
+        # Issue #16957
+        base_dir = os.path.dirname(self.dir)
+        with change_cwd(path=self.dir):
+            rv = which(self.file, path=base_dir)
+            if sys.platform == "win32":
+                # Windows: current directory implicitly on PATH
+                self.assertEqual(rv, os.path.join(os.curdir, self.file))
+            else:
+                # Other platforms: shouldn't match in the current directory.
+                self.assertIsNone(rv)
+
+    @unittest.skipIf(hasattr(os, 'geteuid') and os.geteuid() == 0,
+                     'non-root user required')
+    def test_non_matching_mode(self):
+        # Set the file read-only and ask for writeable files.
+        os.chmod(self.temp_file.name, stat.S_IREAD)
+        if os.access(self.temp_file.name, os.W_OK):
+            self.skipTest("can't set the file read-only")
+        rv = which(self.file, path=self.dir, mode=os.W_OK)
+        self.assertIsNone(rv)
+
+    def test_relative_path(self):
+        base_dir, tail_dir = os.path.split(self.dir)
+        with change_cwd(path=base_dir):
+            rv = which(self.file, path=tail_dir)
+            self.assertEqual(rv, os.path.join(tail_dir, self.file))
+
+    def test_nonexistent_file(self):
+        # Return None when no matching executable file is found on the path.
+        rv = which("foo.exe", path=self.dir)
+        self.assertIsNone(rv)
+
+    @unittest.skipUnless(sys.platform == "win32",
+                         "pathext check is Windows-only")
+    def test_pathext_checking(self):
+        # Ask for the file without the ".exe" extension, then ensure that
+        # it gets found properly with the extension.
+        rv = which(self.file[:-4], path=self.dir)
+        self.assertEqual(rv, self.temp_file.name[:-4] + ".EXE")
+
+    def test_environ_path(self):
+        with EnvironmentVarGuard() as env:
+            env['PATH'] = self.dir
+            rv = which(self.file)
+            self.assertEqual(rv, self.temp_file.name)
+
+    def test_empty_path(self):
+        with change_cwd(path=self.dir):
+            with EnvironmentVarGuard() as env:
+                env['PATH'] = self.dir
+                rv = which(self.file, path='')
+                self.assertIsNone(rv)
+
+    def test_empty_path_no_PATH(self):
+        with EnvironmentVarGuard() as env:
+            env.pop('PATH', None)
+            rv = which(self.file)
+            self.assertIsNone(rv)

--- a/storage_service/common/which.py
+++ b/storage_service/common/which.py
@@ -1,0 +1,70 @@
+"""Backport of ``shutil.which``.
+
+Extracted from ``Lib/shutil.py`` (Python 3.7).
+"""
+
+import os
+import sys
+
+
+def which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+    """
+    # Check that a given file can be accessed with the correct mode.
+    # Additionally check that `file` is not a directory, as on Windows
+    # directories pass the os.access check.
+    def _access_check(fn, mode):
+        return (
+            os.path.exists(fn) and
+            os.access(fn, mode) and
+            not os.path.isdir(fn))
+
+    # If we're given a path with a directory part, look it up directly rather
+    # than referring to PATH directories. This includes checking relative to
+    # the current directory, e.g. ./script
+    if os.path.dirname(cmd):
+        if _access_check(cmd, mode):
+            return cmd
+        return None
+
+    if path is None:
+        path = os.environ.get("PATH", os.defpath)
+    if not path:
+        return None
+    path = path.split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if os.curdir not in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path extensions.
+        # This will allow us to short circuit when given "python.exe".
+        # If it does match, only test that one, otherwise we have to try
+        # others.
+        if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+            files = [cmd]
+        else:
+            files = [cmd + ext for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir in path:
+        normdir = os.path.normcase(dir)
+        if normdir not in seen:
+            seen.add(normdir)
+            for thefile in files:
+                name = os.path.join(dir, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ setenv =
     DJANGO_SECRET_KEY = 1234
 
 [testenv:py36]
-basepython = python3
+basepython = python36
 skip_install = true
 deps = -rrequirements/test.txt
 commands =


### PR DESCRIPTION
Also, `gnupg1` is added to bionic's osdeps to ensure that GnuPG v1 is also installed. The binary is named `gpg1` which is now matched first by Storage Service.

This is connected to https://github.com/archivematica/Issues/issues/306.