### PR TITLE
import_aip: add config parameters

### DIFF
--- a/storage_service/common/management/commands/import_aip.py
+++ b/storage_service/common/management/commands/import_aip.py
@@ -123,6 +123,15 @@ class Command(BaseCommand):
             default=DEFAULT_UNIX_OWNER,
         )
 
+        parser.add_argument(
+            "--tmp-dir",
+            help="Temporary directory for processing, passed as dir parameter"
+            " to tempfile.mkdtemp(), e.g,'/var/archivematica/sharedDirectory/tmp'."
+            " Default: None ",
+            default=None,
+            required=False,
+        )
+
     def handle(self, *args, **options):
         print(header("Attempting to import the AIP at {}.".format(options["aip_path"])))
         try:
@@ -133,6 +142,7 @@ class Command(BaseCommand):
                 options["compression_algorithm"],
                 options["pipeline"],
                 options["unix_owner"],
+                options["tmp_dir"],
             )
         except ImportAIPException as err:
             print(fail(err))
@@ -396,9 +406,10 @@ def import_aip(
     compression_algorithm,
     adoptive_pipeline_uuid,
     unix_owner,
+    tmp_dir,
 ):
     confirm_aip_exists(aip_path)
-    temp_dir = tempfile.mkdtemp()
+    temp_dir = tempfile.mkdtemp(dir=tmp_dir)
     aip_path = decompress(aip_path, decompress_source, temp_dir)
     validate(aip_path)
     aip_mets_path = get_aip_mets_path(aip_path)

--- a/storage_service/common/management/commands/import_aip.py
+++ b/storage_service/common/management/commands/import_aip.py
@@ -122,7 +122,13 @@ class Command(BaseCommand):
             " imported AIP. Default: {}".format(DEFAULT_UNIX_OWNER),
             default=DEFAULT_UNIX_OWNER,
         )
-
+        parser.add_argument(
+            "--force",
+            help="Do not check if AIP uuid already exists in the Storage"
+            " Service. If so, will overwrite the existing AIP without prompt.",
+            action="store_true",
+            default=False,
+        )
         parser.add_argument(
             "--tmp-dir",
             help="Temporary directory for processing, passed as dir parameter"
@@ -142,6 +148,7 @@ class Command(BaseCommand):
                 options["compression_algorithm"],
                 options["pipeline"],
                 options["unix_owner"],
+                options["force"],
                 options["tmp_dir"],
             )
         except ImportAIPException as err:
@@ -406,6 +413,7 @@ def import_aip(
     compression_algorithm,
     adoptive_pipeline_uuid,
     unix_owner,
+    force,
     tmp_dir,
 ):
     confirm_aip_exists(aip_path)
@@ -414,7 +422,8 @@ def import_aip(
     validate(aip_path)
     aip_mets_path = get_aip_mets_path(aip_path)
     aip_uuid = get_aip_uuid(aip_mets_path)
-    check_if_aip_already_exists(aip_uuid)
+    if not force:
+        check_if_aip_already_exists(aip_uuid)
     local_as_location, final_as_location = get_aip_storage_locations(
         aip_storage_location_uuid
     )


### PR DESCRIPTION
- Add an argument to be able to specify a directory where the AIP is to be decompressed
- Add an argument to be able to skip checking of AIP existence in the SS database

Connected to https://github.com/archivematica/Issues/issues/940