### PR TITLE
Docker: ensure that GnuPG 1.x is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
 	&& apt-get update -qq \
 	&& apt-get install -qq -y --no-install-recommends \
 		gettext \
-		gnupg \
+		gnupg1 \
 		p7zip-full \
 		rsync \
 		unar \


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/745.