### PR TITLE
Allow replication in S3 spaces

### DIFF
--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -46,7 +46,7 @@ class S3(models.Model):
         verbose_name = _("S3")
         app_label = "locations"
 
-    ALLOWED_LOCATION_PURPOSE = [Location.AIP_STORAGE]
+    ALLOWED_LOCATION_PURPOSE = [Location.AIP_STORAGE, Location.REPLICATOR]
 
     def __init__(self, *args, **kwargs):
         super(S3, self).__init__(*args, **kwargs)


### PR DESCRIPTION
This PR allows replicators to be set in S3 spaces.

Connected to https://github.com/archivematica/Issues/issues/721