### PR TITLE
Prefix FILEID for pointer file METS creation

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,7 +14,7 @@ gunicorn==19.9.0
 jsonfield==2.0.1
 logutils==0.3.4.1
 lxml==3.7.3
-metsrw==0.3.8
+metsrw==0.3.10
 ndg-httpsclient==0.4.2
 python-gnupg==0.4.0
 python-keystoneclient==3.10.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,7 +40,7 @@ keystoneauth1==3.14.0     # via python-keystoneclient
 logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
-metsrw==0.3.8
+metsrw==0.3.10
 monotonic==1.5            # via oslo.utils
 msgpack==0.6.1            # via oslo.serialization
 mysqlclient==1.4.2.post1  # via agentarchives

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -45,7 +45,7 @@ logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
 markupsafe==1.1.1         # via jinja2
-metsrw==0.3.8
+metsrw==0.3.10
 monotonic==1.5
 msgpack==0.6.1
 mysqlclient==1.4.2.post1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -41,7 +41,7 @@ keystoneauth1==3.14.0
 logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
-metsrw==0.3.8
+metsrw==0.3.10
 monotonic==1.5
 msgpack==0.6.1
 mysqlclient==1.4.2.post1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,6 @@
 #    pip-compile --output-file=test.txt test.in
 #
 agentarchives==0.4.0
-appnope==0.1.0            # via ipython
 asn1crypto==0.24.0
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
@@ -52,7 +51,7 @@ keystoneauth1==3.14.0
 logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
-metsrw==0.3.8
+metsrw==0.3.10
 mock==3.0.5               # via pytest-mock, vcrpy
 monotonic==1.5
 more-itertools==5.0.0     # via pytest
@@ -113,3 +112,6 @@ virtualenv==16.6.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 whitenoise==3.3.0
 wrapt==1.11.1
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via ipdb, ipython, pytest, tox

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -1281,6 +1281,18 @@ class Package(models.Model):
             package_subtype=package_subtype,
         )
 
+    @staticmethod
+    def construct_file_id_for_pointer(aip_path):
+        """Construct a name for the package that will be used as the fileSec ID
+        and filePtr FILEID in the pointer file created for it. By prefixing the
+        AIP name with 'file-' and letting Archivematica's filename cleanup
+        routines handle the other characters difficult to work with in a
+        file-system, we stand the best change of creating an ID and FILEID that
+        will validate against XML's xs:NCNAME limitations set by the METS
+        standard
+        """
+        return "file-{}".format(os.path.splitext(os.path.basename(aip_path))[0])
+
     def create_pointer_file(
         self,
         premis_object,
@@ -1355,6 +1367,7 @@ class Package(models.Model):
         package_subtype = package_subtype or AIP_PACKAGE_TYPE
         mets_fs_entry = metsrw.FSEntry(
             path=self.full_path,
+            fileid=self.construct_file_id_for_pointer(self.full_path),
             file_uuid=str(self.uuid),
             use=AIP_PACKAGE_TYPE,
             type=AIP_PACKAGE_TYPE,


### PR DESCRIPTION
This commit ensures that IDs and FILEIDs are prefixed when
generated for pointer files belonging to an AIP. The prefix along
with name clean-up procedures in the transfer/ingest workflow ensures
that the ID/FILEID remains consistent with an NC string type as
defined by the XML standard.

Connected to archivematica/issues#660

The output will be a `fileSec` and `structMap` in a pointer file that looks as follows:
```xml
  <mets:fileSec>
    <mets:fileGrp USE="Archival Information Package">
      <mets:file ID="file-my-transfer-5bc5ac2a-951f-4bc5-9039-08ec619eef1f" GROUPID="Group-file-5bc5ac2a-951f-4bc5-9039-08ec619eef1f" ADMID="amdSec_2">
        <mets:FLocat xlink:href="/var/archivematica/sharedDirectory/www/AIPsStore/5bc5/ac2a/951f/4bc5/9039/08ec/619e/ef1f/my-transfer-5bc5ac2a-951f-4bc5-9039-08ec619eef1f.7z" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
        <mets:transformFile TRANSFORMTYPE="decompression" TRANSFORMORDER="1" TRANSFORMALGORITHM="bzip2"/>
      </mets:file>
    </mets:fileGrp>
  </mets:fileSec>
  <mets:structMap ID="structMap_1" LABEL="Archivematica default" TYPE="physical">
    <mets:div TYPE="Archival Information Package" LABEL="my-transfer-5bc5ac2a-951f-4bc5-9039-08ec619eef1f.7z">
      <mets:fptr FILEID="file-my-transfer-5bc5ac2a-951f-4bc5-9039-08ec619eef1f"/>
    </mets:div>
  </mets:structMap>
  <mets:structMap ID="structMap_2" LABEL="Normative Directory Structure" TYPE="logical">
    <mets:div TYPE="Archival Information Package" LABEL="my-transfer-5bc5ac2a-951f-4bc5-9039-08ec619eef1f.7z"/>
  </mets:structMap>
```
Note the `ID` and `FILEID` in the respective instances are both prefixed with `file-` per the original issue. 

And this structure will persist following reingest as well which is why this PR: requires https://github.com/artefactual-labs/mets-reader-writer/pull/72 

**NB.** This PR is complicated by the need to use a different `metsrw`. Once the code has been reviewed and approved, I will push the new `metsrw` and then update this PR to change the requirements so they reference `metsrw-0.3.10`.