### PR TITLE
Async: convert buffer to str before pickling

### DIFF
--- a/storage_service/locations/models/async.py
+++ b/storage_service/locations/models/async.py
@@ -50,7 +50,10 @@ class Async(models.Model):
 
     @property
     def error(self):
-        return pickle.loads(self._error)
+        error = self._error
+        if isinstance(error, six.memoryview):
+            error = str(error)
+        return pickle.loads(error)
 
     @error.setter
     def error(self, value):


### PR DESCRIPTION
Convert `Async.error` to `str` before unserialization.

This was preventing errors from being reported properly.

Connects to https://github.com/archivematica/Issues/issues/671.
Similar to https://github.com/artefactual/archivematica-storage-service/issues/358.