### PR TITLE
Fix for selecting region us-east-1 with S3

### DIFF
--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -101,10 +101,8 @@ class S3(models.Model):
                 raise StorageException(err)
             LOGGER.info("Creating S3 bucket '%s'", self._bucket_name())
             # LocationConstraint cannot be specified if it us-east-1 because it is the default, see: https://github.com/boto/boto3/issues/125
-            if self.region == 'us-east-1':
-                self.client.create_bucket(
-                    Bucket=self._bucket_name()
-                )
+            if self.region == "us-east-1":
+                self.client.create_bucket(Bucket=self._bucket_name())
             else:
                 self.client.create_bucket(
                     Bucket=self._bucket_name(),

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -100,10 +100,16 @@ class S3(models.Model):
             if error_code != "NoSuchBucket":
                 raise StorageException(err)
             LOGGER.info("Creating S3 bucket '%s'", self._bucket_name())
-            self.client.create_bucket(
-                Bucket=self._bucket_name(),
-                CreateBucketConfiguration={"LocationConstraint": self.region},
-            )
+            # LocationConstraint cannot be specified if it us-east-1 because it is the default, see: https://github.com/boto/boto3/issues/125
+            if self.region == 'us-east-1':
+                self.client.create_bucket(
+                    Bucket=self._bucket_name()
+                )
+            else:
+                self.client.create_bucket(
+                    Bucket=self._bucket_name(),
+                    CreateBucketConfiguration={"LocationConstraint": self.region},
+                )
 
     def _bucket_name(self):
         return self.space_id

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -100,10 +100,14 @@ class S3(models.Model):
             if error_code != "NoSuchBucket":
                 raise StorageException(err)
             LOGGER.info("Creating S3 bucket '%s'", self._bucket_name())
-            self.client.create_bucket(
-                Bucket=self._bucket_name(),
-                CreateBucketConfiguration={"LocationConstraint": self.region},
-            )
+            # LocationConstraint cannot be specified if it us-east-1 because it is the default, see: https://github.com/boto/boto3/issues/125
+            if self.region == "us-east-1":
+                self.client.create_bucket(Bucket=self._bucket_name())
+            else:
+                self.client.create_bucket(
+                    Bucket=self._bucket_name(),
+                    CreateBucketConfiguration={"LocationConstraint": self.region},
+                )
 
     def _bucket_name(self):
         return self.space_id


### PR DESCRIPTION
Addresses [archivematica/Issues#922](https://github.com/archivematica/Issues/issues/922)

Before creating a bucket checks to see if the region is us-east-1. If true, then creates bucket without LocationConstraint. Otherwise, creates bucket with a LocationConstraint supplied region. 