### PR TITLE
S3 plugin: allow named bucket to be specified

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -10,3 +10,4 @@ tox
 vcrpy>=1.0.0
 ipdb
 pip-tools==3.7.0
+moto==1.3.8

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -57,6 +57,7 @@ metsrw==0.3.13
 mock==3.0.5               # via pytest-mock, vcrpy
 monotonic==1.5
 more-itertools==5.0.0     # via pytest, zipp
+moto==1.3.8
 msgpack==0.6.2
 mysqlclient==1.4.6
 ndg-httpsclient==0.4.2

--- a/storage_service/locations/constants.py
+++ b/storage_service/locations/constants.py
@@ -100,6 +100,12 @@ PROTOCOL = {
     models.Space.S3: {
         "model": models.S3,
         "form": forms.S3Form,
-        "fields": ["endpoint_url", "access_key_id", "secret_access_key", "region"],
+        "fields": [
+            "endpoint_url",
+            "access_key_id",
+            "secret_access_key",
+            "region",
+            "bucket",
+        ],
     },
 }

--- a/storage_service/locations/fixtures/s3.json
+++ b/storage_service/locations/fixtures/s3.json
@@ -1,0 +1,59 @@
+[
+{
+    "pk": 1,
+    "model": "locations.s3",
+    "fields": {
+        "space": "ae37f081-8baf-4d5d-9b1f-aebe367f1707",
+        "access_key_id": "",
+        "secret_access_key": "",
+        "endpoint_url": "https://s3.amazonaws.com",
+        "region": "us-east-1",
+        "bucket": "test-bucket"
+    }
+},
+{
+    "pk": 2,
+    "model": "locations.space",
+    "fields": {
+        "last_verified": null,
+        "used": 0,
+        "verified": false,
+        "uuid": "ae37f081-8baf-4d5d-9b1f-aebe367f1707",
+        "access_protocol": "S3",
+        "staging_path": "/var/archivematica/storage_service/",
+        "path": "/archivematica",
+        "size": null
+    }
+},
+{
+    "pk": 7,
+    "model": "locations.location",
+    "fields": {
+        "used": 0,
+        "description": "S3",
+        "space": "ae37f081-8baf-4d5d-9b1f-aebe367f1707",
+        "enabled": true,
+        "quota": null,
+        "relative_path": "aips",
+        "purpose": "AS",
+        "uuid": "a2f62831-717b-4890-9292-35b5f4c444c6"
+    }
+},
+{
+    "pk": 1,
+    "model": "locations.package",
+    "fields": {
+        "uuid": "4607c3d9-7b0c-4001-9150-44a373105b45",
+        "description": null,
+        "origin_pipeline": null,
+        "current_location": "a2f62831-717b-4890-9292-35b5f4c444c6",
+        "current_path": "locations/fixtures/small_compressed_bag.zip",
+        "pointer_file_location": "",
+        "pointer_file_path": "",
+        "size": 0,
+        "package_type": "AIP",
+        "status": "Uploaded",
+        "misc_attributes": {}
+    }
+}
+]

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -256,7 +256,13 @@ class SwiftForm(forms.ModelForm):
 class S3Form(forms.ModelForm):
     class Meta:
         model = models.S3
-        fields = ("endpoint_url", "access_key_id", "secret_access_key", "region")
+        fields = (
+            "endpoint_url",
+            "access_key_id",
+            "secret_access_key",
+            "region",
+            "bucket",
+        )
 
 
 class LocationForm(forms.ModelForm):

--- a/storage_service/locations/migrations/0023_s3_bucket_field.py
+++ b/storage_service/locations/migrations/0023_s3_bucket_field.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("locations", "0022_update_pipeline_help_text")]
+
+    operations = [
+        migrations.AddField(
+            model_name="s3",
+            name="bucket",
+            field=models.CharField(
+                help_text="S3 Bucket Name",
+                max_length=64,
+                verbose_name="S3 Bucket",
+                blank=True,
+            ),
+        )
+    ]

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 
 # Third party dependencies, alphabetical
 import boto3
+import botocore
 import re
 import scandir
 
@@ -26,21 +27,27 @@ LOGGER = logging.getLogger(__name__)
 
 class S3(models.Model):
     space = models.OneToOneField("Space", to_field="uuid")
-    endpoint_url = models.CharField(
-        max_length=2048,
-        verbose_name=_("S3 Endpoint URL"),
-        help_text=_("S3 Endpoint URL. Eg. https://s3.amazonaws.com"),
-    )
     access_key_id = models.CharField(
         max_length=64, verbose_name=_("Access Key ID to authenticate")
     )
     secret_access_key = models.CharField(
         max_length=256, verbose_name=_("Secret Access Key to authenticate with")
     )
+    endpoint_url = models.CharField(
+        max_length=2048,
+        verbose_name=_("S3 Endpoint URL"),
+        help_text=_("S3 Endpoint URL. Eg. https://s3.amazonaws.com"),
+    )
     region = models.CharField(
         max_length=64,
         verbose_name=_("Region"),
         help_text=_("Region in S3. Eg. us-east-2"),
+    )
+    bucket = models.CharField(
+        max_length=64,
+        verbose_name=_("S3 Bucket"),
+        blank=True,
+        help_text=_("S3 Bucket Name"),
     )
 
     class Meta:
@@ -92,25 +99,25 @@ class S3(models.Model):
             > Found and 403 Forbidden. "
             via-- Amazon AWS: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketHEAD.html
         """
-        LOGGER.debug("Test the S3 bucket '%s' exists", self._bucket_name())
+        LOGGER.debug("Test the S3 bucket '%s' exists", self.bucket_name)
         try:
-            loc_info = self.client.get_bucket_location(Bucket=self._bucket_name())
+            loc_info = self.client.get_bucket_location(Bucket=self.bucket_name)
             LOGGER.debug("S3 bucket's response: %s", loc_info)
         except self.client.exceptions.ClientError as err:
             error_code = err.response["Error"]["Code"]
             if error_code != "NoSuchBucket":
                 raise StorageException(err)
-            LOGGER.info("Creating S3 bucket '%s'", self._bucket_name())
+            LOGGER.info("Creating S3 bucket '%s'", self.bucket_name)
             self.client.create_bucket(
-                Bucket=self._bucket_name(),
+                Bucket=self.bucket_name,
                 CreateBucketConfiguration={"LocationConstraint": self.region},
             )
 
-    def _bucket_name(self):
-        return self.space_id
+    @property
+    def bucket_name(self):
+        return self.bucket or self.space_id
 
     def browse(self, path):
-        # strip leading slash on path
         path = path.lstrip("/")
 
         # We need a trailing slash on non-empty prefixes because a path like:
@@ -126,7 +133,7 @@ class S3(models.Model):
         if path != "":
             path = path.rstrip("/") + "/"
 
-        objects = self.resource.Bucket(self._bucket_name()).objects.filter(Prefix=path)
+        objects = self.resource.Bucket(self.bucket_name).objects.filter(Prefix=path)
 
         directories = set()
         entries = set()
@@ -143,7 +150,6 @@ class S3(models.Model):
             else:
                 entries.add(relative_key)
                 properties[relative_key] = {
-                    "verbose name": objectSummary.key,
                     "size": objectSummary.size,
                     "timestamp": objectSummary.last_modified,
                     "e_tag": objectSummary.e_tag,
@@ -167,9 +173,7 @@ class S3(models.Model):
                 )
             )
             delete_path = delete_path.lstrip(os.sep)
-        obj = self.resource.Bucket(self._bucket_name()).objects.filter(
-            Prefix=delete_path
-        )
+        obj = self.resource.Bucket(self.bucket_name).objects.filter(Prefix=delete_path)
         items = False
         for object_summary in obj:
             items = True
@@ -183,14 +187,12 @@ class S3(models.Model):
 
     def move_to_storage_service(self, src_path, dest_path, dest_space):
         self._ensure_bucket_exists()
-        bucket = self.resource.Bucket(self._bucket_name())
+        bucket = self.resource.Bucket(self.bucket_name)
 
         # strip leading slash on src_path
         src_path = src_path.lstrip("/")
 
-        objects = self.resource.Bucket(self._bucket_name()).objects.filter(
-            Prefix=src_path
-        )
+        objects = self.resource.Bucket(self.bucket_name).objects.filter(Prefix=src_path)
 
         for objectSummary in objects:
             dest_file = objectSummary.key.replace(src_path, dest_path, 1)
@@ -200,7 +202,7 @@ class S3(models.Model):
 
     def move_from_storage_service(self, src_path, dest_path, package=None):
         self._ensure_bucket_exists()
-        bucket = self.resource.Bucket(self._bucket_name())
+        bucket = self.resource.Bucket(self.bucket_name)
 
         if os.path.isdir(src_path):
             # ensure trailing slash on both paths

--- a/storage_service/locations/tests/test_api.py
+++ b/storage_service/locations/tests/test_api.py
@@ -44,6 +44,7 @@ class TestSpaceAPI(TestCase):
             "access_key_id": "Cah4cae1",
             "secret_access_key": "Thu6Ahqu",
             "region": "us-west-2",
+            "bucket": "test-bucket",
         }
         response = self.client.post(
             "/api/v2/space/", data=json.dumps(data), content_type="application/json"

--- a/storage_service/locations/tests/test_s3.py
+++ b/storage_service/locations/tests/test_s3.py
@@ -1,0 +1,23 @@
+import os
+
+import boto3
+from django.test import TestCase
+
+from locations import models
+
+
+class TestS3Storage(TestCase):
+
+    fixtures = ["base.json", "s3.json"]
+
+    def setUp(self):
+        self.s3_object = models.S3.objects.get(id=1)
+
+    def test_bucket_name(self):
+        assert self.s3_object.bucket_name == "test-bucket"
+
+    def test_bucket_name_falls_back_to_space_id(self):
+        self.s3_object.bucket = ""
+        self.s3_object.save()
+
+        assert self.s3_object.bucket_name == "ae37f081-8baf-4d5d-9b1f-aebe367f1707"

--- a/storage_service/locations/tests/test_s3.py
+++ b/storage_service/locations/tests/test_s3.py
@@ -1,11 +1,14 @@
-import os
-
+import botocore
 import boto3
+import mock
+import pytest
 from django.test import TestCase
+from moto import mock_s3
 
 from locations import models
 
 
+@mock_s3
 class TestS3Storage(TestCase):
 
     fixtures = ["base.json", "s3.json"]
@@ -21,3 +24,37 @@ class TestS3Storage(TestCase):
         self.s3_object.save()
 
         assert self.s3_object.bucket_name == "ae37f081-8baf-4d5d-9b1f-aebe367f1707"
+
+    def test_ensure_bucket_exists_continues_if_exists(self):
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket="test-bucket")
+
+        self.s3_object._ensure_bucket_exists()
+
+        client.head_bucket(Bucket="test-bucket")
+
+    def test_ensure_bucket_exists_creates_bucket(self):
+        client = boto3.client("s3", region_name="us-east-1")
+
+        self.s3_object._ensure_bucket_exists()
+
+        client.head_bucket(Bucket="test-bucket")
+
+    def test_ensure_bucket_exists_get_location_fails(self):
+        self.s3_object.client.get_bucket_location = mock.Mock(
+            side_effect=botocore.exceptions.BotoCoreError
+        )
+
+        with pytest.raises(models.StorageException):
+            self.s3_object._ensure_bucket_exists()
+
+    def test_ensure_bucket_exists_creation_fails(self):
+        self.s3_object.client.get_bucket_location = mock.Mock(
+            side_effect=botocore.exceptions.BotoCoreError
+        )
+        self.s3_object.client.create_bucket = mock.Mock(
+            side_effect=botocore.exceptions.BotoCoreError
+        )
+
+        with pytest.raises(models.StorageException):
+            self.s3_object._ensure_bucket_exists()

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ setenv =
     PYTHONPATH = ./storage_service
     DJANGO_SETTINGS_MODULE = storage_service.settings.test
     DJANGO_SECRET_KEY = 1234
+    BOTO_CONFIG=/dev/null
 
 [testenv:py36]
 basepython = python3


### PR DESCRIPTION
Splitting out https://github.com/artefactual/archivematica-storage-service/pull/459 into separate PRs - this addresses https://github.com/archivematica/Issues/issues/558 and adds a bucket name field to the S3 storage plugin so that a pre-existing named bucket can be used, rather than auto creating one to match the space id.