### PR TITLE
Improve the package deletion mechanism around S3

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -5,6 +5,7 @@
 import json
 import logging
 import os
+import pprint
 import re
 import shutil
 import urllib
@@ -1659,11 +1660,15 @@ class PackageResource(ModelResource):
     def _attempt_package_request_event(
         self, package, request_info, event_type, event_status
     ):
-
-        import pprint
-
-        LOGGER.info("PACKAGE DELETE REQUEST:")
-        LOGGER.info(pprint.pformat(request_info))
+        """Generic package request handler, e.g. package recovery: RECOVER_REQ,
+        or package deletion: DEL_REQ.
+        """
+        LOGGER.info(
+            "Package event: '{}' requested, with package status: '{}'".format(
+                event_type, event_status
+            )
+        )
+        LOGGER.debug(pprint.pformat(request_info))
 
         pipeline = Pipeline.objects.get(uuid=request_info["pipeline"])
         request_description = event_type.replace("_", " ").lower()
@@ -1684,11 +1689,6 @@ class PackageResource(ModelResource):
                 store_data=package.status,
             )
             request_event.save()
-
-            # Update package status
-            package.status = event_status
-            package.save()
-
             response = {
                 "message": _("%(event_type)s request created successfully.")
                 % {"event_type": request_description.title()},

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 # stdlib, alphabetical
@@ -1935,10 +1936,10 @@ class Package(models.Model):
                 error = lom._delete_update_lom(self, delete_lom_ids)
         try:
             self.current_location.space.delete_path(self.full_path)
-        except Exception as e:
-            error = e.message
-
-        # Remove pointer file, and the UUID quad directories if they're empty
+        except (StorageException, NotImplementedError, ValueError) as err:
+            return False, err
+        # If deleted correctly, remove pointer file, and the UUID quad
+        # directories if they're empty.
         pointer_path = self.full_pointer_file_path
         if pointer_path:
             try:
@@ -1954,8 +1955,6 @@ class Package(models.Model):
                 os.path.dirname(self.pointer_file_path),
                 base=self.pointer_file_location.full_path,
             )
-
-        self.status = self.DELETED
         self.save()
         return True, error
 


### PR DESCRIPTION
**NB.** This is a direct copy of https://github.com/artefactual/archivematica-storage-service/pull/463 which was accidentally closed before merging. Spotted by @jraddaoui. 

A couple of small issues were effecting our ability to effectively
delete S3 packages. Those are resolved here.

The commit history for these changes are as follows:

* Test generator provided by Boto3

  Tests the generator provided by Boto3. We expect there to be
  something to iterate over if a deletion has been requested. If
  there is nothing to iterate over a StorageException is returned and
  the reason returned to the package.py.

* Manage exceptions from deletion requests

  Except Exception has the potential to suck up a number of other
  errors raised by Python so look specifically at what might be
  returned from various storage adapters.

  Additionally, return immediately if there has been a problem with a
  deletion request instead of letting the code continue to delete the
  pointer file for a package and set its status as deleted when there
  is likely a higer probability that the package hasn't been deleted.

* Remove leading slashes from s3 deletion requests

  When an S3 deletion request is made and the space is configured
  incorrectly, i.e. using a leading slash for a Path, then it will not
  interfere with the deletion. The slash is removed so that the
  package can be found using Boto3 and then deleted.

* Add logging

  Raising a storage service exception isn't guaranteed to appear as a
  log output for the administrator. Ensure that happens here.

We correct some of the logging elsewhere in the code along the way as
well.