### PR TITLE
S3 plugin: enable transfer source and browsing

### DIFF
--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -201,15 +201,15 @@ class S3(models.Model):
         bucket = self.resource.Bucket(self.bucket_name)
 
         # strip leading slash on src_path
-        src_path = src_path.lstrip("/")
+        src_path = src_path.lstrip("/").rstrip(".")
 
         objects = self.resource.Bucket(self.bucket_name).objects.filter(Prefix=src_path)
 
         for objectSummary in objects:
             dest_file = objectSummary.key.replace(src_path, dest_path, 1)
             self.space.create_local_directory(dest_file)
-
-            bucket.download_file(objectSummary.key, dest_file)
+            if not os.path.isdir(dest_file):
+                bucket.download_file(objectSummary.key, dest_file)
 
     def move_from_storage_service(self, src_path, dest_path, package=None):
         self._ensure_bucket_exists()

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -68,7 +68,11 @@ class S3(models.Model):
         verbose_name = _("S3")
         app_label = "locations"
 
-    ALLOWED_LOCATION_PURPOSE = [Location.AIP_STORAGE, Location.REPLICATOR]
+    ALLOWED_LOCATION_PURPOSE = [
+        Location.AIP_STORAGE,
+        Location.REPLICATOR,
+        Location.TRANSFER_SOURCE,
+    ]
 
     @property
     def resource(self):
@@ -124,6 +128,7 @@ class S3(models.Model):
         return self.bucket or self.space_id
 
     def browse(self, path):
+        LOGGER.debug("Browsing s3://%s/%s on S3 storage", self.bucket_name, path)
         path = path.lstrip("/")
 
         # We need a trailing slash on non-empty prefixes because a path like:
@@ -153,7 +158,7 @@ class S3(models.Model):
                 if directory_name:
                     directories.add(directory_name)
                     entries.add(directory_name)
-            else:
+            elif relative_key != "":
                 entries.add(relative_key)
                 properties[relative_key] = {
                     "size": objectSummary.size,

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -202,6 +202,7 @@ class S3(models.Model):
 
         # strip leading slash on src_path
         src_path = src_path.lstrip("/").rstrip(".")
+        dest_path = dest_path.rstrip(".")
 
         objects = self.resource.Bucket(self.bucket_name).objects.filter(Prefix=src_path)
 

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -271,7 +271,8 @@ class Space(models.Model):
         LOGGER.info("path: %s", path)
         try:
             return self.get_child_space().browse(path, *args, **kwargs)
-        except AttributeError:
+        except AttributeError as e:
+            LOGGER.debug("AttributeError while browsing %s: %r", path, e)
             LOGGER.debug("Falling back to default browse local", exc_info=False)
             return self.browse_local(path)
 


### PR DESCRIPTION
Splitting out #459 into separate PRs - this addresses https://github.com/archivematica/Issues/issues/975 and enables the S3 storage plugin to be used for browsing / transfer source.