### PR TITLE
Cherry-pick: Enable ptr file creation for remote filesystem

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -694,7 +694,12 @@ class Package(models.Model):
             )
         if not package_type:
             package_type = self.package_type
-        isfile = os.path.isfile(package_full_path)
+        # The package hasn't been moved yet, test for it being a file on the
+        # originating Space.
+        try:
+            isfile = self.origin_location.space.isfile(package_full_path)
+        except NotImplementedError:
+            isfile = os.path.isfile(package_full_path)
         isaip = package_type in (Package.AIP, Package.AIC)
         ret = isfile and isaip
         if not ret:

--- a/storage_service/locations/models/pipeline_local.py
+++ b/storage_service/locations/models/pipeline_local.py
@@ -172,3 +172,14 @@ class PipelineLocalFS(models.Model):
             assume_rsync_daemon=self.assume_rsync_daemon,
             rsync_password=self.rsync_password,
         )
+
+    def isfile(self, path):
+        """Verify that something is a file in this Space's context."""
+        LOGGER.info("Testing if isfile in pipeline file system: %s", path)
+        basename = os.path.basename(path)
+        if not basename:
+            return False
+        location_entries = self.space.browse(os.path.dirname(path))
+        return basename in location_entries.get(
+            "entries", []
+        ) and basename not in location_entries.get("directories", [])

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -506,6 +506,17 @@ class Space(models.Model):
                 % {"protocol": self.get_access_protocol_display()}
             )
 
+    def isfile(self, path):
+        """Verify that something is a file in the context of a given space."""
+        child = self.get_child_space()
+        if hasattr(child, "isfile"):
+            return child.isfile(path)
+        else:
+            raise NotImplementedError(
+                _("Space %(protocol)s does not implement isfile")
+                % {"protocol": self.get_access_protocol_display()}
+            )
+
     # HELPER FUNCTIONS
 
     def move_rsync(


### PR DESCRIPTION
When a Storage Service is configured to connect to a pipeline on a
remote server it cannot see the location of the package before it
is transferred over to the storage service. In its current
configuration Archivematica tries to create a pointer file based on
an AIP being a file, or not, before this happens. We implement a
change to query the remote location and create a test for isfile().

Connected to archivematica/Issues#599
Connected to archivematica/Issues#594
Manually cherry-picked from https://github.com/artefactual/archivematica-storage-service/pull/443/files