### PR TITLE
Fix S3 bucket creation

### DIFF
--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -120,9 +120,9 @@ class S3(models.Model):
             LOGGER.info("Creating S3 bucket '%s'", self.bucket_name)
             # LocationConstraint cannot be specified if it us-east-1 because it is the default, see: https://github.com/boto/boto3/issues/125
             if self.region.lower() == "us-east-1":
-                self.client.create_bucket(Bucket=self.bucket_name)
+                self.resource.create_bucket(Bucket=self.bucket_name)
             else:
-                self.client.create_bucket(
+                self.resource.create_bucket(
                     Bucket=self.bucket_name,
                     CreateBucketConfiguration={"LocationConstraint": self.region},
                 )

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -117,13 +117,13 @@ class S3(models.Model):
             error_code = err.response["Error"]["Code"]
             if error_code != "NoSuchBucket":
                 raise StorageException(err)
-            LOGGER.info("Creating S3 bucket '%s'", self._bucket_name())
+            LOGGER.info("Creating S3 bucket '%s'", self.bucket_name)
             # LocationConstraint cannot be specified if it us-east-1 because it is the default, see: https://github.com/boto/boto3/issues/125
             if self.region.lower() == "us-east-1":
-                self.client.create_bucket(Bucket=self._bucket_name())
+                self.client.create_bucket(Bucket=self.bucket_name)
             else:
                 self.client.create_bucket(
-                    Bucket=self._bucket_name(),
+                    Bucket=self.bucket_name,
                     CreateBucketConfiguration={"LocationConstraint": self.region},
                 )
 

--- a/storage_service/locations/tests/test_s3.py
+++ b/storage_service/locations/tests/test_s3.py
@@ -15,13 +15,17 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_DIR = os.path.abspath(os.path.join(THIS_DIR, "..", "fixtures"))
 
 
-@mock_s3
 class TestS3Storage(TestCase):
 
     fixtures = ["base.json", "s3.json"]
 
     def setUp(self):
+        self.mock = mock_s3()
+        self.mock.start()
         self.s3_object = models.S3.objects.get(id=1)
+
+    def tearDown(self):
+        self.mock.stop()
 
     def test_bucket_name(self):
         assert self.s3_object.bucket_name == "test-bucket"


### PR DESCRIPTION
This fixes bucket creation in a S3 space when the bucket doesn't exist.

There were two problems:

- The `bucket_name` property of the model was outdated
- https://github.com/artefactual/archivematica-storage-service/pull/515 reintroduced an outdated call to the `client` property which was removed in https://github.com/artefactual/archivematica-storage-service/pull/498

Both of these problems could have been caught by the existing tests, but the mock setup in the S3 tests was also incorrect.

Connected to https://github.com/archivematica/Issues/issues/1048