### PR TITLE
Disallow move from transfer source

### DIFF
--- a/storage_service/locations/models/location.py
+++ b/storage_service/locations/models/location.py
@@ -44,7 +44,7 @@ class Location(models.Model):
     REPLICATOR = "RP"
 
     # List of purposes where moving is not allowed.
-    PURPOSES_DISALLOWED_MOVE = (BACKLOG, AIP_STORAGE)
+    PURPOSES_DISALLOWED_MOVE = (BACKLOG, AIP_STORAGE, TRANSFER_SOURCE)
 
     PURPOSE_CHOICES = (
         (AIP_RECOVERY, _("AIP Recovery")),


### PR DESCRIPTION
Relates to: https://github.com/archivematica/Issues/issues/646

It looks like the defect was introduced when we reduced the number of copies done in https://github.com/artefactual/archivematica-storage-service/pull/320.

This PR builds on work done in https://github.com/artefactual/archivematica-storage-service/pull/422.