### PR TITLE
package: change size to BigInteger

### DIFF
--- a/storage_service/locations/migrations/0025_update_package_size.py
+++ b/storage_service/locations/migrations/0025_update_package_size.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("locations", "0024_allow_blank_aws_auth")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="package",
+            name="size",
+            field=models.BigIntegerField(
+                default=0, help_text="Size in bytes of the package"
+            ),
+        )
+    ]

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -74,7 +74,9 @@ class Package(models.Model):
         Location, to_field="uuid", related_name="+", null=True, blank=True
     )
     pointer_file_path = models.TextField(null=True, blank=True)
-    size = models.IntegerField(default=0, help_text=_("Size in bytes of the package"))
+    size = models.BigIntegerField(
+        default=0, help_text=_("Size in bytes of the package")
+    )
     encryption_key_fingerprint = models.CharField(
         max_length=512,
         blank=True,


### PR DESCRIPTION
When using the Storage Service with a MySQL database instead of an SQLite database the Django `IntegerField` limits the maximum filesize to ~2.15GB. Changing the `IntegerField` to `BigInterField` changes the column type of the `size` column from a 32-bit integer, to a 64-bit integer thus removing any expected file size limits. 

The size of one of my test packages (5.1 GB):

```
+-----+------------+--------------+----------+
| id  | size       | package_type | status   |
+-----+------------+--------------+----------+
| 491 | 5633512243 | AIP          | UPLOADED |
+-----+------------+--------------+----------+
```

This change did introduce one unintended side effect. The requests library deserializes the `BigIntegerField` as a `str`, while the `IntegerField` is deserialized as an `int`. This resulted in a failure in the "Index AIP" task. We address this failure in [this PR](https://github.com/artefactual/archivematica/pull/1507)

Adresses [#981](https://github.com/archivematica/Issues/issues/981).