### PR TITLE
Improve directory listing performance with scandir

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -27,6 +27,7 @@ agentarchives==0.4.0
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
 prometheus_client==0.7.1
 django-prometheus==1.0.15
+scandir==1.10.0
 
 # Support for longer (>30 characters) usernames
 # Using a fork of the main package because this one provides Django (rather than South) migrations

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -74,6 +74,7 @@ requests-oauthlib==1.2.0
 requests==2.21.0
 rfc3986==1.3.2            # via oslo.config
 s3transfer==0.2.1         # via boto3
+scandir==1.10.0
 six==1.12.0               # via cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, stevedore
 stevedore==1.30.1         # via keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -82,6 +82,7 @@ requests-oauthlib==1.2.0
 requests==2.21.0
 rfc3986==1.3.2
 s3transfer==0.2.1
+scandir==1.10.0
 six==1.12.0
 sphinx==1.2b1
 stevedore==1.30.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -76,6 +76,7 @@ requests-oauthlib==1.2.0
 requests==2.21.0
 rfc3986==1.3.2
 s3transfer==0.2.1
+scandir==1.10.0
 six==1.12.0
 stevedore==1.30.1
 sword2==0.2.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -100,7 +100,7 @@ requests-oauthlib==1.2.0
 requests==2.21.0
 rfc3986==1.3.2
 s3transfer==0.2.1
-scandir==1.10.0           # via pathlib2
+scandir==1.10.0
 simplegeneric==0.8.1      # via ipython
 six==1.12.0
 stevedore==1.30.1

--- a/storage_service/common/management/commands/import_aip.py
+++ b/storage_service/common/management/commands/import_aip.py
@@ -58,6 +58,7 @@ import tarfile
 import tempfile
 
 import bagit
+import scandir
 from django.core.management.base import BaseCommand
 from django.db.utils import IntegrityError
 from django.utils.six.moves import input
@@ -166,7 +167,7 @@ def is_compressed(aip_path):
 
 
 def tree(path):
-    for root, _, files in os.walk(path):
+    for root, _, files in scandir.walk(path):
         level = root.replace(path, "").count(os.sep)
         indent = " " * 4 * (level)
         print(header("{}{}/".format(indent, os.path.basename(root))))
@@ -275,7 +276,7 @@ def fix_ownership(aip_path, unix_owner):
     passwd_struct = getpwnam(unix_owner)
     am_uid = passwd_struct.pw_uid
     am_gid = passwd_struct.pw_gid
-    for root, dirs, files in os.walk(aip_path):
+    for root, dirs, files in scandir.walk(aip_path):
         os.chown(root, am_uid, am_gid)
         for dir_ in dirs:
             os.chown(os.path.join(root, dir_), am_uid, am_gid)

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import uuid
 
+import scandir
 from django.core.exceptions import ObjectDoesNotExist
 from django import http
 from django.utils.translation import ugettext as _
@@ -605,7 +606,7 @@ def recalculate_size(rein_aip_internal_path):
     """
     if os.path.isdir(rein_aip_internal_path):
         size = 0
-        for dirpath, ___, filenames in os.walk(rein_aip_internal_path):
+        for dirpath, ___, filenames in scandir.walk(rein_aip_internal_path):
             for filename in filenames:
                 file_path = os.path.join(dirpath, filename)
                 size += os.path.getsize(file_path)

--- a/storage_service/locations/models/arkivum.py
+++ b/storage_service/locations/models/arkivum.py
@@ -17,6 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 
 # Third party dependencies, alphabetical
 import dateutil.parser
+import scandir
 
 # This project, alphabetical
 from common import utils
@@ -385,7 +386,7 @@ class Arkivum(models.Model):
                     )
                     # Pick a random file and check the locality of it.
                     # WARNING assumes the package is local/not local as a unit.
-                    for dirpath, dirs, files in os.walk(package.full_path):
+                    for dirpath, dirs, files in scandir.walk(package.full_path):
                         if files:
                             file_path = os.path.join(dirpath, files[0])
                             break

--- a/storage_service/locations/models/dspace_rest.py
+++ b/storage_service/locations/models/dspace_rest.py
@@ -20,6 +20,7 @@ from django.utils.translation import ugettext_lazy as _
 # Third party dependencies, alphabetical
 from lxml import etree
 import requests
+import scandir
 from requests import RequestException
 
 # This project, alphabetical
@@ -390,7 +391,7 @@ class DSpaceREST(models.Model):
         base_url = "{}/items/{}".format(
             self._get_base_url(self.ds_rest_url), ds_item["uuid"]
         )
-        for root, __, files in os.walk(source_path):
+        for root, __, files in scandir.walk(source_path):
             for name in files:
                 bitstream_url = "{}/bitstreams?name={}".format(
                     base_url, urllib.quote(name.encode("utf-8"))

--- a/storage_service/locations/models/duracloud.py
+++ b/storage_service/locations/models/duracloud.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 
 # Third party dependencies, alphabetical
 import requests
+import scandir
 
 # This project, alphabetical
 from common import utils
@@ -475,7 +476,7 @@ class Duracloud(models.Model):
             # Both source and destination paths should end with /
             destination_path = os.path.join(destination_path, "")
             # Duracloud does not accept folders, so upload each file individually
-            for path, dirs, files in os.walk(source_path):
+            for path, dirs, files in scandir.walk(source_path):
                 for basename in files:
                     entry = os.path.join(path, basename)
                     dest = entry.replace(source_path, destination_path, 1)

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -28,6 +28,7 @@ from django_extensions.db.fields import UUIDField
 import metsrw
 from metsrw.plugins import premisrw
 import requests
+import scandir
 
 # This project, alphabetical
 from common import premis, utils
@@ -2783,7 +2784,7 @@ def _replace_old_pres_ders_with_reingested(
     preservation_regex = r"(.+)-\w{8}-\w{4}-\w{4}-\w{4}-\w{12}(.*)"
     removed_pres_der_paths = []  # a return value
     # Walk through all files in the internally stored reingested AIP
-    for rein_aip_dirpath, ___, rein_aip_filenames in os.walk(rein_aip_objects_dir):
+    for rein_aip_dirpath, ___, rein_aip_filenames in scandir.walk(rein_aip_objects_dir):
         for rein_aip_filename in rein_aip_filenames:
             match = re.match(preservation_regex, rein_aip_filename)
             # This file is a preservation derivative, so copy it

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -13,6 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 # Third party dependencies, alphabetical
 import boto3
 import re
+import scandir
 
 # This project, alphabetical
 
@@ -209,7 +210,7 @@ class S3(models.Model):
             # strip leading slash on dest_path
             dest_path = dest_path.lstrip("/")
 
-            for path, dirs, files in os.walk(src_path):
+            for path, dirs, files in scandir.walk(src_path):
                 for basename in files:
                     entry = os.path.join(path, basename)
                     dest = entry.replace(src_path, dest_path, 1)

--- a/storage_service/locations/models/swift.py
+++ b/storage_service/locations/models/swift.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 # Third party dependencies, alphabetical
+import scandir
 import swiftclient
 
 # This project, alphabetical
@@ -214,7 +215,7 @@ class Swift(models.Model):
             # Both source and destination paths should end with /
             destination_path = os.path.join(destination_path, "")
             # Swift does not accept folders, so upload each file individually
-            for path, dirs, files in os.walk(source_path):
+            for path, dirs, files in scandir.walk(source_path):
                 for basename in files:
                     entry = os.path.join(path, basename)
                     dest = entry.replace(source_path, destination_path, 1)

--- a/storage_service/locations/tests/test_dspace_rest.py
+++ b/storage_service/locations/tests/test_dspace_rest.py
@@ -361,6 +361,7 @@ def test_move_from_storage_service(
     mocker.patch("os.remove")
     mocker.patch("__builtin__.open")
     mocker.patch("os.listdir", return_value=[AIP_METS_FILENAME])
+    mocker.patch("scandir.walk", return_value=[("", [], [AIP_METS_FILENAME])])
 
     # Patch ``requests.post``
     def mock_requests_post(*args, **kwargs):
@@ -468,8 +469,6 @@ def test_move_from_storage_service(
     if package.package_type == Package.DIP:
         # No METS extraction happens with DIP, therefore no removal needed
         os.remove.assert_not_called()
-        # Note: os.walk underlyingly calls os.listdir, so for the DIP case,
-        # os.listdir may be called several times
         os.listdir.assert_called_with(package_source_path)
         assert actual_bitstream_args == (DS_REST_DIP_DEPO_URL,)
         if as_credentials_set:


### PR DESCRIPTION
Relates to: https://github.com/archivematica/Issues/issues/908

Includes a new version of the file browsing function `path2browse` which is around 48% faster (under Docker for Mac, which is slow, probably less of an improvent than that on real world systems).

Moves usage of `os.walk` to `scandir.walk` which is very low impact, and an easy win.

Moving from `os.listdir` to `scandir.scandir` is a bit harder, and since much of the relevant code can't easily be tested (it relates to SWORD, DSpace, etc), I think it's not worth undertaking for now.