### PR TITLE
Fix: Problem while running the docker-compose up -d -build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV SS_GUNICORN_ERRORLOG -
 ENV FORWARDED_ALLOW_IPS *
 
 # OS dependencies
-RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
+RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list \
   && set -ex \
 	&& apt-get update -qq \
 	&& apt-get install -qq -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV SS_GUNICORN_ERRORLOG -
 ENV FORWARDED_ALLOW_IPS *
 
 # OS dependencies
-RUN RUN RUN RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
+RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
   && set -ex \
 	&& apt-get update -qq \
 	&& apt-get install -qq -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ENV SS_GUNICORN_ERRORLOG -
 ENV FORWARDED_ALLOW_IPS *
 
 # OS dependencies
-RUN set -ex \
+RUN RUN RUN RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
+  && set -ex \
 	&& apt-get update -qq \
 	&& apt-get install -qq -y --no-install-recommends \
 		gettext \


### PR DESCRIPTION
Problem while running the `docker-compose up -d -build` command:

> Err http://deb.debian.org jessie-updates/main amd64 Packages
>   404  Not Found
> Fetched 10.1 MB in 7s (1268 kB/s)
> W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found

According to the IRC channel for Debian, Jessie is now not supported:

Debian Jessie, jessie-updates and jessie-backports REMOVED 2019-03-24

https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html