### PR TITLE
Use server-side processing for packages table

### DIFF
--- a/storage_service/locations/datatable_utils.py
+++ b/storage_service/locations/datatable_utils.py
@@ -1,0 +1,160 @@
+"""DataTable utils
+
+Implements the server-side processing options needed by the jQuery
+DataTables v1.9 library used in the packages tables of the storage
+service (in the Packages and the Location detail views).
+
+The request and response details are documented in:
+http://legacy.datatables.net/usage/server-side
+"""
+
+import os
+
+from django.db.models import Q
+from django.utils import timezone
+
+from .models import Package
+
+
+class DataTable(object):
+    """This class parses the parameters sent by the JS client code and
+    builds a filtered and sorted list of `Package` objects.
+    """
+
+    # number of rows to display on a single page when using pagination
+    DEFAULT_DISPLAY_LENGTH = 10
+
+    def __init__(self, query_dict):
+        self.total_records = Package.objects.count()
+        self.params = self.parse_datatable_parameters(query_dict)
+        self.echo = self.params["echo"]
+        search_filter = Q()
+        if self.params["search"]:
+            search = self.params["search"]
+            # remove any leading slashes so we can search in relative paths
+            search_as_path = search.lstrip(os.path.sep)
+            search_filter |= (
+                Q(uuid__icontains=search)
+                | Q(description__icontains=search)
+                | Q(origin_pipeline__uuid__icontains=search)
+                | Q(origin_pipeline__description__icontains=search)
+                | Q(current_location__relative_path__icontains=search_as_path)
+                | Q(current_location__space__path__icontains=search_as_path)
+                | Q(current_path__icontains=search_as_path)
+                | Q(package_type__icontains=search)
+                | Q(status__icontains=search)
+            )
+        queryset = Package.objects.filter(search_filter)
+        self.total_display_records = queryset.count()
+        self.packages = self.get_packages(queryset)
+
+    def _get_int_parameter(self, query_dict, param, default=0):
+        """Get an integer parameter from the request QueryDict.
+
+        Return `default` on failure
+        """
+        try:
+            return int(query_dict.get(param))
+        except (ValueError, TypeError):
+            return default
+
+    def sorting_column(self, query_dict):
+        """Return a dictionary with the column index and sorting direction of
+        the column used for sorting the table.
+
+        The DataTable library can sort by multiple columns but this
+        implementation is very simple and limited to a single column sort.
+        """
+        result = {}
+        sorting_columns_count = self._get_int_parameter(query_dict, "iSortingCols")
+        if sorting_columns_count == 1:
+            sorting_column_index = self._get_int_parameter(
+                query_dict, "iSortCol_0", None
+            )
+            if sorting_column_index is not None:
+                is_sortable = (
+                    query_dict.get("bSortable_{}".format(sorting_column_index))
+                    == "true"
+                )
+                if is_sortable:
+                    sort_direction = query_dict.get("sSortDir_0", "asc")
+                    result = {
+                        "index": sorting_column_index,
+                        "direction": sort_direction,
+                    }
+        return result
+
+    def parse_datatable_parameters(self, query_dict):
+        return {
+            # query for text based search
+            "search": query_dict.get("sSearch", ""),
+            # options for limiting result display
+            "display_start": self._get_int_parameter(query_dict, "iDisplayStart"),
+            "display_length": self._get_int_parameter(
+                query_dict, "iDisplayLength", default=self.DEFAULT_DISPLAY_LENGTH
+            ),
+            # sorting information
+            "sorting_column": self.sorting_column(query_dict),
+            # parameter sent by the client that the server needs
+            # to return back in order to identify each single rendering
+            "echo": self._get_int_parameter(query_dict, "sEcho", default=-1),
+        }
+
+    def sort(self, queryset):
+        sorting_column = self.params["sorting_column"]
+        if not sorting_column or sorting_column.get("index") is None:
+            return queryset
+        # the columns represented by these indexes can be sorted
+        # through the queryset using the order_by method
+        ORDER_BY_MAPPING = {
+            0: "uuid",
+            1: "origin_pipeline__description",
+            3: "size",
+            5: "replicated_package__uuid",
+        }
+        # these columns instead can't be sorted directly with the
+        # queryset so the queryset needs to be converted into a list
+        # and then sorted using helper methods
+        SORT_KEY_HELPERS_MAPPING = {
+            2: self.sort_by_full_path_key,
+            4: self.sort_by_package_type_key,
+            6: self.sort_by_status_key,
+            7: self.sort_by_fixity_date_key,
+            8: self.sort_by_fixity_status_key,
+        }
+        sort_descending = sorting_column.get("direction") == "desc"
+        if sorting_column["index"] in ORDER_BY_MAPPING:
+            field = ORDER_BY_MAPPING[sorting_column["index"]]
+            if sort_descending:
+                field = "-{}".format(field)
+            return queryset.order_by(field)
+        elif sorting_column["index"] in SORT_KEY_HELPERS_MAPPING:
+            key = SORT_KEY_HELPERS_MAPPING[sorting_column["index"]]
+            return sorted(list(queryset), key=key, reverse=sort_descending)
+        else:
+            return queryset
+
+    def get_packages(self, queryset):
+        result = self.sort(queryset)
+        display_start = self.params["display_start"]
+        display_length = self.params["display_length"]
+        try:
+            return result[display_start : (display_start + display_length)]
+        except IndexError:
+            return []
+
+    def sort_by_full_path_key(self, package):
+        return package.full_path
+
+    def sort_by_package_type_key(self, package):
+        return package.get_package_type_display()
+
+    def sort_by_status_key(self, package):
+        return package.get_status_display()
+
+    def sort_by_fixity_date_key(self, package):
+        # avoid comparing datetimes with None
+        return package.latest_fixity_check_datetime or timezone.now()
+
+    def sort_by_fixity_status_key(self, package):
+        return package.latest_fixity_check_result

--- a/storage_service/locations/tests/test_datatable.py
+++ b/storage_service/locations/tests/test_datatable.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""Tests for the datatable utilities."""
+
+from django.test import TestCase
+
+from locations import datatable_utils
+
+
+class TestDataTable(TestCase):
+
+    fixtures = ["base.json", "package.json"]
+
+    def test_initialization(self):
+        datatable = datatable_utils.DataTable({})
+        expected_params = {
+            "search": "",
+            "display_start": 0,
+            "display_length": 10,
+            "sorting_column": {},
+            "echo": -1,
+        }
+        assert datatable.params == expected_params
+        assert datatable.total_records == 7
+        assert datatable.total_display_records == 7
+        assert len(datatable.packages) == 7
+
+    def test_search_description(self):
+        datatable = datatable_utils.DataTable(
+            {
+                "sSearch": "Small bagged package",
+                "iDisplayStart": 0,
+                "iDisplayLength": 20,
+                "sEcho": "1",
+            }
+        )
+        expected_params = {
+            "search": "Small bagged package",
+            "display_start": 0,
+            "display_length": 20,
+            "sorting_column": {},
+            "echo": 1,
+        }
+        assert datatable.params == expected_params
+        assert datatable.total_records == 7
+        assert datatable.total_display_records == 1
+        assert len(datatable.packages) == 1
+
+    def test_search_current_path(self):
+        datatable = datatable_utils.DataTable(
+            {
+                "sSearch": "working_bag",
+                "iDisplayStart": 0,
+                "iDisplayLength": 10,
+                "sEcho": "1",
+            }
+        )
+        expected_params = {
+            "search": "working_bag",
+            "display_start": 0,
+            "display_length": 10,
+            "sorting_column": {},
+            "echo": 1,
+        }
+        assert datatable.params == expected_params
+        assert datatable.total_records == 7
+        assert datatable.total_display_records == 3
+        assert len(datatable.packages) == 3
+
+    def test_search_type(self):
+        datatable = datatable_utils.DataTable(
+            {
+                "sSearch": "Transfer",
+                "iDisplayStart": 0,
+                "iDisplayLength": 10,
+                "sEcho": "1",
+            }
+        )
+        expected_params = {
+            "search": "Transfer",
+            "display_start": 0,
+            "display_length": 10,
+            "sorting_column": {},
+            "echo": 1,
+        }
+        assert datatable.params == expected_params
+        assert datatable.total_records == 7
+        assert datatable.total_display_records == 3
+        assert len(datatable.packages) == 3
+
+    def test_search_status(self):
+        datatable = datatable_utils.DataTable(
+            {
+                "sSearch": "Uploaded",
+                "iDisplayStart": 0,
+                "iDisplayLength": 10,
+                "sEcho": "1",
+            }
+        )
+        expected_params = {
+            "search": "Uploaded",
+            "display_start": 0,
+            "display_length": 10,
+            "sorting_column": {},
+            "echo": 1,
+        }
+        assert datatable.params == expected_params
+        assert datatable.total_records == 7
+        assert datatable.total_display_records == 7
+        assert len(datatable.packages) == 7
+
+    def test_sorting_uuid(self):
+        datatable = datatable_utils.DataTable(
+            {
+                "iSortingCols": 1,
+                "iSortCol_0": 0,
+                "bSortable_0": "true",
+                "iDisplayStart": 0,
+                "iDisplayLength": 10,
+                "sEcho": "1",
+            }
+        )
+        expected_params = {
+            "search": "",
+            "display_start": 0,
+            "display_length": 10,
+            "sorting_column": {"index": 0, "direction": "asc"},
+            "echo": 1,
+        }
+        assert datatable.params == expected_params
+        expected_uuids = [
+            "0d4e739b-bf60-4b87-bc20-67a379b28cea",
+            "6aebdb24-1b6b-41ab-b4a3-df9a73726a34",
+            "79245866-ca80-4f84-b904-a02b3e0ab621",
+            "88deec53-c7dc-4828-865c-7356386e9399",
+            "9f260047-a9b7-4a75-bb6a-e8d94c83edd2",
+            "a59033c2-7fa7-41e2-9209-136f07174692",
+            "e0a41934-c1d7-45ba-9a95-a7531c063ed1",
+        ]
+        assert [package.uuid for package in datatable.packages] == expected_uuids

--- a/storage_service/locations/urls.py
+++ b/storage_service/locations/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     ),
     # Packages
     url(r"^packages/$", views.package_list, name="package_list"),
+    url(r"^packages_ajax/$", views.package_list_ajax, name="package_list_ajax"),
     url(
         r"^packages/package_delete_request/$",
         views.package_delete_request,

--- a/storage_service/static/js/project.js
+++ b/storage_service/static/js/project.js
@@ -1,5 +1,6 @@
 $(document).ready(function() {
-  $('.datatable').dataTable({
+  var uri = $("#user-data-packages").data("uri") || "/";
+  var dataTableOptions = {
     // List of language strings from https://datatables.net/reference/option/language
     oLanguage: {
       sDecimal:        "",
@@ -25,7 +26,32 @@ $(document).ready(function() {
         sSortDescending: gettext(": activate to sort column descending"),
       },
     }
+  };
+  // separate options for packages table
+  var packagesDataTableOptions = {};
+  for (var k in dataTableOptions) {
+    packagesDataTableOptions[k] = dataTableOptions[k];
+  }
+  // enable server-side processing
+  packagesDataTableOptions["bServerSide"] = true;
+  packagesDataTableOptions["bProcessing"] = true;
+  packagesDataTableOptions["sAjaxSource"] = uri + "packages_ajax";
+  var columns = [];
+  // for each column create a function that replaces the
+  // table cell content with the HTML returned by the server
+  $('.packages-datatable thead th').each(function(i, header) {
+    columns.push({
+      "mData": function(source, type, val) {
+        var $tr = $(Object.values(source).join(""));
+        return $tr.find('td').eq(i).html();
+      },
+      "bSortable": $(header).hasClass("sortable")
+    });
   });
+  packagesDataTableOptions["aoColumns"] = columns;
+
+  $('.datatable').dataTable(dataTableOptions);
+  $('.packages-datatable').dataTable(packagesDataTableOptions);
 
   $("body").on("click", "a.request-delete", function(event) {
     var self = $(event.target);

--- a/storage_service/templates/base.html
+++ b/storage_service/templates/base.html
@@ -62,19 +62,21 @@
       </div>
     </div>
 
-    <div class="container">
-      {% block sidebar %}{% endblock sidebar %}
+    {% block body %}
+      <div class="container">
+        {% block sidebar %}{% endblock sidebar %}
 
-      <div class="row">
-        <h1>{% block page_title %}{% trans "Archivematica Storage Service" %}{% endblock page_title %}</h1>
+        <div class="row">
+          <h1>{% block page_title %}{% trans "Archivematica Storage Service" %}{% endblock page_title %}</h1>
 
-        {% for message in messages %}
-          <div class='alert alert-{{message.tags}}'>{{ message }}</div>
-        {% endfor %}
+          {% for message in messages %}
+            <div class='alert alert-{{message.tags}}'>{{ message }}</div>
+          {% endfor %}
 
-        {% block content %}{% endblock content %}
-      </div>
-    </div> <!-- /container -->
+          {% block content %}{% endblock content %}
+        </div>
+      </div> <!-- /container -->
+    {% endblock %}
 
     <!-- Le javascript
     ================================================== -->

--- a/storage_service/templates/fluid.html
+++ b/storage_service/templates/fluid.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block body %}
+  <div class="container-fluid">
+    {% block sidebar %}{% endblock sidebar %}
+
+    <div class="row-fluid">
+      <h1>{% block page_title %}{% trans "Archivematica Storage Service" %}{% endblock page_title %}</h1>
+
+      {% for message in messages %}
+        <div class='alert alert-{{message.tags}}'>{{ message }}</div>
+      {% endfor %}
+
+      {% block content %}{% endblock content %}
+    </div>
+  </div> <!-- /container -->
+{% endblock %}

--- a/storage_service/templates/locations/location_detail.html
+++ b/storage_service/templates/locations/location_detail.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "fluid.html" %}
 {% load i18n %}
 
 {% block page_title %}{% blocktrans %}{{ location }} Information{% endblocktrans %}{% endblock %}
@@ -72,7 +72,7 @@
 
 <h2>{% trans "Packages" %}</h2>
 
-{% if packages %}
+{% if package_count %}
   {% include "snippets/packages_table.html" %}
 {% else %}
   <p>{% trans "No packages in this space." %}</p>

--- a/storage_service/templates/locations/package_list.html
+++ b/storage_service/templates/locations/package_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "fluid.html" %}
 {% load i18n %}
 
 {% block page_title %}{% trans "All Packages" %}{% endblock %}
@@ -12,7 +12,7 @@
   | <a href="{% url 'package_delete_request' %}">{% trans "View delete requests" %}</a>
 </p>
 
-{% if packages %}
+{% if package_count %}
   {% include "snippets/packages_table.html" %}
 {% else %}
   <p>{% trans "No packages currently exist." %}</p>

--- a/storage_service/templates/snippets/package_row.html
+++ b/storage_service/templates/snippets/package_row.html
@@ -1,0 +1,85 @@
+{% load i18n %}
+      <tr>
+        <td>{{ package.uuid }}</td>
+        <td>
+          {% if package.origin_pipeline %}
+          <a href="{% url 'pipeline_detail' package.origin_pipeline.uuid %}">{{ package.origin_pipeline }}</a>
+          {% else %}
+          {% trans "None" %}
+          {% endif %}
+        </td>
+        <td>
+          {% if package.status != package.DELETED %}
+            <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">{{ package.full_path }}</a>
+          {% else %}
+            <span>{{ package.full_path }}</span>
+          {% endif %}
+        </td>
+        <td>{{ package.size|filesizeformat }}</td>
+        <td>{{ package.get_package_type_display }}</td>
+
+        <td>
+        {% if package.replicated_package %}
+          {{ package.replicated_package.uuid }}
+        {% endif %}
+        </td>
+
+        <td>
+          {{ package.get_status_display }}
+          {% if package.status != 'DELETED' and package.status != 'FAIL'%}
+          (<a href="{% url 'package_update_status' package.uuid %}?next={{ redirect_path }}">{% trans "Update Status" %}</a>)
+          {% endif %}
+        </td>
+        <td>
+          {{ package.latest_fixity_check_datetime|default_if_none:"" }}
+        </td>
+        <td>
+          <a href="{% url 'package_fixity' package.uuid %}">{{ package.latest_fixity_check_result|yesno:_("Success,Failed,") }}</a>
+        </td>
+        <td>
+          {% if package.pointer_file_location %}
+            <a href="{% url 'pointer_file_request' 'v2' 'file' package.uuid %}">{% trans "Pointer File" %}</a> |
+          {% endif %}
+          {% if package.status != package.DELETED %}
+            <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">{% trans "Download" %}</a> |
+          {% endif %}
+
+          <!-- Replicas should not be re-ingestible -->
+          {% if package.package_type in 'AIP AIC' and not package.replicated_package %}
+            <a href="{% url 'aip_reingest' package.uuid %}?next={{ redirect_path }}">{% trans "Re-ingest" %}</a> |
+          {% endif %}
+
+          {% if package.package_type in package.PACKAGE_TYPE_CAN_DELETE %}
+          <a href="#" class="request-delete"
+             data-package-type="{{ package.package_type }}"
+             data-package-uuid="{{ package.uuid }}"
+             data-package-pipeline="{{ package.origin_pipeline.uuid }}"
+             >{% trans "Request Deletion" %}</a>
+          {% endif %}
+
+          {% if package.package_type in package.PACKAGE_TYPE_CAN_DELETE_DIRECTLY and package.status != package.DELETED %}
+            <form method="POST" class="submit-confirm" action="{% url 'package_delete' package.uuid %}">
+              {% csrf_token %}
+              <button class="link" type="submit">{% trans "Delete" %}</button>
+              <div class="confirm-modal modal hide fade" tabindex="-1" role="dialog">
+                <div class="modal-header">
+                  <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                  <h3>{% trans "Delete package" %}</h3>
+                </div>
+                <div class="modal-body">
+                  <p>
+                    {% blocktrans with type=package.package_type uuid=package.uuid %}
+                      Are you sure you want to delete this package ({{ type }}) with UUID <strong>{{ uuid }}</strong>?
+                    {% endblocktrans %}
+                  </p>
+                </div>
+                <div class="modal-footer">
+                  <button class="btn" data-dismiss="modal" aria-hidden="true">{% trans "Close" %}</button>
+                  <button class="btn btn-danger" type="submit">{% trans "Delete" %}</button>
+                </div>
+              </div>
+            </form>
+          {% endif %}
+
+        </td>
+      </tr>

--- a/storage_service/templates/snippets/packages_table.html
+++ b/storage_service/templates/snippets/packages_table.html
@@ -1,121 +1,23 @@
 {% load i18n %}
-  <table class="datatable">
+  <table class="packages-datatable">
     <thead>
       <tr>
         <th>{% trans "UUID" %}</th>
-        <th>{% trans "Description" %}</th>
-        <th>{% trans "Originating Pipeline" %}</th>
-        <th>{% trans "Current Location" %}</th>
-        <th>{% trans "Size" %}</th>
-        <th>{% trans "Type" %}</th>
-        <th>{% trans "Replicas" %}</th>
-        <th>{% trans "Is Replica Of" %}</th>
-        <th>{% trans "Pointer File" %}</th>
-        <th>{% trans "Status" %}</th>
-        <th>{% trans "Fixity Date" %}</th>
-        <th>{% trans "Fixity Status" %}</th>
+        <th class="sortable">{% trans "Originating Pipeline" %}</th>
+        <th class="sortable">{% trans "Current Location" %}</th>
+        <th class="sortable">{% trans "Size" %}</th>
+        <th class="sortable">{% trans "Type" %}</th>
+        <th class="sortable">{% trans "Replica Of" %}</th>
+        <th class="sortable">{% trans "Status" %}</th>
+        <th class="sortable">{% trans "Fixity Date" %}</th>
+        <th class="sortable">{% trans "Fixity Status" %}</th>
         <th>{% trans "Actions" %}</th>
       </tr>
     </thead>
     <tbody>
-    {% for package in packages %}
       <tr>
-        <td>{{ package.uuid }}</td>
-        <td>{{ package.description|default:_("None") }}</td>
-        <td>
-          {% if package.origin_pipeline %}
-          <a href="{% url 'pipeline_detail' package.origin_pipeline.uuid %}">{{ package.origin_pipeline }}</a>
-          {% else %}
-          {% trans "None" %}
-          {% endif %}
-        </td>
-        <td><a href="{% url 'location_detail' package.current_location.uuid %}">{{ package.full_path }}</a></td>
-        <td>{{ package.size|filesizeformat }}</td>
-        <td>{{ package.get_package_type_display }}</td>
-
-        <td>
-        {% with package.replicas.all as replicas %}
-          {% if replicas %}
-            <ul>
-            {% for replica in replicas %}
-              <li>{{ replica.uuid }}</li>
-            {% endfor %}
-            </ul>
-          {% endif %}
-        {% endwith %}
-        </td>
-
-        <td>
-        {% if package.replicated_package %}
-          {{ package.replicated_package.uuid }}
-        {% endif %}
-        </td>
-
-        <td>
-          {% if package.pointer_file_location %}
-          <a href="{% url 'pointer_file_request' 'v2' 'file' package.uuid %}">{% trans "Pointer File" %}</a>
-          {% else %}
-          {% trans "None" %}
-          {% endif %}
-        </td>
-        <td>
-          {{ package.get_status_display }}
-          {% if package.status != 'DELETED' and package.status != 'FAIL'%}
-          (<a href="{% url 'package_update_status' package.uuid %}?next={{ request.path }}">{% trans "Update Status" %}</a>)
-          {% endif %}
-        </td>
-        <td>
-          {{ package.latest_fixity_check_datetime|default_if_none:"" }}
-        </td>
-        <td>
-          <a href="{% url 'package_fixity' package.uuid %}">{{ package.latest_fixity_check_result|yesno:_("Success,Failed,") }}</a>
-        </td>
-        <td>
-
-          {% if package.status != package.DELETED %}
-            <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">{% trans "Download" %}</a>
-          {% endif %}
-
-          <!-- Replicas should not be re-ingestible -->
-          {% if package.package_type in 'AIP AIC' and not package.replicated_package %}
-            <a href="{% url 'aip_reingest' package.uuid %}?next={{ request.path }}">{% trans "Re-ingest" %}</a>
-          {% endif %}
-
-          {% if package.package_type in package.PACKAGE_TYPE_CAN_DELETE %}
-          <a href="#" class="request-delete"
-             data-package-type="{{ package.package_type }}"
-             data-package-uuid="{{ package.uuid }}"
-             data-package-pipeline="{{ package.origin_pipeline.uuid }}"
-             >{% trans "Request Deletion" %}</a>
-          {% endif %}
-
-          {% if package.package_type in package.PACKAGE_TYPE_CAN_DELETE_DIRECTLY and package.status != package.DELETED %}
-            <form method="POST" class="submit-confirm" action="{% url 'package_delete' package.uuid %}">
-              {% csrf_token %}
-              <button class="link" type="submit">{% trans "Delete" %}</button>
-              <div class="confirm-modal modal hide fade" tabindex="-1" role="dialog">
-                <div class="modal-header">
-                  <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-                  <h3>{% trans "Delete package" %}</h3>
-                </div>
-                <div class="modal-body">
-                  <p>
-                    {% blocktrans with type=package.package_type uuid=package.uuid %}
-                      Are you sure you want to delete this package ({{ type }}) with UUID <strong>{{ uuid }}</strong>?
-                    {% endblocktrans %}
-                  </p>
-                </div>
-                <div class="modal-footer">
-                  <button class="btn" data-dismiss="modal" aria-hidden="true">{% trans "Close" %}</button>
-                  <button class="btn btn-danger" type="submit">{% trans "Delete" %}</button>
-                </div>
-              </div>
-            </form>
-          {% endif %}
-
-        </td>
+        <td colspan="10" class="dataTables_empty">{% trans "Loading data from server" %}</td>
       </tr>
-    {% endfor %}
     </tbody>
   </table>
   <div id="user-data-packages" style="display: none;"


### PR DESCRIPTION
This PR changes the implementation of the two tables that display packages in the Storage Service. It adds a new view (`/packages_ajax`) that uses the [server-side processing options](http://legacy.datatables.net/usage/server-side) of the DataTable library to retrieve small batches of packages through AJAX requests instead of the full list of packages.

It also addresses the following changes proposed by Sara and the rest of the team in https://github.com/archivematica/Issues/issues/676#issuecomment-497077314 and below:

* Deleted the Description column which was set always to None. I think this is caused by not having the `description` field included in `storage_service.locations.api.PackageResource.Meta.fields`
* Changed the link in the Current location column to allow downloading the package (similar to the Download action)
* Moved the Pointer File link under the Actions column
* Removed the Replicas column and retitled the "Is Replica Of" column
* Most of the columns are now sortable and searchable and sorting by size uses the actual package size now
* Made the Packages tab and Location views fluid (expand the whole viewport width)

Connected to https://github.com/archivematica/Issues/issues/676
Connected to https://github.com/archivematica/Issues/issues/678