### PR TITLE
Fix pip dependency installation issue (brotli)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 # updated May 9, 2017 for 0.11.0 release
 bagit==1.5.4
 boto3==1.6.5
-brotli==0.5.2  # Better compression library for WhiteNoise
+brotli==1.0.7  # Better compression library for WhiteNoise
 defusedxml==0.5.0
 Django>=1.8,<1.9
 django-extensions==1.7.9


### PR DESCRIPTION
Recent versions of pip couldn't get brotli to build (see [error log](https://gist.github.com/sevein/c9a3afa107aeedc5e63bbc7b600002fe)). Updating brotli to the latest release fixed the problem.

This is connected to https://github.com/archivematica/Issues/issues/455.