### PR TITLE
S3 plugin: allow blank authentication details

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -328,6 +328,21 @@ This is the current list of strings supported:
     - **Type:** `string`
     - **Default:** ``
 
+### AWS-specific environment variables
+
+    These variables can be set to allow AWS authentication for S3 storage spaces as an alternative
+	to providing these details via the user interface. See [AWS CLI Environment Variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) for details.
+
+- **`AWS_ACCESS_KEY_ID`**:
+    - **Description:** Access key for AWS authentication
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AWS_SECRET_ACCESS_KEY`**:
+    - **Description:** Secret key associated with the access key
+    - **Type:** `string`
+    - **Default:** ``
+
 ## Logging configuration
 
 Storage Service 0.10.0 and earlier releases are configured by default to log to

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,6 +2,7 @@
 # updated May 9, 2017 for 0.11.0 release
 bagit==1.7.0
 boto3==1.9.174
+botocore==1.12.253
 brotli==0.5.2  # Better compression library for WhiteNoise
 defusedxml==0.5.0
 Django>=1.8,<1.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ agentarchives==0.4.0
 babel==2.7.0              # via oslo.i18n
 bagit==1.7.0
 boto3==1.9.174
-botocore==1.12.253        # via boto3, s3transfer
+botocore==1.12.253
 brotli==0.5.2
 certifi==2019.9.11        # via requests
 cffi==1.13.2              # via cryptography

--- a/storage_service/locations/migrations/0024_allow_blank_aws_auth.py
+++ b/storage_service/locations/migrations/0024_allow_blank_aws_auth.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("locations", "0023_s3_bucket_field")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="s3",
+            name="access_key_id",
+            field=models.CharField(
+                max_length=64, verbose_name="Access Key ID to authenticate", blank=True
+            ),
+        ),
+        migrations.AlterField(
+            model_name="s3",
+            name="secret_access_key",
+            field=models.CharField(
+                max_length=256,
+                verbose_name="Secret Access Key to authenticate with",
+                blank=True,
+            ),
+        ),
+    ]

--- a/storage_service/locations/tests/test_s3.py
+++ b/storage_service/locations/tests/test_s3.py
@@ -41,7 +41,7 @@ class TestS3Storage(TestCase):
         client.head_bucket(Bucket="test-bucket")
 
     def test_ensure_bucket_exists_get_location_fails(self):
-        self.s3_object.client.get_bucket_location = mock.Mock(
+        self.s3_object.resource.meta.client.get_bucket_location = mock.Mock(
             side_effect=botocore.exceptions.BotoCoreError
         )
 
@@ -49,10 +49,10 @@ class TestS3Storage(TestCase):
             self.s3_object._ensure_bucket_exists()
 
     def test_ensure_bucket_exists_creation_fails(self):
-        self.s3_object.client.get_bucket_location = mock.Mock(
+        self.s3_object.resource.meta.client.get_bucket_location = mock.Mock(
             side_effect=botocore.exceptions.BotoCoreError
         )
-        self.s3_object.client.create_bucket = mock.Mock(
+        self.s3_object.resource.meta.client.create_bucket = mock.Mock(
             side_effect=botocore.exceptions.BotoCoreError
         )
 


### PR DESCRIPTION
Splitting out #459  into separate PRs - this addresses https://github.com/archivematica/Issues/issues/712 and allows the authentication fields on the S3 storage plugin to be left blank so that authentication information can be taken from the environment instead.