### PR TITLE
Include replicas in package search

### DIFF
--- a/storage_service/locations/datatable_utils.py
+++ b/storage_service/locations/datatable_utils.py
@@ -43,8 +43,10 @@ class DataTable(object):
                 | Q(current_path__icontains=search_as_path)
                 | Q(package_type__icontains=search)
                 | Q(status__icontains=search)
+                | Q(replicas__uuid__icontains=search)
+                | Q(replicated_package__uuid__icontains=search)
             )
-        queryset = Package.objects.filter(search_filter)
+        queryset = Package.objects.filter(search_filter).distinct()
         self.total_display_records = queryset.count()
         self.packages = self.get_packages(queryset)
 


### PR DESCRIPTION
This PR allows to search for a package UUID and get its replicas returned in the packages table. Searching for a replica UUID will also return the replicated package.

Connected to https://github.com/archivematica/Issues/issues/801