### PR TITLE
S3: Enable the creation of storage spaces in different AWS/S3 regions

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 # Base requirements - for all installations
 # updated May 9, 2017 for 0.11.0 release
 bagit==1.7.0
-boto3==1.6.5
+boto3==1.9.174
 brotli==0.5.2  # Better compression library for WhiteNoise
 defusedxml==0.5.0
 Django>=1.8,<1.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,8 @@ agentarchives==0.4.0
 asn1crypto==0.24.0        # via cryptography
 babel==2.6.0              # via oslo.i18n
 bagit==1.7.0
-boto3==1.6.5
-botocore==1.9.23          # via boto3, s3transfer
+boto3==1.9.174
+botocore==1.12.175        # via boto3, s3transfer
 brotli==0.5.2
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cryptography
@@ -71,10 +71,10 @@ pyyaml==5.1               # via oslo.config, oslo.serialization
 requests-oauthlib==1.2.0
 requests==2.21.0
 rfc3986==1.3.2            # via oslo.config
-s3transfer==0.1.13        # via boto3
+s3transfer==0.2.1         # via boto3
 six==1.12.0               # via cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, stevedore
 stevedore==1.30.1         # via keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1
-urllib3==1.24.3           # via requests
+urllib3==1.24.3           # via botocore, requests
 whitenoise==3.3.0
 wrapt==1.11.1             # via debtcollector, positional

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,8 +8,8 @@ agentarchives==0.4.0
 asn1crypto==0.24.0
 babel==2.6.0
 bagit==1.7.0
-boto3==1.6.5
-botocore==1.9.23
+boto3==1.9.174
+botocore==1.12.175
 brotli==0.5.2
 certifi==2019.3.9
 cffi==1.12.3
@@ -79,7 +79,7 @@ pyyaml==5.1
 requests-oauthlib==1.2.0
 requests==2.21.0
 rfc3986==1.3.2
-s3transfer==0.1.13
+s3transfer==0.2.1
 six==1.12.0
 sphinx==1.2b1
 stevedore==1.30.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,8 +8,8 @@ agentarchives==0.4.0
 asn1crypto==0.24.0
 babel==2.6.0
 bagit==1.7.0
-boto3==1.6.5
-botocore==1.9.23
+boto3==1.9.174
+botocore==1.12.175
 brotli==0.5.2
 certifi==2019.3.9
 cffi==1.12.3
@@ -73,7 +73,7 @@ pyyaml==5.1
 requests-oauthlib==1.2.0
 requests==2.21.0
 rfc3986==1.3.2
-s3transfer==0.1.13
+s3transfer==0.2.1
 six==1.12.0
 stevedore==1.30.1
 sword2==0.2.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,8 +11,8 @@ attrs==19.1.0             # via pytest
 babel==2.6.0
 backports.shutil-get-terminal-size==1.0.0  # via ipython
 bagit==1.7.0
-boto3==1.6.5
-botocore==1.9.23
+boto3==1.9.174
+botocore==1.12.175
 brotli==0.5.2
 certifi==2019.3.9
 cffi==1.12.3
@@ -97,7 +97,7 @@ pyyaml==5.1
 requests-oauthlib==1.2.0
 requests==2.21.0
 rfc3986==1.3.2
-s3transfer==0.1.13
+s3transfer==0.2.1
 scandir==1.10.0           # via pathlib2
 simplegeneric==0.8.1      # via ipython
 six==1.12.0


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/638 and https://github.com/archivematica/Issues/issues/639

**EDIT:** *(from Ross)*

This had been rebased and ensures that Boto3 is upgraded. There were complications testing using the [`head_bucket`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.head_bucket) client function with Boto3, namely, the 404 we anticipated wasn't being returned, at least in my environment. And my testing of nonsense bucket names proved inconsistent as well. I swapped `head_bucket` out for [`get_bucket_location`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_bucket_location) which is equally usable, and can only return information if the bucket exists. If the bucket doesn't exist we can create it per the original logic, and return an exception if there are any other difficulties. 

I have added notes on this in the docstring. 

**Notes on testing**

Those looking at this might be tempted to use the same space delete the bucket and then change the region settings to show S3 switching between locations. I would caution against this without leaving adequate time between bucket deletions as the S3 service may still be processing that.

The easiest way to test that we can create locations in different spaces is to create two different spaces.

Two locations I used for testing are: 

* ca-central-1
* us-east-2

Good work @mamedin and thanks to whomever may CR this! 
