### PR TITLE
mail: make default_from_email and tls configurable

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -129,6 +129,16 @@ This is the current list of strings supported:
     - **Type:** `int`
     - **Default:** `587`
 
+- **`DEFAULT_FROM_EMAIL`**
+    - **Description:** https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
+    - **Type:** `string`
+    - **Default:** `webmaster@localhost`
+
+- **`EMAIL_USE_TLS`**
+    - **Description:** https://docs.djangoproject.com/en/dev/ref/settings/#email-use-tls
+    - **Type:** `boolean`
+    - **Default:** `true`
+
 ### Gunicorn-specific environment variables
 
 - **`SS_GUNICORN_USER`**:

--- a/storage_service/storage_service/settings/production.py
+++ b/storage_service/storage_service/settings/production.py
@@ -54,8 +54,11 @@ EMAIL_PORT = environ.get("EMAIL_PORT", 587)
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#email-subject-prefix
 EMAIL_SUBJECT_PREFIX = "[Archivematica Storage Service] "
 
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
+DEFAULT_FROM_EMAIL = environ.get("DEFAULT_FROM_EMAIL", "webmaster@localhost")
+
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#email-use-tls
-EMAIL_USE_TLS = True
+EMAIL_USE_TLS = is_true(environ.get("EMAIL_USE_TLS", "True"))
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#server-email
 SERVER_EMAIL = EMAIL_HOST_USER


### PR DESCRIPTION
This PR makes DEFAULT_FROM_EMAIL and EMAIL_USE_TLS variables
configurable.

See https://docs.djangoproject.com/en/dev/ref/settings/

Connects to https://github.com/archivematica/Issues/issues/921