### PR TITLE
Rely on GPG class to retrieve binary version

### DIFF
--- a/storage_service/locations/models/gpg.py
+++ b/storage_service/locations/models/gpg.py
@@ -347,14 +347,16 @@ def _extract_tar(tarpath):
 
 
 def _parse_gpg_version(raw_gpg_version):
-    return raw_gpg_version.splitlines()[0].split()[-1]
+    return ".".join(str(i) for i in raw_gpg_version)
 
 
 def _get_gpg_version():
-    """Return the version of GPG installed. The first line of stdout from ``gpg
-    --version`` is expected to be something like 'gpg (GnuPG) 1.4.16'
+    """Return the version of GPG installed as a string.
+
+    ``gpgutils.gpg.version`` is a 3-item tuple of integers, e.g.:
+    ``(1, 4, 16)`` for GnuPG v1.4.16.
     """
-    return _parse_gpg_version(subprocess.check_output(['gpg', '--version']))
+    return _parse_gpg_version(gpgutils.gpg().version)
 
 
 def create_encryption_event(encr_result, key_fingerprint):

--- a/storage_service/locations/tests/test_gpg.py
+++ b/storage_service/locations/tests/test_gpg.py
@@ -21,9 +21,7 @@ GPG_VERSION = '1.4.16'
 SS_VERSION = '0.11.0'
 SUCCESS_STATUS = 'good times'
 DECRYPT_RET_FAIL_STATUS = 'bad stuff happened'
-RAW_GPG_VERSION = ('gpg (GnuPG) {}\n'
-                   'and some other nonsense\n'
-                   'and some more nonsense'.format(GPG_VERSION))
+RAW_GPG_VERSION = (1, 4, 16)
 SOME_FINGERPRINT = EXP_FINGERPRINT = 'B9C518917A958DD0B1F5E1B80C3D34DDA5958532'
 SOME_OTHER_FINGERPRINT = 'BBBB18917A958DD0B1F5E1B80C3D34DDA595BBBB'
 TEST_AGENTS = [
@@ -358,8 +356,7 @@ def test__parse_gpg_version():
 
 
 def test_create_encryption_event(mocker):
-    mocker.patch.object(subprocess, 'check_output',
-                        return_value=RAW_GPG_VERSION)
+    mocker.patch.object(gpg, '_get_gpg_version', return_value=GPG_VERSION)
     mocker.patch.object(utils, 'get_ss_premis_agents', return_value=TEST_AGENTS)
     stderr = 'me contain " quote'
     encr_result = FakeGPGRet(ok=True, status=SUCCESS_STATUS, stderr=stderr)
@@ -378,7 +375,6 @@ def test_create_encryption_event(mocker):
     assert [x for x in lai if x[0] == 'linking_agent_identifier_value'][0][1] == (
         'Archivematica-Storage-Service-{}'.format(SS_VERSION))
     utils.get_ss_premis_agents.assert_called_once()
-    subprocess.check_output.assert_called_once_with(['gpg', '--version'])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This commit changes the logic in `_get_gpg_version` so it uses
`gpgutils.gpg` which holds a parsed version of the GnuPG binary and
knows how to locate the binary when it has different names, e.g. `gpg1`
instead of `gpg`.

It avoids the following exception from being raised:

```
Traceback:
  File "/src/storage_service/locations/models/gpg.py", line 362, in create_encryption_event
    gpg_version = _get_gpg_version()
  File "/src/storage_service/locations/models/gpg.py", line 357, in _get_gpg_version
    return _parse_gpg_version(subprocess.check_output(['gpg', '--version']))
  File "/usr/local/lib/python2.7/site-packages/gevent/subprocess.py", line 336, in check_output
    with Popen(*popenargs, stdout=PIPE, **kwargs) as process:
  File "/usr/local/lib/python2.7/site-packages/gevent/subprocess.py", line 650, in __init__
    reraise(*exc_info)
  File "/usr/local/lib/python2.7/site-packages/gevent/subprocess.py", line 619, in __init__
    restore_signals, start_new_session)
  File "/usr/local/lib/python2.7/site-packages/gevent/subprocess.py", line 1491, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory: 'gpg'
```

With this fix applied, [aip-encryption.feature](https://github.com/artefactual-labs/archivematica-acceptance-tests/blob/master/features/core/aip-encryption.feature) passes again.

Extends https://github.com/artefactual/archivematica-storage-service/pull/425.

Connects to https://github.com/archivematica/Issues/issues/306.