### PR TITLE
Extend service callbacks

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -1381,7 +1381,7 @@ class PackageResource(ModelResource):
     def aip_store_callback_request(self, request, bundle, **kwargs):
         package = bundle.obj
 
-        callbacks = Callback.objects.filter(event="post_store")
+        callbacks = Callback.objects.filter(event="post_store", enabled=True)
         if len(callbacks) == 0:
             return http.HttpNoContent()
 
@@ -1428,8 +1428,9 @@ class PackageResource(ModelResource):
             for file_ in files:
                 for callback in callbacks:
                     uri = callback.uri.replace("<source_id>", file_.source_id)
+                    body = callback.body.replace("<source_id>", file_.source_id)
                     try:
-                        callback.execute(uri)
+                        callback.execute(uri, body)
                         file_.stored = True
                         file_.save()
                     except CallbackError:

--- a/storage_service/locations/fixtures/callback.json
+++ b/storage_service/locations/fixtures/callback.json
@@ -1,0 +1,72 @@
+[
+{
+  "fields": {
+    "body": "",
+    "expected_status": 200,
+    "uuid": "6020d3d9-ecb0-4339-8bbb-0d9ec1d6877b",
+    "enabled": true,
+    "uri": "http://consumer.com/api/v1/file/<source_id>/",
+    "method": "delete",
+    "headers": "",
+    "event": "post_store"
+  },
+  "model": "locations.callback",
+  "pk": 1
+},
+{
+  "fields": {
+    "body": "",
+    "expected_status": 200,
+    "uuid": "24eb7980-27de-4729-927a-ac91f726469d",
+    "enabled": true,
+    "uri": "http://consumer.com/api/v1/aip/<package_uuid>/",
+    "method": "post",
+    "headers": "",
+    "event": "post_store_aip"
+  },
+  "model": "locations.callback",
+  "pk": 2
+},
+{
+  "fields": {
+    "body": "",
+    "expected_status": 200,
+    "uuid": "6be67a5a-b970-4d88-b7dc-548195476853",
+    "enabled": true,
+    "uri": "http://consumer.com/api/v1/aic/<package_uuid>/",
+    "method": "post",
+    "headers": "",
+    "event": "post_store_aic"
+  },
+  "model": "locations.callback",
+  "pk": 3
+},
+{
+  "fields": {
+    "body": "",
+    "expected_status": 200,
+    "uuid": "6be67a5a-b970-4d88-b7dc-548195476853",
+    "enabled": false,
+    "uri": "http://consumer.com/api/v1/aic/<package_uuid>/",
+    "method": "post",
+    "headers": "",
+    "event": "post_store_aic"
+  },
+  "model": "locations.callback",
+  "pk": 4
+},
+{
+  "fields": {
+    "body": "{\"download_url\": \"http://ss.com/api/v2/file/<package_uuid>/download/\"}",
+    "expected_status": 202,
+    "uuid": "ef0672a2-d0ed-474b-95f6-ff8f9ea1fc15",
+    "enabled": true,
+    "uri": "https://consumer.com/api/v1/dip/<package_uuid>/stored",
+    "method": "post",
+    "headers": "{\"Authorization\": \"Token token_string\", \"Origin\": \"http://ss.com\"}",
+    "event": "post_store_dip"
+  },
+  "model": "locations.callback",
+  "pk": 5
+}
+]

--- a/storage_service/locations/migrations/0021_alter_callback.py
+++ b/storage_service/locations/migrations/0021_alter_callback.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("locations", "0020_dspace_rest")]
+
+    operations = [
+        migrations.AddField(
+            model_name="callback",
+            name="body",
+            field=models.TextField(
+                help_text="Body content for each request. Set the 'Content-type' header accordingly.",
+                null=True,
+                verbose_name="Body",
+                blank=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="callback",
+            name="headers",
+            field=models.TextField(
+                help_text="Headers for each request.",
+                null=True,
+                verbose_name="Headers",
+                blank=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="callback",
+            name="event",
+            field=models.CharField(
+                help_text="Type of event when this callback should be executed.",
+                max_length=15,
+                verbose_name="Event",
+                choices=[
+                    (b"post_store", "Post-store AIP (source files)"),
+                    (b"post_store_aip", "Post-store AIP"),
+                    (b"post_store_aic", "Post-store AIC"),
+                    (b"post_store_dip", "Post-store DIP"),
+                ],
+            ),
+        ),
+    ]

--- a/storage_service/locations/tests/test_forms.py
+++ b/storage_service/locations/tests/test_forms.py
@@ -1,0 +1,59 @@
+import os
+
+from django.test import TestCase
+
+from locations import forms, models
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+FIXTURES_DIR = os.path.abspath(os.path.join(THIS_DIR, "..", "fixtures", ""))
+
+
+class TestCallbackForm(TestCase):
+    fixtures = ["callback.json"]
+
+    def test_headers_added(self):
+        callback = models.Callback.objects.get(
+            uuid="ef0672a2-d0ed-474b-95f6-ff8f9ea1fc15"
+        )
+        form = forms.CallbackForm(None, instance=callback)
+        # Existing headers should be added in order
+        assert form.fields["header_0"].initial == (
+            "Authorization",
+            "Token token_string",
+        )
+        assert form.fields["header_1"].initial == ("Origin", "http://ss.com")
+        # An extra field should be added
+        assert form.fields["header_2"]
+
+    def test_headers_processed(self):
+        callback = models.Callback.objects.get(
+            uuid="ef0672a2-d0ed-474b-95f6-ff8f9ea1fc15"
+        )
+        post_data = {
+            "event": "post_store_dip",
+            "uri": "https://consumer.com/api/v1/dip/<package_uuid>/stored",
+            "method": "post",
+            "header_0_0": "Authorization",
+            "header_0_1": "Token token_string",
+            "header_1_0": "Origin",
+            "header_1_1": "http://ss.com",
+            "header_2_0": "Existing-header-fields-key",
+            "header_2_1": "Existing header fields value",
+            "header_3_0": "",
+            "header_3_1": "",
+            "header_4_0": "New-header-fields-key",
+            "header_4_1": "New header fields value",
+            "body": "",
+            "expected_status": 202,
+            "enabled": True,
+        }
+        form = forms.CallbackForm(post_data, instance=callback)
+        callback = form.save()
+        # Headers should be processed in order, ignoring empty values
+        processed_headers = (
+            '{"Authorization": "Token token_string", '
+            '"Origin": "http://ss.com", '
+            '"Existing-header-fields-key": "Existing header fields value", '
+            '"New-header-fields-key": "New header fields value"}'
+        )
+        assert callback.headers == processed_headers

--- a/storage_service/static/css/project.css
+++ b/storage_service/static/css/project.css
@@ -1,24 +1,25 @@
 body {
-    font-size:100%;
+  font-size:100%;
 }
 
 h1 {
-    font-size:2em;
+  font-size:2em;
 }
 
 h2 {
-    font-size: 1.8em;
-    margin-top: 1em;
+  font-size: 1.8em;
+  margin-top: 1em;
 }
 
 p {
-    font-size:0.875em;
+  font-size:0.875em;
 }
 
 .row {
-    display: table-row;
-    margin-left: 0;
+  display: table-row;
+  margin-left: 0;
 }
+
 .sidebar ul,
 .sidebar li {
   list-style: none;
@@ -31,8 +32,8 @@ p {
 }
 
 div.sidebar {
-    width: 15%;
-    min-width: 120px;
+  width: 15%;
+  min-width: 120px;
 }
 
 form ul {
@@ -54,16 +55,17 @@ table.attr-val-table td {
 }
 
 label.required-field:after {
-    content: '*'
+  content: '*';
 }
 
 .errorlist {
   color: red;
 }
 
-/* Mimic regular Bootstrap 2.x links.
-   This is used inside inline forms pretending to be just regular links! */
-
+/*
+Mimic regular Bootstrap 2.x links. This is used inside
+inline forms pretending to be just regular links!
+*/
 button.link {
   background: none !important;
   color: #08c;
@@ -78,4 +80,12 @@ button.link:hover,
 button.link:active {
   color: #005580;
   text-decoration: underline;
+}
+
+.callback > form input[name^=header_] {
+  margin: 0 10px 0 0;
+}
+
+.callback-extended-description {
+  margin-bottom: 20px;
 }

--- a/storage_service/static/js/project.js
+++ b/storage_service/static/js/project.js
@@ -1,87 +1,161 @@
-
 $(document).ready(function() {
-    $('.datatable').dataTable({
-      // List of language strings from https://datatables.net/reference/option/language
-      oLanguage: {
-          sDecimal:        "",
-          sEmptyTable:     gettext("No data available in table"),
-          sInfo:           gettext("Showing _START_ to _END_ of _TOTAL_ entries"),
-          sInfoEmpty:      gettext("Showing 0 to 0 of 0 entries"),
-          sInfoFiltered:   gettext("(filtered from _MAX_ total entries)"),
-          sInfoPostFix:    "",
-          sThousands:      ",",
-          sLengthMenu:     gettext("Show _MENU_ entries"),
-          sLoadingRecords: gettext("Loading..."),
-          sProcessing:     gettext("Processing..."),
-          sSearch:         gettext("Search:"),
-          sZeroRecords:    gettext("No matching records found"),
-          oPaginate: {
-              sFirst:      gettext("First"),
-              sLast:       gettext("Last"),
-              sNext:       gettext("Next"),
-              sPrevious:   gettext("Previous")
-          },
-          oAria: {
-              sSortAscending:  gettext(": activate to sort column ascending"),
-              sSortDescending: gettext(": activate to sort column descending"),
-          },
+  $('.datatable').dataTable({
+    // List of language strings from https://datatables.net/reference/option/language
+    oLanguage: {
+      sDecimal:        "",
+      sEmptyTable:     gettext("No data available in table"),
+      sInfo:           gettext("Showing _START_ to _END_ of _TOTAL_ entries"),
+      sInfoEmpty:      gettext("Showing 0 to 0 of 0 entries"),
+      sInfoFiltered:   gettext("(filtered from _MAX_ total entries)"),
+      sInfoPostFix:    "",
+      sThousands:      ",",
+      sLengthMenu:     gettext("Show _MENU_ entries"),
+      sLoadingRecords: gettext("Loading..."),
+      sProcessing:     gettext("Processing..."),
+      sSearch:         gettext("Search:"),
+      sZeroRecords:    gettext("No matching records found"),
+      oPaginate: {
+        sFirst:      gettext("First"),
+        sLast:       gettext("Last"),
+        sNext:       gettext("Next"),
+        sPrevious:   gettext("Previous")
+      },
+      oAria: {
+        sSortAscending:  gettext(": activate to sort column ascending"),
+        sSortDescending: gettext(": activate to sort column descending"),
+      },
+    }
+  });
+
+  $("a.request-delete").click(function() {
+    var self = $(this);
+    var uuid = self.data('package-uuid');
+    var pipeline = self.data('package-pipeline');
+    var packageType = self.data('package-type');
+    var $userDataEl = $("#user-data-packages");
+    var userId = $userDataEl.data('user-id');
+    var userEmail = $userDataEl.data('user-email');
+    var userUsername = $userDataEl.data('user-username');
+    var userAPIKey = $userDataEl.data('user-api-key');
+    var uri = $userDataEl.data('uri');
+    var formData = {
+      "event_reason": "Storage Service user wants to delete " + packageType + " " + uuid + ".",
+      "pipeline": pipeline,
+      "user_id": userId,
+      "user_email": userEmail
+    };
+    $.ajax({
+      type: "POST",
+      url: uri + "api/v2/file/" + uuid + '/delete_aip/',
+      data: JSON.stringify(formData),
+      dataType: "json",
+      contentType: "application/json; charset=utf-8",
+      headers: {"Authorization": "ApiKey " + userUsername + ":" + userAPIKey},
+      success: function(data) {
+        $("div#package-delete-alert").remove();
+        $("h1").first().after(
+          "<div id='package-delete-alert' class='alert alert-success'>" +
+          data.message + "</div>");
+      },
+      failure: function(errMsg) {
+        $("div#package-delete-alert").remove();
+        $("h1").first().after(
+          "<div id='package-delete-alert' class='alert alert-warning'>" +
+          data.message + "</div>"
+        );
       }
     });
+    return false;
+  });
 
-    $("a.request-delete").click(function() {
-        var self = $(this);
-        var uuid = self.data('package-uuid');
-        var pipeline = self.data('package-pipeline');
-        var packageType = self.data('package-type');
-        var $userDataEl = $("#user-data-packages");
-        var userId = $userDataEl.data('user-id');
-        var userEmail = $userDataEl.data('user-email');
-        var userUsername = $userDataEl.data('user-username');
-        var userAPIKey = $userDataEl.data('user-api-key');
-        var uri = $userDataEl.data('uri');
-        var formData = {
-            "event_reason": "Storage Service user wants to delete " + packageType + " " + uuid + ".",
-            "pipeline": pipeline,
-            "user_id": userId,
-            "user_email": userEmail};
-        $.ajax({
-            type: "POST",
-            url: uri + "api/v2/file/" + uuid + '/delete_aip/',
-            data: JSON.stringify(formData),
-            dataType: "json",
-            contentType: "application/json; charset=utf-8",
-            headers: {"Authorization": "ApiKey " + userUsername + ":" + userAPIKey},
-            success: function(data) {
-                $("div#package-delete-alert").remove();
-                $("h1").first().after(
-                    "<div id='package-delete-alert' class='alert alert-success'>" +
-                    data.message + "</div>");
-            },
-            failure: function(errMsg) {
-                $("div#package-delete-alert").remove();
-                $("h1").first().after(
-                    "<div id='package-delete-alert' class='alert alert-warning'>" +
-                    data.message + "</div>");
-            }
+  // Enable confirmation modal in certain forms. The submit button is
+  // overriden so it opens the modal. The submit button inside the modal is
+  // allowed to submit the form instead.
+  // Used in `packages_table.html` (delete DIP functionality).
+  // Currently limited to one form per page, see jQuery.each for more.
+  $("form.submit-confirm").each(function(index, target) {
+    var $form = $(target);
+    var $modal = $form.find(".confirm-modal");
+    $form.on("click", "button[type=submit]", function(event) {
+      var $button = $(event.target);
+      if ($button.parents(".confirm-modal").length) {
+        return true;
+      }
+      event.preventDefault();
+      $modal.modal("show");
+    });
+  });
+
+  /***************
+  CALLBACK HEADERS
+  ***************/
+
+  // Add delete link besides each callback header
+  $(".callback > form input[name^=header_] + input[name^=header_]").each(function() {
+    $(this).after($('<a href="#" class="delete_header">' + gettext("Delete") + '</a>'));
+  });
+
+  // Append add header link after the existing headers
+  $(".callback > form p:has(input[name^=header_] + input[name^=header_])").last().after(
+    $('<p><a href="#" class="add_header">' + gettext("Add header") + '</a></p>')
+  );
+
+  // Manage inputs from a set of headers
+  function updateHeaderInputs(headers, increment=0, clean=true) {
+    // Do nothing if no need to increment properties or clean values
+    if (increment === 0 && !clean) {
+      return;
+    }
+    headers.find("input[name^=header_]").each(function() {
+      var $input = $(this);
+      // Update first digits of input id and name properties
+      if (increment !== 0) {
+        $.each(["id", "name"], function(index, value) {
+          $input.prop(value, $input.prop(value).replace(/\d+/, function(key) {
+            return parseInt(key) + increment;
+          }));
         });
-        return false;
+      }
+      // Remove current value
+      if (clean) {
+        $input.val("");
+      }
     });
+  }
 
-    // Enable confirmation modal in certain forms. The submit button is
-    // overriden so it opens the modal. The submit button inside the modal is
-    // allowed to submit the form instead.
-    // Used in `packages_table.html` (delete DIP functionality).
-    // Currently limited to one form per page, see jQuery.each for more.
-    $("form.submit-confirm").each(function(index, target) {
-      var $form = $(target);
-      var $modal = $form.find(".confirm-modal");
-      $form.on("click", "button[type=submit]", function(event) {
-          var $button = $(event.target);
-	  if ($button.parents(".confirm-modal").length) {
-            return true;
-          }
-          event.preventDefault();
-          $modal.modal("show");
-      });
-    });
+  // Delete header link click listener
+  $("body").on("click", ".callback > form a.delete_header", function(event) {
+    event.preventDefault();
+    var $this_header = $(this).parent();
+    var $headers_count = $this_header.parent().find(":has(input[name^=header_])").length;
+    // If there is more than one header, update the ones after this to
+    // decrease the id and name counter (keeping the values) and remove it.
+    if ($headers_count > 1) {
+      var $following_headers = $this_header.nextAll(":has(input[name^=header_])");
+      updateHeaderInputs($following_headers, -1, false)
+      // If we're deleting the first header, move the label to the next one
+      var $label = $this_header.find("label").first();
+      if ($label) {
+        $following_headers.first().prepend($label);
+      }
+      $this_header.remove();
+    } else {
+      // Otherwise, just remove this header inputs values
+      updateHeaderInputs($this_header)
+    }
+  });
+
+  // Add header link click listener
+  $("body").on("click", ".callback > form a.add_header", function(event) {
+    event.preventDefault();
+    // Clone last header
+    var $last_header = $(this).parent().prev();
+    var $clone = $last_header.clone();
+    // Remove label if cloning the first header
+    $clone.find("label").remove();
+    // Increase the inputs id and name properties and remove the values
+    updateHeaderInputs($clone, 1)
+    // Append modified clone after last header
+    $last_header.after($clone);
+  });
 });

--- a/storage_service/templates/locations/callback_detail.html
+++ b/storage_service/templates/locations/callback_detail.html
@@ -7,9 +7,20 @@
 
 <div class="callback">
   <dl>
+    <dt>{% trans "Event" %}</dt> <dd>{{ callback.get_event_display }}</dd>
     <dt>{% trans "URI" %}</dt> <dd>{{ callback.uri }}</dd>
-    <dt>{% trans "Event" %}</dt> <dd>{{ callback.event }}</dd>
     <dt>{% trans "HTTP Method" %}</dt> <dd>{{ callback.method }}</dd>
+    <dt>{% trans "Headers" %}</dt>
+    {% if callback.headers %}
+      <dd>
+        <ul>
+          {% for key, value in callback.get_headers.items %}
+            <li>{{ key }}: {{ value }}</li>
+          {% endfor %}
+        </ul>
+      </dd>
+    {% endif %}
+    <dt>{% trans "Body" %}</dt> <dd>{{ callback.body|linebreaksbr }}</dd>
     <dt>{% trans "Expected status" %}</dt> <dd>{{ callback.expected_status }}</dd>
     <dt>{% trans "Enabled" %}</dt> <dd>{{ callback.enabled|yesno:_("Enabled,Disabled")}}</dd>
     <dt>{% trans "Actions" %}</dt> <dd>

--- a/storage_service/templates/locations/callback_form.html
+++ b/storage_service/templates/locations/callback_form.html
@@ -1,18 +1,38 @@
 {% extends "administration/base.html" %}
-
+{% load i18n %}
 {% block page_title %}{{ action }}{% endblock %}
-
 {% block content %}
+{% include 'snippets/callback_description.html' %}
 
-<div class='callback'>
-    {% if callback %}
-    <form action="{% url 'callback_edit' callback.uuid %}" method="post">
-    {% else %}
-    <form action="{% url 'callback_create' %}" method="post">
-    {% endif %}
-    {% csrf_token %}
-        {{ form.as_p }}
-        <input type="submit" value="{{action}}" class='btn btn-primary' />
-    </form>
+<div class="callback-extended-description">
+  <p>{% trans "Those actions are determined by the following events:" %}</p>
+  <p>
+    <strong>{% trans "Post-store AIP (source files)" %}:</strong>
+    {% blocktrans with placeholder="<em>&lt;source_id&gt;</em>" trimmed %}
+    Occurs after an AIP has been stored and it causes the execution of a request for
+    each source file of the AIP. If the placeholder {{ placeholder }} is found
+    in the callback URL or body, it will be replaced by the source file UUID.
+    {% endblocktrans %}
+  </p>
+  <p>
+    <strong>{% trans "Post-store AIP, Post-store AIC and Post-store DIP" %}:</strong>
+    {% blocktrans with placeholder="<em>&lt;package_uuid&gt;</em>" trimmed %}
+    Occur after an AIP, AIC or DIP has been stored and they cause the execution of a
+    single request for the package. If the placeholder {{ placeholder }} is found
+    in the callback URL or body, it will be replaced by the AIP, AIC or DIP UUID.
+    {% endblocktrans %}
+  </p>
+</div>
+
+<div class="callback">
+  {% if callback %}
+  <form action="{% url 'callback_edit' callback.uuid %}" method="post">
+  {% else %}
+  <form action="{% url 'callback_create' %}" method="post">
+  {% endif %}
+  {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="{{action}}" class="btn btn-primary"/>
+  </form>
 </div>
 {% endblock %}

--- a/storage_service/templates/snippets/callbacks_table.html
+++ b/storage_service/templates/snippets/callbacks_table.html
@@ -14,7 +14,7 @@
     <tbody>
     {% for callback in callbacks %}
       <tr>
-        <td>{{ callback.event }}</td>
+        <td>{{ callback.get_event_display }}</td>
         <td>{{ callback.uri }}</td>
         <td>{{ callback.method }}</td>
         <td>{{ callback.expected_status }}</td>


### PR DESCRIPTION
Allows to create request callbacks for AIP, AIC and DIP stored events
alongside the existing "post_store" event used for AIP source files.

- Add new event options for callbacks.
- Add "body" and "headers" fields for better callback customization.
- Manage headers key/value fields dynamically.
- Execute new post store AIP, AIC and DIP callbacks after the package
  is moved to uploaded.
- Replace `<package_uuid>` by the package UUID in the callback URI
  and body.
- Check enabled field on callback execution.
- Display event labels.
- Improve callback form description.

https://github.com/archivematica/Issues/issues/147