### PR TITLE
Update pointer file PREMIS version

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,7 +14,7 @@ gunicorn==19.9.0
 jsonfield==2.0.1
 logutils==0.3.4.1
 lxml==3.7.3
-metsrw==0.3.1
+metsrw==0.3.8
 ndg-httpsclient==0.4.2
 python-gnupg==0.4.0
 python-keystoneclient==3.10.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,7 +40,7 @@ keystoneauth1==3.14.0     # via python-keystoneclient
 logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
-metsrw==0.3.1
+metsrw==0.3.8
 monotonic==1.5            # via oslo.utils
 msgpack==0.6.1            # via oslo.serialization
 mysqlclient==1.4.2.post1  # via agentarchives

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -45,7 +45,7 @@ logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
 markupsafe==1.1.1         # via jinja2
-metsrw==0.3.1
+metsrw==0.3.8
 monotonic==1.5
 msgpack==0.6.1
 mysqlclient==1.4.2.post1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -41,7 +41,7 @@ keystoneauth1==3.14.0
 logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
-metsrw==0.3.1
+metsrw==0.3.8
 monotonic==1.5
 msgpack==0.6.1
 mysqlclient==1.4.2.post1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -52,7 +52,7 @@ keystoneauth1==3.14.0
 logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
-metsrw==0.3.1
+metsrw==0.3.8
 mock==3.0.5               # via pytest-mock, vcrpy
 monotonic==1.5
 more-itertools==5.0.0     # via pytest

--- a/storage_service/common/management/commands/import_aip.py
+++ b/storage_service/common/management/commands/import_aip.py
@@ -63,7 +63,7 @@ from django.db.utils import IntegrityError
 from django.utils.six.moves import input
 
 from administration.models import Settings
-from common import utils
+from common import premis, utils
 from locations import models
 
 
@@ -360,7 +360,7 @@ def compress(aip_model_inst, compression_algorithm):
     """Use the Package model's compress_package method to compress the AIP
     being imported, update the Package model's ``size`` attribute, retrieve
     PREMIS agents and event for the compression (using the package model's
-    ``get_premis_aip_compression_event`` method) and return a 3-tuple:
+    ``create_premis_aip_compression_event`` method) and return a 3-tuple:
     (aip_model_inst, compression_event, compression_agents).
     """
     if not compression_algorithm:
@@ -379,8 +379,8 @@ def compress(aip_model_inst, compression_algorithm):
     aip_model_inst.current_path = new_current_path
     shutil.rmtree(compressed_aip_parent_path)
     aip_model_inst.size = utils.recalculate_size(new_full_path)
-    compression_agents = utils.get_ss_premis_agents()
-    compression_event = aip_model_inst.get_premis_aip_compression_event(
+    compression_agents = [premis.SS_AGENT]
+    compression_event = premis.create_premis_aip_compression_event(
         details["event_detail"],
         details["event_outcome_detail_note"],
         agents=compression_agents,

--- a/storage_service/common/premis.py
+++ b/storage_service/common/premis.py
@@ -1,0 +1,349 @@
+"""
+PREMIS metadata generation.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import uuid
+
+import metsrw
+from django.utils import timezone
+
+from storage_service import __version__ as ss_version
+
+
+PREMIS_META = metsrw.plugins.premisrw.PREMIS_3_0_META
+SS_AGENT = metsrw.plugins.premisrw.PREMISAgent(
+    data=(
+        "agent",
+        PREMIS_META,
+        (
+            "agent_identifier",
+            ("agent_identifier_type", "preservation system"),
+            (
+                "agent_identifier_value",
+                "Archivematica-Storage-Service-{}".format(ss_version),
+            ),
+        ),
+        ("agent_name", "Archivematica Storage Service"),
+        ("agent_type", "software"),
+    )
+)
+
+
+def timestamp():
+    return timezone.now().strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def add_agents_to_event_as_list(event, agents):
+    """Add agents in ``agents`` to the list ``event`` which represents a
+    PREMIS:EVENT.
+    :param list event: a PREMIS:EVENT represented as a list
+    :param iterable agents: an iterable of premisrw.PREMISAgent instances.
+    """
+    for agent in agents:
+        event.append(
+            (
+                "linking_agent_identifier",
+                ("linking_agent_identifier_type", agent.identifier_type),
+                ("linking_agent_identifier_value", agent.identifier_value),
+            )
+        )
+    return event
+
+
+def create_replication_event(
+    original_package_uuid, replica_package_uuid, event_uuid=None, agents=None
+):
+    """Return a PREMISEvent for replication of an AIP.
+    """
+    outcome_detail_note = (
+        "Replicated Archival Information Package (AIP) {} by creating"
+        " replica {}.".format(original_package_uuid, replica_package_uuid)
+    )
+    if not agents:
+        agents = [SS_AGENT]
+    if not event_uuid:
+        event_uuid = str(uuid.uuid4())
+    event = [
+        "event",
+        PREMIS_META,
+        (
+            "event_identifier",
+            ("event_identifier_type", "UUID"),
+            ("event_identifier_value", event_uuid),
+        ),
+        ("event_type", "replication"),
+        ("event_date_time", timestamp()),
+        (
+            "event_detail_information",
+            ("event_detail", "Replication of an Archival Information Package"),
+        ),
+        (
+            "event_outcome_information",
+            ("event_outcome", "success"),
+            (
+                "event_outcome_detail",
+                ("event_outcome_detail_note", outcome_detail_note),
+            ),
+        ),
+    ]
+    event = tuple(add_agents_to_event_as_list(event, agents))
+
+    return metsrw.plugins.premisrw.PREMISEvent(data=event)
+
+
+def create_premis_aip_creation_event(
+    package_uuid, master_aip_uuid=None, agents=None, inst=True
+):
+    """Return a PREMISEvent for creation of an AIP."""
+    if master_aip_uuid:
+        outcome_detail_note = (
+            "Created Archival Information Package (AIP) {} by replicating"
+            " previously created AIP {}".format(package_uuid, master_aip_uuid)
+        )
+    else:
+        outcome_detail_note = "Created Archival Information Package (AIP) {}".format(
+            package_uuid
+        )
+    if not agents:
+        agents = [SS_AGENT]
+    event = [
+        "event",
+        PREMIS_META,
+        (
+            "event_identifier",
+            ("event_identifier_type", "UUID"),
+            ("event_identifier_value", str(uuid.uuid4())),
+        ),
+        # Question: use the more specific 'information package creation'
+        # PREMIS event?
+        ("event_type", "creation"),
+        ("event_date_time", timestamp()),
+        (
+            "event_detail_information",
+            ("event_detail", "Creation of an Archival Information Package"),
+        ),
+        (
+            "event_outcome_information",
+            ("event_outcome", "success"),
+            (
+                "event_outcome_detail",
+                ("event_outcome_detail_note", outcome_detail_note),
+            ),
+        ),
+    ]
+    event = tuple(add_agents_to_event_as_list(event, agents))
+
+    return metsrw.plugins.premisrw.PREMISEvent(data=event)
+
+
+def create_premis_aip_compression_event(
+    event_detail, event_outcome_detail_note, agents=None
+):
+    """Return a PREMISEvent describing the compression of an AIP."""
+    if not agents:
+        agents = [SS_AGENT]
+    event = [
+        "event",
+        PREMIS_META,
+        (
+            "event_identifier",
+            ("event_identifier_type", "UUID"),
+            ("event_identifier_value", str(uuid.uuid4())),
+        ),
+        ("event_type", "compression"),
+        ("event_date_time", timestamp()),
+        ("event_detail_information", ("event_detail", event_detail)),
+        (
+            "event_outcome_information",
+            ("event_outcome", "success"),
+            (
+                "event_outcome_detail",
+                ("event_outcome_detail_note", event_outcome_detail_note),
+            ),
+        ),
+    ]
+    event = tuple(add_agents_to_event_as_list(event, agents))
+
+    return metsrw.plugins.premisrw.PREMISEvent(data=event)
+
+
+def create_replication_validation_event(
+    replica_package_uuid,
+    checksum_report,
+    master_aip_uuid,
+    fixity_report=None,
+    agents=None,
+):
+    """Return a PREMISEvent for validation of AIP replication.
+    """
+    success = checksum_report["success"]
+    if fixity_report:
+        success = fixity_report["success"] and success
+    outcome = success and "success" or "failure"
+    detail = (
+        "Validated the replication of Archival Information Package (AIP)"
+        " {master_aip_uuid} to replica AIP {replica_aip_uuid}".format(
+            master_aip_uuid=master_aip_uuid, replica_aip_uuid=replica_package_uuid
+        )
+    )
+    if fixity_report:
+        detail += " by performing a BagIt fixity check and by comparing" " checksums"
+        outcome_detail_note = "{}\n{}".format(
+            fixity_report["message"], checksum_report["message"]
+        )
+    else:
+        detail += " by comparing checksums"
+        outcome_detail_note = checksum_report["message"]
+    if not agents:
+        agents = [SS_AGENT]
+    event = [
+        "event",
+        PREMIS_META,
+        (
+            "event_identifier",
+            ("event_identifier_type", "UUID"),
+            ("event_identifier_value", str(uuid.uuid4())),
+        ),
+        ("event_type", "validation"),
+        ("event_date_time", timestamp()),
+        ("event_detail_information", ("event_detail", detail)),
+        (
+            "event_outcome_information",
+            ("event_outcome", outcome),
+            (
+                "event_outcome_detail",
+                ("event_outcome_detail_note", outcome_detail_note),
+            ),
+        ),
+    ]
+    event = tuple(add_agents_to_event_as_list(event, agents))
+
+    return metsrw.plugins.premisrw.PREMISEvent(data=event)
+
+
+def create_replication_derivation_relationship(
+    related_aip_uuid, replication_event_uuid, premis_version=None
+):
+    """Return a PREMIS relationship of type derivation relating an implicit
+    PREMIS object (an AIP) to some to related AIP (with UUID
+    ``related_aip_uuid``) via a replication event with UUID
+    ``replication_event_uuid``. Note the complication wherein PREMIS v. 2.2
+    uses 'Identification' where PREMIS v. 3.0 uses 'Identifier'.
+    """
+    if not premis_version:
+        premis_version = PREMIS_META["version"]
+    related_object_identifier = {"2.2": "related_object_identification"}.get(
+        premis_version, "related_object_identifier"
+    )
+    related_event_identifier = {"2.2": "related_event_identification"}.get(
+        premis_version, "related_event_identifier"
+    )
+    return (
+        "relationship",
+        ("relationship_type", "derivation"),
+        ("relationship_sub_type", ""),
+        (
+            related_object_identifier,
+            ("related_object_identifier_type", "UUID"),
+            ("related_object_identifier_value", related_aip_uuid),
+        ),
+        (
+            related_event_identifier,
+            ("related_event_identifier_type", "UUID"),
+            ("related_event_identifier_value", replication_event_uuid),
+        ),
+    )
+
+
+def create_aip_premis_object(
+    package_uuid,
+    package_size,
+    package_extension,
+    message_digest_algorithm,
+    message_digest,
+    archive_tool,
+    compression_program_version,
+    composition_level=1,
+    premis_relationships=None,
+):
+    """Return a <premis:object> element for this package's (AIP's) pointer
+    file.
+    :param str package_uuid: unique identifier for the PREMIS object
+    :param str package_size: size of object in bytes
+    :param str package_extension: object file extension, e.g. .7z
+    :param str message_digest_algorithm: name of the algorithm used to generate
+        ``message_digest``.
+    :param str message_digest: hex string checksum for the
+        packaged/compressed AIP.
+    :param str archive_tool: name of the tool (program) used to compress
+        the AIP, e.g., '7-Zip'.
+    :param str compression_program_version: version of ``archive_tool``
+        used.
+    :keyword int composition_level: PREMIS composition level (e.g. 2)
+    :returns: <premis:object> as a tuple.
+    """
+    # PRONOM ID and PRONOM name for each file extension
+    pronom_conversion = {
+        ".7z": {"puid": "fmt/484", "name": "7Zip format"},
+        ".bz2": {"puid": "x-fmt/268", "name": "BZIP2 Compressed Archive"},
+    }
+    premis_relationships = premis_relationships or []
+    kwargs = dict(
+        xsi_type="premis:file",
+        identifier_value=package_uuid,
+        message_digest_algorithm=message_digest_algorithm,
+        message_digest=message_digest,
+        size=str(package_size),
+        creating_application_name=archive_tool,
+        creating_application_version=compression_program_version,
+        date_created_by_application=timestamp(),
+        relationship=premis_relationships,
+        premis_version=PREMIS_META["version"],
+        composition_level=str(composition_level),
+    )
+    try:
+        kwargs.update(
+            {
+                "format_name": pronom_conversion[package_extension]["name"],
+                "format_registry_name": "PRONOM",
+                "format_registry_key": pronom_conversion[package_extension]["puid"],
+            }
+        )
+    except KeyError:
+        pass
+
+    return metsrw.plugins.premisrw.PREMISObject(**kwargs)
+
+
+def create_encryption_event(encr_result, key_fingerprint, gpg_version):
+    """Return a PREMIS:EVENT for the encryption event."""
+    detail = "program=GPG; version={}; key={}".format(gpg_version, key_fingerprint)
+    outcome_detail_note = 'Status="{}"; Standard Error="{}"'.format(
+        encr_result.status.replace('"', r"\""),
+        encr_result.stderr.replace('"', r"\"").strip(),
+    )
+    agents = [SS_AGENT]
+    event = [
+        "event",
+        PREMIS_META,
+        (
+            "event_identifier",
+            ("event_identifier_type", "UUID"),
+            ("event_identifier_value", str(uuid.uuid4())),
+        ),
+        ("event_type", "encryption"),
+        ("event_date_time", timestamp()),
+        ("event_detail_information", ("event_detail", detail)),
+        (
+            "event_outcome_information",
+            ("event_outcome", "success"),
+            (
+                "event_outcome_detail",
+                ("event_outcome_detail_note", outcome_detail_note),
+            ),
+        ),
+    ]
+    event = tuple(add_agents_to_event_as_list(event, agents))
+
+    return metsrw.plugins.premisrw.PREMISEvent(data=event)

--- a/storage_service/common/tests/test_premis.py
+++ b/storage_service/common/tests/test_premis.py
@@ -1,0 +1,35 @@
+from collections import namedtuple
+
+from common import premis
+from storage_service import __version__ as ss_version
+
+
+FakeGPGRet = namedtuple("FakeGPGRet", "ok status stderr")
+GPG_VERSION = "1.4.16"
+SUCCESS_STATUS = "good times"
+SOME_FINGERPRINT = "B9C518917A958DD0B1F5E1B80C3D34DDA5958532"
+
+
+def test_create_encryption_event():
+    stderr = 'me contain " quote'
+    encr_result = FakeGPGRet(ok=True, status=SUCCESS_STATUS, stderr=stderr)
+    event = premis.create_encryption_event(
+        encr_result, SOME_FINGERPRINT, GPG_VERSION
+    ).data
+    assert event[0] == "event"
+    event = event[2:]
+    assert [x for x in event if x[0] == "event_type"][0][1] == "encryption"
+    assert [x for x in event if x[0] == "event_detail_information"][0][1][1] == (
+        "program=GPG; version={}; key={}".format(GPG_VERSION, SOME_FINGERPRINT)
+    )
+    eoi = [x for x in event if x[0] == "event_outcome_information"][0]
+    assert [x for x in eoi if x[0] == "event_outcome"][0][1] == "success"
+    assert [x for x in eoi if x[0] == "event_outcome_detail"][0][1][1] == (
+        'Status="{}"; Standard Error="{}"'.format(
+            SUCCESS_STATUS, stderr.replace('"', r"\"")
+        )
+    )
+    lai = [x for x in event if x[0] == "linking_agent_identifier"][0]
+    assert [x for x in lai if x[0] == "linking_agent_identifier_value"][0][1] == (
+        "Archivematica-Storage-Service-{}".format(ss_version)
+    )

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -10,8 +10,6 @@ import os
 import shutil
 import uuid
 
-from metsrw.plugins import premisrw
-
 from django.core.exceptions import ObjectDoesNotExist
 from django import http
 from django.utils.translation import ugettext as _
@@ -349,63 +347,6 @@ def coerce_str(string):
     if isinstance(string, six.text_type):
         return string.encode("utf-8")
     return string
-
-
-def add_agents_to_event_as_list(event, agents):
-    """Add agents in ``agents`` to the list ``event`` which represents a
-    PREMIS:EVENT.
-    :param list event: a PREMIS:EVENT represented as a list
-    :param iterable agents: an iterable of premisrw.PREMISAgent instances.
-    """
-    for agent in agents:
-        event.append(
-            (
-                "linking_agent_identifier",
-                ("linking_agent_identifier_type", agent.identifier_type),
-                ("linking_agent_identifier_value", agent.identifier_value),
-            )
-        )
-    return event
-
-
-def mets_file_now():
-    return datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
-
-
-def get_ss_premis_agents(inst=True):
-    """Return PREMIS agents for preservation events performed by the
-    Storage Service.
-    Note: Archivematica returns a 'repository code'-type agent while we
-    are currently just returning a 'preservation system' one. What is
-    the desired behaviour here? AM's agents used for compression from
-    db::
-
-        +----+-----------------------+----------------------+------------------------------------------------------+--------------------+
-        | pk | agentIdentifierType   | agentIdentifierValue | agentName                                            | agentType          |
-        +----+-----------------------+----------------------+------------------------------------------------------+--------------------+
-        |  1 | preservation system   | Archivematica-1.7    | Archivematica                                        | software           |
-        |  2 | repository code       | test                 | test                                                 | organization       |
-        +----+-----------------------+----------------------+------------------------------------------------------+--------------------+
-    """
-    agents = [
-        (
-            "agent",
-            premisrw.PREMIS_META,
-            (
-                "agent_identifier",
-                ("agent_identifier_type", "preservation system"),
-                (
-                    "agent_identifier_value",
-                    "Archivematica-Storage-Service-{}".format(ss_version),
-                ),
-            ),
-            ("agent_name", "Archivematica Storage Service"),
-            ("agent_type", "software"),
-        )
-    ]
-    if inst:
-        return [premisrw.PREMISAgent(data=data) for data in agents]
-    return agents
 
 
 StorageEffects = namedtuple(


### PR DESCRIPTION
Relates to: https://github.com/archivematica/Issues/issues/713

Update metsrw to the latest release for PREMIS 3 compatibility, and update PREMIS generation to use the correct format.

The bulk of this PR is consolidating PREMIS tuple construction in `common.premis` — please note when reviewing that most of the changed code has been moved (mostly as is, with a few changes for version 3 and to accommodate different imports and references to packages) to try to make updates like this a bit easier in future. The consolidation isn't "done" by any means; there's still a lot of PREMIS and METS related logic in the Package model.
