### PR TITLE
 Increase default workers to 3 

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -147,12 +147,14 @@ This is the current list of strings supported:
     - **Default:** `127.0.0.1:8001`
 
 - **`SS_GUNICORN_WORKERS`**:
-    - **Description:** number of gunicorn worker processes to run. See [WORKERS](http://docs.gunicorn.org/en/stable/settings.html#workers). If `SS_GUNICORN_WORKER_CLASS` is set to `gevent`, then `SS_BAG_VALIDATION_NO_PROCESSES` **must** be set to `1`. Otherwise reingest will fail at bagit validate. See [#708](https://github.com/artefactual/archivematica/issues/708).
-    - **Type:** `integer`
-    - **Default:** `1`
+    - **Description:** Number of gunicorn worker processes to run.  Note that if Archivematica
+    is running on the same system, a lower number of workers than Gunicorn recommends should be
+    used. See [WORKERS](http://docs.gunicorn.org/en/stable/settings.html#workers) and [How Many Workers?](https://docs.gunicorn.org/en/stable/design.html#how-many-workers) for more details. 
+   - **Type:** `integer`
+    - **Default:** `3`
 
 - **`SS_GUNICORN_WORKER_CLASS`**:
-    - **Description:** the type of worker processes to run. See [WORKER-CLASS](http://docs.gunicorn.org/en/stable/settings.html#worker-class).
+    - **Description:** the type of worker processes to run. See [WORKER-CLASS](http://docs.gunicorn.org/en/stable/settings.html#worker-class). If `SS_GUNICORN_WORKER_CLASS` is set to `gevent`, then `SS_BAG_VALIDATION_NO_PROCESSES` **must** be set to `1`. Otherwise reingest will fail at bagit validate. See [#708](https://github.com/artefactual/archivematica/issues/708).
     - **Type:** `string`
     - **Default:** `gevent`
 

--- a/install/storage-service.gunicorn-config.py
+++ b/install/storage-service.gunicorn-config.py
@@ -16,7 +16,7 @@ group = os.environ.get("SS_GUNICORN_GROUP", "archivematica")
 bind = os.environ.get("SS_GUNICORN_BIND", "127.0.0.1:8001")
 
 # http://docs.gunicorn.org/en/stable/settings.html#workers
-workers = os.environ.get("SS_GUNICORN_WORKERS", "1")
+workers = os.environ.get("SS_GUNICORN_WORKERS", "3")
 
 # http://docs.gunicorn.org/en/stable/settings.html#worker-class
 # WARNING: if ``worker_class`` is set to ``'gevent'``, then

--- a/storage_service/storage_service/settings/local.py
+++ b/storage_service/storage_service/settings/local.py
@@ -24,6 +24,10 @@ else:
             "SS_DB_HOST"
         ),  # Set to empty string forr localhost. Not used with sqlite3.
         "PORT": "",  # Set to empty string for default. Not used with sqlite3.
+        "OPTIONS": {
+            # https://docs.djangoproject.com/en/1.8/ref/databases/#database-is-locked-errors
+            "timeout": 30
+        },
     }
 # ######## END DATABASE CONFIGURATION
 

--- a/storage_service/storage_service/settings/production.py
+++ b/storage_service/storage_service/settings/production.py
@@ -24,6 +24,10 @@ else:
             "SS_DB_HOST"
         ),  # Set to empty string forr localhost. Not used with sqlite3.
         "PORT": "",  # Set to empty string for default. Not used with sqlite3.
+        "OPTIONS": {
+            # https://docs.djangoproject.com/en/1.8/ref/databases/#database-is-locked-errors
+            "timeout": 30
+        },
     }
 # ######## END DATABASE CONFIGURATION
 


### PR DESCRIPTION
Connects to: https://github.com/archivematica/Issues/issues/944

It's hard to determine an ideal number of workers given the number of other processes on the system. It seems clear though that 2-4 is a good minimum, so start at 3.

Also increases the default SQLite timeout to try to mitigate concurrent write errors.

I'm not sure if this should be merged as it may cause more trouble than it's worth due to the use of SQLite.