### PR TITLE
Remove 'beta' string from Dataverse Space form

### DIFF
--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -115,13 +115,6 @@ class DataverseForm(forms.ModelForm):
         model = models.Dataverse
         fields = ('host', 'api_key', 'agent_name', 'agent_type', 'agent_identifier')
 
-    def as_p(self):
-        # Add a warning to the Dataverse-specific section of the form
-        content = super(DataverseForm, self).as_p()
-        content += '\n<div class="alert">{}</div>'.format(
-            _('Integration with Dataverse is currently a beta feature'))
-        return mark_safe(content)
-
 
 class DuracloudForm(forms.ModelForm):
     class Meta:


### PR DESCRIPTION
Removes the string that said the Dataverse feature in the Storage Service was still a Beta. 

Connected to archivematica/issues#388

--

Hi @sromkey, I believe this should have been marked with the `1.9` milestone. Is it okay to do that so it can be merged?