### PR TITLE
Expose LDAP TLS options via env variables

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -188,6 +188,138 @@ This is the current list of strings supported:
     - **Type:** `string`
     - **Default:** `archivematica-storage-service`
 
+### LDAP-specific environment variables
+
+    These variables specify the behaviour of LDAP authentication. If `SS_LDAP_AUTHENTICATION` is false,
+    none of the other ones are used.
+
+- **`SS_LDAP_AUTHENTICATION`**:
+    - **Description:** Enables user authentication via LDAP.
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`AUTH_LDAP_SERVER_URI`**:
+    - **Description:** Address of the LDAP server to authenticate against.
+    - **Type:** `string`
+    - **Default:** `ldap://localhost`
+
+- **`AUTH_LDAP_BIND_DN`**:
+    - **Description:** LDAP "bind DN"; the object to authenticate against the LDAP server with, in order
+    to lookup users, e.g. "cn=admin,dc=example,dc=com".  Empty string for anonymous.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_BIND_PASSWORD`**:
+    - **Description:** Password for the LDAP bind DN.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_USER_SEARCH_BASE_DN`**:
+    - **Description:** Base LDAP DN for user search, e.g. "ou=users,dc=example,dc=com".
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_USER_SEARCH_BASE_FILTERSTR`**:
+    - **Description:** Filter for identifying LDAP user objects, e.g. "(uid=%(user)s)". The `%(user)s`
+    portion of the string will be replaced by the username. This variable is only used if
+    `AUTH_LDAP_USER_SEARCH_BASE_DN` is not empty.
+    - **Type:** `string`
+    - **Default:** `(uid=%(user)s)`
+
+- **`AUTH_LDAP_USER_DN_TEMPLATE`**:
+    - **Description:** Template for LDAP user search, e.g. "uid=%(user)s,ou=users,dc=example,dc=com".
+    Not applicable if `AUTH_LDAP_USER_SEARCH_BASE_DN` is set.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_GROUP_IS_ACTIVE`**:
+    - **Description:** Template for LDAP group used to set the Django user `is_active` flag, e.g.
+    "cn=active,ou=django,ou=groups,dc=example,dc=com".
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_GROUP_IS_STAFF`**:
+    - **Description:** Template for LDAP group used to set the Django user `is_staff` flag, e.g.
+    "cn=staff,ou=django,ou=groups,dc=example,dc=com".
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_GROUP_IS_SUPERUSER`**:
+    - **Description:** Template for LDAP group used to set the Django user `is_superuser` flag, e.g.
+    "cn=admins,ou=django,ou=groups,dc=example,dc=com".
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_GROUP_SEARCH_BASE_DN`**:
+    - **Description:** Base LDAP DN for group search, e.g. "ou=django,ou=groups,dc=example,dc=com".
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_GROUP_SEARCH_BASE_FILTERSTR`**:
+    - **Description:** Filter for identifying LDAP group objects, e.g. "(objectClass=groupOfNames)".
+    This variable is only used if `AUTH_LDAP_GROUP_SEARCH_BASE_DN` is not empty.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_REQUIRE_GROUP`**:
+    - **Description:** Filter for a group that LDAP users must belong to in order to authenticate, e.g.
+    "cn=enabled,ou=django,ou=groups,dc=example,dc=com"
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_DENY_GROUP`**:
+    - **Description:** Filter for a group that LDAP users must _not_ belong to in order to authenticate,
+    e.g. "cn=disabled,ou=django,ou=groups,dc=example,dc=com"
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_FIND_GROUP_PERMS`**:
+    - **Description:** If we should use LDAP group membership to calculate group permissions.
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`AUTH_LDAP_CACHE_GROUPS`**:
+    - **Description:** If we should cache groups to minimize LDAP traffic.
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`AUTH_LDAP_GROUP_CACHE_TIMEOUT`**:
+    - **Description:** How long we should cache LDAP groups for (in seconds). Only applies if
+    `AUTH_LDAP_CACHE_GROUPS` is true.
+    - **Type:** `integer`
+    - **Default:** `3600`
+
+- **`AUTH_LDAP_START_TLS`**:
+    - **Description:** Determines if we update to a secure LDAP connection using StartTLS after connecting.
+    - **Type:** `boolean`
+    - **Default:** `true`
+
+- **`AUTH_LDAP_PROTOCOL_VERSION`**:
+    - **Description:** If set, forces LDAP protocol version 3.
+    - **Type:** `integer`
+    - **Default:** ``
+
+- **`AUTH_LDAP_TLS_CACERTFILE`**:
+    - **Description:** Path to a custom LDAP certificate authority file.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_TLS_CERTFILE`**:
+    - **Description:** Path to a custom LDAP certificate file.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_TLS_KEYFILE`**:
+    - **Description:** Path to a custom LDAP key file (matching the cert given in `AUTH_LDAP_TLS_CERTFILE`).
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_TLS_REQUIRE_CERT`**:
+    - **Description:** How strict to be regarding TLS cerfiticate verification. Allowed values are "never",
+    "allow", "try", "demand", or "hard". Corresponds to the TLSVerifyClient OpenLDAP setting.
+    - **Type:** `string`
+    - **Default:** ``
+
 ## Logging configuration
 
 Storage Service 0.10.0 and earlier releases are configured by default to log to

--- a/install/README.md
+++ b/install/README.md
@@ -6,6 +6,7 @@
 - [Environment variables](#environment-variables)
   - [Application-specific environment variables](#application-specific-environment-variables)
   - [Gunicorn-specific environment variables](#gunicorn-specific-environment-variables)
+  - [LDAP-specific environment variables](#ldap-specific-environment-variables)
 - [Logging configuration](#logging-configuration)
 
 ## Introduction

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -384,10 +384,46 @@ if LDAP_AUTHENTICATION:
     except ValueError:
         AUTH_LDAP_GROUP_CACHE_TIMEOUT = None
 
-    # Non-configurable sane defaults
-    AUTH_LDAP_START_TLS = True
-    AUTH_LDAP_ALWAYS_UPDATE_USER = True
+    AUTH_LDAP_START_TLS = is_true(environ.get("AUTH_LDAP_START_TLS", "TRUE"))
+
     AUTH_LDAP_GLOBAL_OPTIONS = {}
+    if environ.get("AUTH_LDAP_PROTOCOL_VERSION", None) == "3":
+        AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_PROTOCOL_VERSION] = ldap.VERSION3
+    if environ.get("AUTH_LDAP_TLS_CACERTFILE", None):
+        AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_CACERTFILE] = environ.get(
+            "AUTH_LDAP_TLS_CACERTFILE"
+        )
+    if environ.get("AUTH_LDAP_TLS_CERTFILE", None):
+        AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_CERTFILE] = environ.get(
+            "AUTH_LDAP_TLS_CERTFILE"
+        )
+    if environ.get("AUTH_LDAP_TLS_KEYFILE", None):
+        AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_KEYFILE] = environ.get(
+            "AUTH_LDAP_TLS_KEYFILE"
+        )
+    if environ.get("AUTH_LDAP_TLS_REQUIRE_CERT", None):
+        require_cert = environ.get("AUTH_LDAP_TLS_REQUIRE_CERT").lower()
+        if require_cert == "never":
+            AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_NEVER
+        elif require_cert == "allow":
+            AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_ALLOW
+        elif require_cert == "try":
+            AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_TRY
+        elif require_cert == "demand":
+            AUTH_LDAP_GLOBAL_OPTIONS[
+                ldap.OPT_X_TLS_REQUIRE_CERT
+            ] = ldap.OPT_X_TLS_DEMAND
+        elif require_cert == "hard":
+            AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_HARD
+        else:
+            raise ImproperlyConfigured(
+                (
+                    "Unexpected value for AUTH_LDAP_TLS_REQUIRE_CERT: {}. "
+                    "Supported values: 'never', 'allow', try', 'hard', or 'demand'."
+                ).format(require_cert)
+            )
+    # Non-configurable sane defaults
+    AUTH_LDAP_ALWAYS_UPDATE_USER = True
 
 ######### END LDAP CONFIGURATION #########
 

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -380,9 +380,11 @@ if LDAP_AUTHENTICATION:
     )
     AUTH_LDAP_CACHE_GROUPS = is_true(environ.get("AUTH_LDAP_CACHE_GROUPS", "FALSE"))
     try:
-        AUTH_LDAP_GROUP_CACHE_TIMEOUT = int(environ.get("AUTH_LDAP_DENY_GROUP", ""))
+        AUTH_LDAP_GROUP_CACHE_TIMEOUT = int(
+            environ.get("AUTH_LDAP_GROUP_CACHE_TIMEOUT", "3600")
+        )
     except ValueError:
-        AUTH_LDAP_GROUP_CACHE_TIMEOUT = None
+        AUTH_LDAP_GROUP_CACHE_TIMEOUT = 3600
 
     AUTH_LDAP_START_TLS = is_true(environ.get("AUTH_LDAP_START_TLS", "TRUE"))
 


### PR DESCRIPTION
It seems that most users will need to set some TLS options (certfiles, etc), so exposing those via env vars is helpful.

Connected to: archivematica/Issues#680