### PR TITLE
Ensure that the storage service can see an AIP to test whether a pointer file needs creating

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -611,7 +611,12 @@ class Package(models.Model):
                 self.current_path)
         if not package_type:
             package_type = self.package_type
-        isfile = os.path.isfile(package_full_path)
+        # The package hasn't been moved yet, test for it being a file on the
+        # originating Space.
+        try:
+            isfile = self.origin_location.space.isfile(package_full_path)
+        except NotImplementedError:
+            isfile = os.path.isfile(package_full_path)
         isaip = package_type in (Package.AIP, Package.AIC)
         ret = isfile and isaip
         if not ret:

--- a/storage_service/locations/models/pipeline_local.py
+++ b/storage_service/locations/models/pipeline_local.py
@@ -136,3 +136,13 @@ class PipelineLocalFS(models.Model):
 
         # Move file
         return self.space.move_rsync(source_path, destination_path, assume_rsync_daemon=self.assume_rsync_daemon, rsync_password=self.rsync_password)
+
+    def isfile(self, path):
+        """Verify that something is a file in this Space's context."""
+        LOGGER.info("Testing if isfile in pipeline file system: %s", path)
+        basename = os.path.basename(path)
+        if not basename:
+            return False
+        location_entries = self.space.browse(os.path.dirname(path))
+        return (basename in location_entries.get("entries", []) and
+            basename not in location_entries.get("directories", []))

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -448,6 +448,17 @@ class Space(models.Model):
                 {'protocol': self.get_access_protocol_display()}
             )
 
+    def isfile(self, path):
+        """Verify that something is a file in the context of a given space."""
+        child = self.get_child_space()
+        if hasattr(child, 'isfile'):
+            return child.isfile(path)
+        else:
+            raise NotImplementedError(
+                _('Space %(protocol)s does not implement isfile') %
+                {'protocol': self.get_access_protocol_display()}
+            )
+
     # HELPER FUNCTIONS
 
     def move_rsync(self, source, destination, try_mv_local=False, assume_rsync_daemon=False, rsync_password=None):


### PR DESCRIPTION
Enable ptr file creation for remote filesystem

When a Storage Service is configured to connect to a pipeline on a
remote server it cannot see the location of the package before it
is transferred over to the storage service. In its current
configuration Archivematica tries to create a pointer file based on
an AIP being a file, or not, before this happens. We implement a
change to query the remote location here and test for isfile here.

Connected to archivematica/issues#594
Connected to archivematica/issues#599