### PR TITLE
Update package status

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -1688,6 +1688,11 @@ class PackageResource(ModelResource):
                 user_email=request_info["user_email"],
                 store_data=package.status,
             )
+
+            # Update package status
+            package.status = event_status
+            package.save()
+
             request_event.save()
             response = {
                 "message": _("%(event_type)s request created successfully.")

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -2005,6 +2005,7 @@ class Package(models.Model):
                 os.path.dirname(self.pointer_file_path),
                 base=self.pointer_file_location.full_path,
             )
+        self.status = self.DELETED
         self.save()
         return True, error
 

--- a/storage_service/locations/tests/test_package.py
+++ b/storage_service/locations/tests/test_package.py
@@ -74,12 +74,16 @@ class TestPackage(TestCase):
         )
 
         # It returns a "success" message when the package was deleted
-        # successfully.
+        # successfully and updates its status
         models.Package.objects.filter(uuid=self.package.uuid).update(
             package_type=models.Package.DIP
         )
         response = self.client.post(url, follow=True)
         verify_redirect_message(response, "Package deleted successfully!")
+        assert (
+            models.Package.objects.get(uuid=self.package.uuid).status
+            == models.Package.DELETED
+        )
 
         # It returns an "error" message when the package could not be deleted
         # and the underlying code raised an exception.


### PR DESCRIPTION
This PR updates the package status when it's deleted from the file system and when it's requested to be deleted or recovered. This fixes the Status column in the Archival storage of the Dashboard and in the Packages table of the Storage Service and the Delete modal for DIPs.

Connected to https://github.com/archivematica/Issues/issues/1014