### PR TITLE
Filter packages in location detail view

### DIFF
--- a/storage_service/locations/datatable_utils.py
+++ b/storage_service/locations/datatable_utils.py
@@ -25,10 +25,13 @@ class DataTable(object):
     DEFAULT_DISPLAY_LENGTH = 10
 
     def __init__(self, query_dict):
-        self.total_records = Package.objects.count()
+        search_filter = Q()
+        location_uuid = query_dict.get("location-uuid")
+        if location_uuid:
+            search_filter = Q(current_location=location_uuid)
+        self.total_records = Package.objects.filter(search_filter).count()
         self.params = self.parse_datatable_parameters(query_dict)
         self.echo = self.params["echo"]
-        search_filter = Q()
         if self.params["search"]:
             search = self.params["search"]
             # remove any leading slashes so we can search in relative paths

--- a/storage_service/locations/tests/test_datatable.py
+++ b/storage_service/locations/tests/test_datatable.py
@@ -228,3 +228,23 @@ class TestDataTable(TestCase):
             "e0a41934-c1d7-45ba-9a95-a7531c063ed1",
         ]
         assert [package.uuid for package in datatable.packages] == expected_uuids
+
+    def test_packages_are_filtered_by_location(self):
+        # count all packages with no filtering
+        datatable = datatable_utils.DataTable(
+            {"iDisplayStart": 0, "iDisplayLength": 10, "sEcho": "1"}
+        )
+        assert datatable.total_records == 9
+        aip_storage_location = models.Location.objects.get(
+            uuid="615103f0-0ee0-4a12-ba17-43192d1143ea"
+        )
+        # count packages only from that location
+        datatable = datatable_utils.DataTable(
+            {
+                "iDisplayStart": 0,
+                "iDisplayLength": 10,
+                "sEcho": "1",
+                "location-uuid": aip_storage_location.uuid,
+            }
+        )
+        assert datatable.total_records == 6

--- a/storage_service/static/js/project.js
+++ b/storage_service/static/js/project.js
@@ -1,5 +1,7 @@
 $(document).ready(function() {
-  var uri = $("#user-data-packages").data("uri") || "/";
+  var $userDataEl = $("#user-data-packages");
+  var uri = $userDataEl.data("uri") || "/";
+  var location = $userDataEl.data("location-uuid");
   var dataTableOptions = {
     // List of language strings from https://datatables.net/reference/option/language
     oLanguage: {
@@ -36,6 +38,12 @@ $(document).ready(function() {
   packagesDataTableOptions["bServerSide"] = true;
   packagesDataTableOptions["bProcessing"] = true;
   packagesDataTableOptions["sAjaxSource"] = uri + "packages_ajax";
+  if (typeof(location) === "string" && location.length) {
+    packagesDataTableOptions["fnServerParams"] = function(data) {
+      // this will get to the request.GET query dict
+      data.push({"name": "location-uuid", "value": location});
+    };
+  }
   var columns = [];
   // for each column create a function that replaces the
   // table cell content with the HTML returned by the server

--- a/storage_service/templates/snippets/packages_table.html
+++ b/storage_service/templates/snippets/packages_table.html
@@ -22,6 +22,7 @@
   </table>
   <div id="user-data-packages" style="display: none;"
        data-uri="{{ uri }}"
+       data-location-uuid="{{ location.uuid }}"
        data-user-id="{{ user.id }}"
        data-user-email="{{ user.email }}"
        data-user-username="{{ user.username }}"


### PR DESCRIPTION
This PR fixes the location detail view to list only packages contained in that location.

The JS code that does the ajax requests now passes the location UUID back to the server using [the `fnServerParams` callback](http://legacy.datatables.net/ref).

Connected to https://github.com/archivematica/Issues/issues/953