### PR TITLE
Add support for Open ID Connect (OIDC) authentication.

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -387,6 +387,56 @@ These variables specify the behaviour of CAS authentication. If `SS_CAS_AUTHENTI
     - **Type:** `string`
     - **Default:** `None`
 
+### OIDC-specific environment variables
+
+    These variables specify the behaviour of OpenID Connect (OIDC) authentication.
+	If `SS_OIDC_AUTHENTICATION` is false, none of the other ones are used.
+
+- **`SS_OIDC_AUTHENTICATION`**:
+    - **Description:** Enables user authentication via OIDC.
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`OIDC_RP_CLIENT_ID`**:
+    - **Description:** OIDC client ID
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_RP_CLIENT_SECRET`**:
+    - **Description:** OIDC client secret
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AZURE_TENANT_ID`**:
+    - **Description:** Azure Active Directory Tenant ID - if this is provided, the endpoint URLs will be automatically generated from this.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_OP_AUTHORIZATION_ENDPOINT`**:
+    - **Description:** URL of OIDC provider authorization endpoint
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_OP_TOKEN_ENDPOINT`**:
+    - **Description:** URL of OIDC provider token endpoint
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_OP_USER_ENDPOINT`**:
+    - **Description:** URL of OIDC provider userinfo endpoint
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_OP_JWKS_ENDPOINT`**:
+    - **Description:** URL of OIDC provider JWKS endpoint
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_RP_SIGN_ALGO`**:
+    - **Description:** Algorithm used by the ID provider to sign ID tokens
+    - **Type:** `string`
+    - **Default:** `HS256`
+
 ### AWS-specific environment variables
 
 These variables can be set to allow AWS authentication for S3 storage spaces as an alternative to providing these details via the user interface. See [AWS CLI Environment Variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) for details.

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -43,5 +43,5 @@ django-auth-ldap==1.3.0
 # CAS authentication
 django-cas-ng==3.6.0
 
-# Required for OpenID Connect authentication and pinned to a version that supports Django 1.8
-mozilla-django-oidc==1.0.0
+# Required for OpenID Connect authentication
+mozilla-django-oidc

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -42,3 +42,6 @@ django-auth-ldap==1.3.0
 
 # CAS authentication
 django-cas-ng==3.6.0
+
+# Required for OpenID Connect authentication and pinned to a version that supports Django 1.8
+mozilla-django-oidc==1.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,7 +48,7 @@ git+https://github.com/seatme/django-longer-username.git@seatme#egg=longeruserna
 lxml==3.7.3               # via -r base.in, metsrw, python-cas
 metsrw==0.3.15            # via -r base.in
 monotonic==1.5            # via oslo.utils
-mozilla-django-oidc==1.0.0  # via -r base.in
+mozilla-django-oidc==1.2.3  # via -r base.in
 msgpack==1.0.0            # via oslo.serialization
 mysqlclient==1.4.6        # via agentarchives
 ndg-httpsclient==0.4.2    # via -r base.in
@@ -84,7 +84,7 @@ rfc3986==1.4.0            # via oslo.config
 s3transfer==0.2.1         # via boto3
 scandir==1.10.0           # via -r base.in, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
-six==1.15.0               # via cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore
+six==1.15.0               # via cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, mozilla-django-oidc, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore
 stevedore==1.32.0         # via keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1             # via -r base.in
 typing==3.7.4.3           # via importlib-resources

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ cffi==1.14.1              # via cryptography
 chardet==3.0.4            # via requests
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, zipp
-cryptography==3.0         # via pyopenssl
+cryptography==3.0         # via josepy, mozilla-django-oidc, pyopenssl
 debtcollector==1.22.0     # via oslo.config, oslo.utils, python-keystoneclient
 defusedxml==0.5.0         # via -r base.in
 django-auth-ldap==1.3.0   # via -r base.in
@@ -24,7 +24,7 @@ django-extensions==1.7.9  # via -r base.in
 django-prometheus==1.0.15  # via -r base.in
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.in
 django-tastypie==0.14.3   # via -r base.in
-django==1.11.29           # via -r base.in, django-auth-ldap, django-cas-ng, jsonfield
+django==1.11.29           # via -r base.in, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
 docutils==0.15.2          # via botocore
 enum34==1.1.10            # via cryptography, oslo.config
 funcsigs==1.0.2           # via debtcollector, oslo.utils
@@ -40,6 +40,7 @@ importlib-resources==1.5.0  # via -r base.in, netaddr
 ipaddress==1.0.23         # via cryptography
 iso8601==0.1.12           # via keystoneauth1, oslo.utils
 jmespath==0.10.0          # via boto3, botocore
+josepy==1.3.0             # via mozilla-django-oidc
 jsonfield==2.0.1          # via -r base.in
 keystoneauth1==4.0.1      # via python-keystoneclient
 logutils==0.3.4.1         # via -r base.in
@@ -47,6 +48,7 @@ git+https://github.com/seatme/django-longer-username.git@seatme#egg=longeruserna
 lxml==3.7.3               # via -r base.in, metsrw, python-cas
 metsrw==0.3.15            # via -r base.in
 monotonic==1.5            # via oslo.utils
+mozilla-django-oidc==1.0.0  # via -r base.in
 msgpack==1.0.0            # via oslo.serialization
 mysqlclient==1.4.6        # via agentarchives
 ndg-httpsclient==0.4.2    # via -r base.in
@@ -65,7 +67,7 @@ prometheus-client==0.7.1  # via -r base.in, django-prometheus
 pyasn1-modules==0.2.8     # via python-ldap
 pyasn1==0.4.8             # via pyasn1-modules, python-ldap
 pycparser==2.20           # via cffi
-pyopenssl==19.1.0         # via ndg-httpsclient
+pyopenssl==19.1.0         # via josepy, ndg-httpsclient
 pyparsing==2.4.7          # via oslo.utils
 python-cas==1.5.0         # via django-cas-ng
 python-dateutil==2.8.1    # via botocore, django-tastypie
@@ -77,12 +79,12 @@ python-swiftclient==3.3.0  # via -r base.in
 pytz==2020.1              # via babel, django, oslo.serialization, oslo.utils
 pyyaml==5.3.1             # via oslo.config, oslo.serialization
 requests-oauthlib==1.2.0  # via -r base.in
-requests==2.21.0          # via -r base.in, agentarchives, keystoneauth1, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib
+requests==2.21.0          # via -r base.in, agentarchives, keystoneauth1, mozilla-django-oidc, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib
 rfc3986==1.4.0            # via oslo.config
 s3transfer==0.2.1         # via boto3
 scandir==1.10.0           # via -r base.in, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
-six==1.15.0               # via cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore
+six==1.15.0               # via cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore
 stevedore==1.32.0         # via keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1             # via -r base.in
 typing==3.7.4.3           # via importlib-resources

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -53,7 +53,7 @@ lxml==3.7.3               # via -r base.txt, metsrw, python-cas
 markupsafe==1.1.1         # via jinja2
 metsrw==0.3.15            # via -r base.txt
 monotonic==1.5            # via -r base.txt, oslo.utils
-mozilla-django-oidc==1.0.0  # via -r base.txt
+mozilla-django-oidc==1.2.3  # via -r base.txt
 msgpack==1.0.0            # via -r base.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.4.2    # via -r base.txt
@@ -93,7 +93,7 @@ rfc3986==1.4.0            # via -r base.txt, oslo.config
 s3transfer==0.2.1         # via -r base.txt, boto3
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via -r base.txt, importlib-resources
-six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore, transifex-client
+six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, mozilla-django-oidc, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore, transifex-client
 sphinx==1.2b1             # via -r local.in
 stevedore==1.32.0         # via -r base.txt, keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1             # via -r base.txt

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -16,7 +16,7 @@ chardet==3.0.4            # via -r base.txt, requests
 click==7.1.2              # via pip-tools
 configparser==4.0.2       # via -r base.txt, importlib-metadata
 contextlib2==0.6.0.post1  # via -r base.txt, importlib-metadata, importlib-resources, zipp
-cryptography==3.0         # via -r base.txt, pyopenssl
+cryptography==3.0         # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
 debtcollector==1.22.0     # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
 defusedxml==0.5.0         # via -r base.txt
 dj-database-url==0.4.2    # via -r local.in
@@ -26,7 +26,7 @@ django-extensions==1.7.9  # via -r base.txt
 django-prometheus==1.0.15  # via -r base.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
 django-tastypie==0.14.3   # via -r base.txt
-django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, jsonfield
+django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
 docutils==0.15.2          # via -r base.txt, botocore, sphinx
 enum34==1.1.10            # via -r base.txt, cryptography, oslo.config
 funcsigs==1.0.2           # via -r base.txt, debtcollector, oslo.utils
@@ -44,6 +44,7 @@ ipython==1.1.0            # via -r local.in
 iso8601==0.1.12           # via -r base.txt, keystoneauth1, oslo.utils
 jinja2==2.11.2            # via sphinx
 jmespath==0.10.0          # via -r base.txt, boto3, botocore
+josepy==1.3.0             # via -r base.txt, mozilla-django-oidc
 jsonfield==2.0.1          # via -r base.txt
 keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base.txt
@@ -52,6 +53,7 @@ lxml==3.7.3               # via -r base.txt, metsrw, python-cas
 markupsafe==1.1.1         # via jinja2
 metsrw==0.3.15            # via -r base.txt
 monotonic==1.5            # via -r base.txt, oslo.utils
+mozilla-django-oidc==1.0.0  # via -r base.txt
 msgpack==1.0.0            # via -r base.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.4.2    # via -r base.txt
@@ -73,7 +75,7 @@ pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r base.txt, cffi
 pygments==2.5.2           # via sphinx
-pyopenssl==19.1.0         # via -r base.txt, ndg-httpsclient
+pyopenssl==19.1.0         # via -r base.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via -r base.txt, oslo.utils
 python-cas==1.5.0         # via -r base.txt, django-cas-ng
 python-dateutil==2.8.1    # via -r base.txt, botocore, django-tastypie
@@ -84,13 +86,14 @@ python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
 python-swiftclient==3.3.0  # via -r base.txt
 pytz==2020.1              # via -r base.txt, babel, django, oslo.serialization, oslo.utils
 pyyaml==5.3.1             # via -r base.txt, oslo.config, oslo.serialization
+readline==6.2.4.1         # via ipython
 requests-oauthlib==1.2.0  # via -r base.txt
-requests==2.21.0          # via -r base.txt, agentarchives, keystoneauth1, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib
+requests==2.21.0          # via -r base.txt, agentarchives, keystoneauth1, mozilla-django-oidc, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib
 rfc3986==1.4.0            # via -r base.txt, oslo.config
 s3transfer==0.2.1         # via -r base.txt, boto3
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via -r base.txt, importlib-resources
-six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore, transifex-client
+six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore, transifex-client
 sphinx==1.2b1             # via -r local.in
 stevedore==1.32.0         # via -r base.txt, keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1             # via -r base.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -49,7 +49,7 @@ git+https://github.com/seatme/django-longer-username.git@seatme#egg=longeruserna
 lxml==3.7.3               # via -r base.txt, metsrw, python-cas
 metsrw==0.3.15            # via -r base.txt
 monotonic==1.5            # via -r base.txt, oslo.utils
-mozilla-django-oidc==1.0.0  # via -r base.txt
+mozilla-django-oidc==1.2.3  # via -r base.txt
 msgpack==1.0.0            # via -r base.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.4.2    # via -r base.txt
@@ -86,7 +86,7 @@ rfc3986==1.4.0            # via -r base.txt, oslo.config
 s3transfer==0.2.1         # via -r base.txt, boto3
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via -r base.txt, importlib-resources
-six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore
+six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, mozilla-django-oidc, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore
 stevedore==1.32.0         # via -r base.txt, keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1             # via -r base.txt
 typing==3.7.4.3           # via -r base.txt, importlib-resources

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,7 +15,7 @@ cffi==1.14.1              # via -r base.txt, cryptography
 chardet==3.0.4            # via -r base.txt, requests
 configparser==4.0.2       # via -r base.txt, importlib-metadata
 contextlib2==0.6.0.post1  # via -r base.txt, importlib-metadata, importlib-resources, zipp
-cryptography==3.0         # via -r base.txt, pyopenssl
+cryptography==3.0         # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
 debtcollector==1.22.0     # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
 defusedxml==0.5.0         # via -r base.txt
 dj-database-url==0.4.2    # via -r production.in
@@ -25,7 +25,7 @@ django-extensions==1.7.9  # via -r base.txt
 django-prometheus==1.0.15  # via -r base.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
 django-tastypie==0.14.3   # via -r base.txt
-django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, jsonfield
+django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
 docutils==0.15.2          # via -r base.txt, botocore
 enum34==1.1.10            # via -r base.txt, cryptography, oslo.config
 funcsigs==1.0.2           # via -r base.txt, debtcollector, oslo.utils
@@ -41,6 +41,7 @@ importlib-resources==1.5.0  # via -r base.txt, netaddr
 ipaddress==1.0.23         # via -r base.txt, cryptography
 iso8601==0.1.12           # via -r base.txt, keystoneauth1, oslo.utils
 jmespath==0.10.0          # via -r base.txt, boto3, botocore
+josepy==1.3.0             # via -r base.txt, mozilla-django-oidc
 jsonfield==2.0.1          # via -r base.txt
 keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base.txt
@@ -48,6 +49,7 @@ git+https://github.com/seatme/django-longer-username.git@seatme#egg=longeruserna
 lxml==3.7.3               # via -r base.txt, metsrw, python-cas
 metsrw==0.3.15            # via -r base.txt
 monotonic==1.5            # via -r base.txt, oslo.utils
+mozilla-django-oidc==1.0.0  # via -r base.txt
 msgpack==1.0.0            # via -r base.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.4.2    # via -r base.txt
@@ -67,7 +69,7 @@ psycopg2==2.7.1           # via -r production.in
 pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r base.txt, cffi
-pyopenssl==19.1.0         # via -r base.txt, ndg-httpsclient
+pyopenssl==19.1.0         # via -r base.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via -r base.txt, oslo.utils
 python-cas==1.5.0         # via -r base.txt, django-cas-ng
 python-dateutil==2.8.1    # via -r base.txt, botocore, django-tastypie
@@ -79,12 +81,12 @@ python-swiftclient==3.3.0  # via -r base.txt
 pytz==2020.1              # via -r base.txt, babel, django, oslo.serialization, oslo.utils
 pyyaml==5.3.1             # via -r base.txt, oslo.config, oslo.serialization
 requests-oauthlib==1.2.0  # via -r base.txt
-requests==2.21.0          # via -r base.txt, agentarchives, keystoneauth1, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib
+requests==2.21.0          # via -r base.txt, agentarchives, keystoneauth1, mozilla-django-oidc, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib
 rfc3986==1.4.0            # via -r base.txt, oslo.config
 s3transfer==0.2.1         # via -r base.txt, boto3
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via -r base.txt, importlib-resources
-six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore
+six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore
 stevedore==1.32.0         # via -r base.txt, keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1             # via -r base.txt
 typing==3.7.4.3           # via -r base.txt, importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -30,7 +30,7 @@ configparser==4.0.2       # via -r base.txt, importlib-metadata
 contextlib2==0.6.0.post1  # via -r base.txt, importlib-metadata, importlib-resources, vcrpy, zipp
 cookies==2.2.1            # via responses
 coverage==4.2             # via -r test.in, pytest-cov
-cryptography==3.0         # via -r base.txt, moto, pyopenssl
+cryptography==3.0         # via -r base.txt, josepy, moto, mozilla-django-oidc, pyopenssl
 debtcollector==1.22.0     # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
 decorator==4.4.2          # via ipython, networkx, traitlets
 defusedxml==0.5.0         # via -r base.txt
@@ -41,7 +41,7 @@ django-extensions==1.7.9  # via -r base.txt
 django-prometheus==1.0.15  # via -r base.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
 django-tastypie==0.14.3   # via -r base.txt
-django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, jsonfield
+django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
 docker==4.2.2             # via moto
 docutils==0.15.2          # via -r base.txt, botocore
 ecdsa==0.15               # via python-jose
@@ -65,6 +65,7 @@ ipython==5.10.0           # via ipdb
 iso8601==0.1.12           # via -r base.txt, keystoneauth1, oslo.utils
 jinja2==2.11.2            # via moto
 jmespath==0.10.0          # via -r base.txt, boto3, botocore
+josepy==1.3.0             # via -r base.txt, mozilla-django-oidc
 jsondiff==1.1.2           # via moto
 jsonfield==2.0.1          # via -r base.txt
 jsonpatch==1.26           # via cfn-lint
@@ -82,6 +83,7 @@ mock==3.0.5               # via moto, pytest-mock, responses, vcrpy
 monotonic==1.5            # via -r base.txt, oslo.utils
 more-itertools==5.0.0     # via pytest
 moto==1.3.8               # via -r test.in
+mozilla-django-oidc==1.0.0  # via -r base.txt
 msgpack==1.0.0            # via -r base.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.4.2    # via -r base.txt
@@ -110,7 +112,7 @@ pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, pyasn1-modules, python-jose, python-ldap, rsa
 pycparser==2.20           # via -r base.txt, cffi
 pygments==2.5.2           # via ipython
-pyopenssl==19.1.0         # via -r base.txt, ndg-httpsclient
+pyopenssl==19.1.0         # via -r base.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via -r base.txt, oslo.utils, packaging
 pyrsistent==0.16.0        # via jsonschema
 pytest-cov==2.4.0         # via -r test.in
@@ -128,7 +130,7 @@ python-swiftclient==3.3.0  # via -r base.txt
 pytz==2020.1              # via -r base.txt, babel, django, moto, oslo.serialization, oslo.utils
 pyyaml==5.3.1             # via -r base.txt, cfn-lint, moto, oslo.config, oslo.serialization, vcrpy
 requests-oauthlib==1.2.0  # via -r base.txt
-requests==2.21.0          # via -r base.txt, agentarchives, docker, keystoneauth1, moto, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib, responses
+requests==2.21.0          # via -r base.txt, agentarchives, docker, keystoneauth1, moto, mozilla-django-oidc, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib, responses
 responses==0.10.15        # via moto
 rfc3986==1.4.0            # via -r base.txt, oslo.config
 rsa==4.5                  # via python-jose
@@ -136,7 +138,7 @@ s3transfer==0.2.1         # via -r base.txt, boto3
 scandir==1.10.0           # via -r base.txt, pathlib2
 simplegeneric==0.8.1      # via ipython
 singledispatch==3.4.0.3   # via -r base.txt, importlib-resources
-six==1.15.0               # via -r base.txt, aws-sam-translator, cfn-lint, cryptography, debtcollector, django-extensions, docker, ecdsa, jsonschema, junit-xml, keystoneauth1, metsrw, mock, more-itertools, moto, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pyrsistent, pytest, python-cas, python-dateutil, python-jose, python-keystoneclient, python-swiftclient, responses, singledispatch, stevedore, tox, traitlets, vcrpy, virtualenv, websocket-client
+six==1.15.0               # via -r base.txt, aws-sam-translator, cfn-lint, cryptography, debtcollector, django-extensions, docker, ecdsa, josepy, jsonschema, junit-xml, keystoneauth1, metsrw, mock, more-itertools, moto, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pyrsistent, pytest, python-cas, python-dateutil, python-jose, python-keystoneclient, python-swiftclient, responses, singledispatch, stevedore, tox, traitlets, vcrpy, virtualenv, websocket-client
 stevedore==1.32.0         # via -r base.txt, keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1             # via -r base.txt
 toml==0.10.1              # via tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -83,7 +83,7 @@ mock==3.0.5               # via moto, pytest-mock, responses, vcrpy
 monotonic==1.5            # via -r base.txt, oslo.utils
 more-itertools==5.0.0     # via pytest
 moto==1.3.8               # via -r test.in
-mozilla-django-oidc==1.0.0  # via -r base.txt
+mozilla-django-oidc==1.2.3  # via -r base.txt
 msgpack==1.0.0            # via -r base.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.4.2    # via -r base.txt
@@ -138,7 +138,7 @@ s3transfer==0.2.1         # via -r base.txt, boto3
 scandir==1.10.0           # via -r base.txt, pathlib2
 simplegeneric==0.8.1      # via ipython
 singledispatch==3.4.0.3   # via -r base.txt, importlib-resources
-six==1.15.0               # via -r base.txt, aws-sam-translator, cfn-lint, cryptography, debtcollector, django-extensions, docker, ecdsa, josepy, jsonschema, junit-xml, keystoneauth1, metsrw, mock, more-itertools, moto, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pyrsistent, pytest, python-cas, python-dateutil, python-jose, python-keystoneclient, python-swiftclient, responses, singledispatch, stevedore, tox, traitlets, vcrpy, virtualenv, websocket-client
+six==1.15.0               # via -r base.txt, aws-sam-translator, cfn-lint, cryptography, debtcollector, django-extensions, docker, ecdsa, josepy, jsonschema, junit-xml, keystoneauth1, metsrw, mock, more-itertools, moto, mozilla-django-oidc, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pyrsistent, pytest, python-cas, python-dateutil, python-jose, python-keystoneclient, python-swiftclient, responses, singledispatch, stevedore, tox, traitlets, vcrpy, virtualenv, websocket-client
 stevedore==1.32.0         # via -r base.txt, keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1             # via -r base.txt
 toml==0.10.1              # via tox

--- a/storage_service/common/backends.py
+++ b/storage_service/common/backends.py
@@ -3,10 +3,14 @@ from __future__ import absolute_import
 
 import json
 
+import requests
 from django.conf import settings
 from django_cas_ng.backends import CASBackend
-from josepy.jws import JWS
+from django.core.exceptions import SuspiciousOperation
+from django.utils.encoding import smart_text
+from josepy.jws import JWS, Header
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+from mozilla_django_oidc.utils import import_from_settings
 
 
 class CustomCASBackend(CASBackend):
@@ -24,6 +28,41 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
     """
     Provide OpenID Connect authentication
     """
+
+    def retrieve_matching_jwk(self, token):
+        """Get the signing key by exploring the JWKS endpoint of the OP."""
+
+        # This method is overridden to provide a fix for "alg" potentially not
+        # being present in the response (it is optional in the spec, and not
+        # provided by Azure)
+
+        # The latest version of mozilla-django-oidc provides this fix, but we
+        # cannot currently use it due to being on Django 1.8. Once we are on a
+        # recent Django version and using mozilla_django_oidc>=1.1.0 then we
+        # can discard this override.
+        response_jwks = requests.get(
+            self.OIDC_OP_JWKS_ENDPOINT,
+            verify=import_from_settings("OIDC_VERIFY_SSL", True),
+        )
+        response_jwks.raise_for_status()
+        jwks = response_jwks.json()
+
+        # Compute the current header from the given token to find a match
+        jws = JWS.from_compact(token)
+        json_header = jws.signature.protected
+        header = Header.json_loads(json_header)
+
+        key = None
+        for jwk in jwks["keys"]:
+            if jwk["kid"] != smart_text(header.kid):
+                continue
+            if "alg" in jwk and jwk["alg"] != smart_text(header.alg):
+                raise SuspiciousOperation("alg values do not match.")
+            key = jwk
+        if key is None:
+            raise SuspiciousOperation("Could not find a valid JWKS.")
+        return key
+
     def get_userinfo(self, access_token, id_token, verified_id):
         """
         Extract user details from JSON web tokens

--- a/storage_service/common/backends.py
+++ b/storage_service/common/backends.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import json
+
 from django.conf import settings
 from django_cas_ng.backends import CASBackend
+from josepy.jws import JWS
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
 
 class CustomCASBackend(CASBackend):
@@ -13,4 +17,34 @@ class CustomCASBackend(CASBackend):
         if settings.CAS_AUTOCONFIGURE_EMAIL and settings.CAS_EMAIL_DOMAIN:
             user.email = "{0}@{1}".format(user.username, settings.CAS_EMAIL_DOMAIN)
             user.save()
+        return user
+
+
+class CustomOIDCBackend(OIDCAuthenticationBackend):
+    """
+    Provide OpenID Connect authentication
+    """
+    def get_userinfo(self, access_token, id_token, verified_id):
+        """
+        Extract user details from JSON web tokens
+        These map to fields on the user field.
+        """
+        id_info = json.loads(JWS.from_compact(id_token).payload.decode("utf-8"))
+        access_info = json.loads(JWS.from_compact(access_token).payload.decode("utf-8"))
+
+        info = {}
+
+        for oidc_attr, user_attr in settings.OIDC_ACCESS_ATTRIBUTE_MAP.items():
+            info[user_attr] = access_info[oidc_attr]
+
+        for oidc_attr, user_attr in settings.OIDC_ID_ATTRIBUTE_MAP.items():
+            info[user_attr] = id_info[oidc_attr]
+
+        return info
+
+    def create_user(self, user_info):
+        user = super(CustomOIDCBackend, self).create_user(user_info)
+        for attr, value in user_info.items():
+            setattr(user, attr, value)
+        user.save()
         return user

--- a/storage_service/common/backends.py
+++ b/storage_service/common/backends.py
@@ -3,14 +3,10 @@ from __future__ import absolute_import
 
 import json
 
-import requests
 from django.conf import settings
 from django_cas_ng.backends import CASBackend
-from django.core.exceptions import SuspiciousOperation
-from django.utils.encoding import smart_text
-from josepy.jws import JWS, Header
+from josepy.jws import JWS
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
-from mozilla_django_oidc.utils import import_from_settings
 
 
 class CustomCASBackend(CASBackend):
@@ -28,40 +24,6 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
     """
     Provide OpenID Connect authentication
     """
-
-    def retrieve_matching_jwk(self, token):
-        """Get the signing key by exploring the JWKS endpoint of the OP."""
-
-        # This method is overridden to provide a fix for "alg" potentially not
-        # being present in the response (it is optional in the spec, and not
-        # provided by Azure)
-
-        # The latest version of mozilla-django-oidc provides this fix, but we
-        # cannot currently use it due to being on Django 1.8. Once we are on a
-        # recent Django version and using mozilla_django_oidc>=1.1.0 then we
-        # can discard this override.
-        response_jwks = requests.get(
-            self.OIDC_OP_JWKS_ENDPOINT,
-            verify=import_from_settings("OIDC_VERIFY_SSL", True),
-        )
-        response_jwks.raise_for_status()
-        jwks = response_jwks.json()
-
-        # Compute the current header from the given token to find a match
-        jws = JWS.from_compact(token)
-        json_header = jws.signature.protected
-        header = Header.json_loads(json_header)
-
-        key = None
-        for jwk in jwks["keys"]:
-            if jwk["kid"] != smart_text(header.kid):
-                continue
-            if "alg" in jwk and jwk["alg"] != smart_text(header.alg):
-                raise SuspiciousOperation("alg values do not match.")
-            key = jwk
-        if key is None:
-            raise SuspiciousOperation("Could not find a valid JWKS.")
-        return key
 
     def get_userinfo(self, access_token, id_token, verified_id):
         """

--- a/storage_service/common/context_processors.py
+++ b/storage_service/common/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def auth_methods(request):
+    return {"oidc_enabled": settings.OIDC_AUTHENTICATION}

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -555,6 +555,11 @@ if OIDC_AUTHENTICATION:
         OIDC_OP_JWKS_ENDPOINT = (
             "https://login.microsoftonline.com/%s/discovery/v2.0/keys" % AZURE_TENANT_ID
         )
+    else:
+        OIDC_OP_AUTHORIZATION_ENDPOINT = environ.get("OIDC_OP_AUTHORIZATION_ENDPOINT", "")
+        OIDC_OP_TOKEN_ENDPOINT = environ.get("OIDC_OP_TOKEN_ENDPOINT", "")
+        OIDC_OP_USER_ENDPOINT = environ.get("OIDC_OP_USER_ENDPOINT", "")
+        OIDC_OP_JWKS_ENDPOINT = environ.get("OIDC_OP_JWKS_ENDPOINT", "")
 
     OIDC_RP_SIGN_ALGO = environ.get("OIDC_RP_SIGN_ALGO", "HS256")
 

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -522,6 +522,50 @@ if CAS_AUTHENTICATION:
 
 ######### END CAS CONFIGURATION #########
 
+OIDC_AUTHENTICATION = is_true(environ.get("SS_OIDC_AUTHENTICATION", ""))
+if OIDC_AUTHENTICATION:
+    ALLOW_USER_EDITS = False
+
+    AUTHENTICATION_BACKENDS += ["common.backends.CustomOIDCBackend"]
+    LOGIN_EXEMPT_URLS.append(r"^oidc")
+    INSTALLED_APPS += ["mozilla_django_oidc"]
+
+    # AUTH_SERVER = 'https://login.microsoftonline.com/common/v2.0/'
+    OIDC_RP_CLIENT_ID = environ.get("OIDC_RP_CLIENT_ID", "")
+    OIDC_RP_CLIENT_SECRET = environ.get("OIDC_RP_CLIENT_SECRET", "")
+
+    OIDC_OP_AUTHORIZATION_ENDPOINT = ""
+    OIDC_OP_TOKEN_ENDPOINT = ""
+    OIDC_OP_USER_ENDPOINT = ""
+    OIDC_OP_JWKS_ENDPOINT = ""
+
+    AZURE_TENANT_ID = environ.get("AZURE_TENANT_ID", "")
+    if AZURE_TENANT_ID:
+        OIDC_OP_AUTHORIZATION_ENDPOINT = (
+            "https://login.microsoftonline.com/%s/oauth2/v2.0/authorize"
+            % AZURE_TENANT_ID
+        )
+        OIDC_OP_TOKEN_ENDPOINT = (
+            "https://login.microsoftonline.com/%s/oauth2/v2.0/token" % AZURE_TENANT_ID
+        )
+        OIDC_OP_USER_ENDPOINT = (
+            "https://login.microsoftonline.com/%s/openid/userinfo" % AZURE_TENANT_ID
+        )
+        OIDC_OP_JWKS_ENDPOINT = (
+            "https://login.microsoftonline.com/%s/discovery/v2.0/keys" % AZURE_TENANT_ID
+        )
+
+    OIDC_RP_SIGN_ALGO = environ.get("OIDC_RP_SIGN_ALGO", "HS256")
+
+    # Username is email address
+    OIDC_USERNAME_ALGO = lambda email: email
+
+    # map attributes from access token
+    OIDC_ACCESS_ATTRIBUTE_MAP = {"given_name": "first_name", "family_name": "last_name"}
+
+    # map attributes from id token
+    OIDC_ID_ATTRIBUTE_MAP = {"email": "email"}
+
 # WARNING: if Gunicorn is being used to serve the Storage Service and its
 # worker class is set to `gevent`, then BagIt validation must use 1 process.
 # Otherwise, calls to `validate` will hang because of the incompatibility

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -556,9 +556,9 @@ if OIDC_AUTHENTICATION:
             "https://login.microsoftonline.com/%s/discovery/v2.0/keys" % AZURE_TENANT_ID
         )
     else:
-        OIDC_OP_AUTHORIZATION_ENDPOINT = environ.get("OIDC_OP_AUTHORIZATION_ENDPOINT", "")
-        OIDC_OP_TOKEN_ENDPOINT = environ.get("OIDC_OP_TOKEN_ENDPOINT", "")
-        OIDC_OP_USER_ENDPOINT = environ.get("OIDC_OP_USER_ENDPOINT", "")
+        OIDC_OP_AUTHORIZATION_ENDPOINT = environ["OIDC_OP_AUTHORIZATION_ENDPOINT"]
+        OIDC_OP_TOKEN_ENDPOINT = environ["OIDC_OP_TOKEN_ENDPOINT"]
+        OIDC_OP_USER_ENDPOINT = environ["OIDC_OP_USER_ENDPOINT"]
         OIDC_OP_JWKS_ENDPOINT = environ.get("OIDC_OP_JWKS_ENDPOINT", "")
 
     OIDC_RP_SIGN_ALGO = environ.get("OIDC_RP_SIGN_ALGO", "HS256")

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -167,6 +167,7 @@ TEMPLATES = [
                 "django.template.context_processors.tz",
                 "django.template.context_processors.request",
                 "django.contrib.messages.context_processors.messages",
+                "common.context_processors.auth_methods",
             ],
             "debug": DEBUG,
         },

--- a/storage_service/storage_service/tests/test_oidc.py
+++ b/storage_service/storage_service/tests/test_oidc.py
@@ -1,0 +1,35 @@
+import pytest
+from django.conf import settings
+from django.test import TestCase
+
+from common.backends import CustomOIDCBackend
+
+
+@pytest.mark.skipif(
+    not settings.OIDC_AUTHENTICATION, reason="tests will only pass if OIDC is enabled"
+)
+class TestOIDC(TestCase):
+    def test_create_user(self):
+        backend = CustomOIDCBackend()
+        user = backend.create_user(
+            {"email": "test@example.com", "first_name": "Test", "last_name": "User"}
+        )
+
+        user.refresh_from_db()
+        assert user.first_name == "Test"
+        assert user.last_name == "User"
+        assert user.email == "test@example.com"
+        assert user.username == "test@example.com"
+
+    def test_get_userinfo(self):
+        # Encoded at https://www.jsonwebtoken.io/
+        # {"email": "test@example.com"}
+        id_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJqdGkiOiI1M2QyMzUzMy04NDk0LTQyZWQtYTJiZC03Mzc2MjNmMjUzZjciLCJpYXQiOjE1NzMwMzE4NDQsImV4cCI6MTU3MzAzNTQ0NH0.m3nHgvj_DyVJMcW5eyYuUss1Y0PNzJV2O3bX0b_DCmI"
+        # {"given_name": "Test", "family_name": "User"}
+        access_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJnaXZlbl9uYW1lIjoiVGVzdCIsImZhbWlseV9uYW1lIjoiVXNlciIsImp0aSI6ImRhZjIwNTNiLWE4MTgtNDE1Yy1hM2Y1LTkxYWVhMTMxYjljZCIsImlhdCI6MTU3MzAzMTk3OSwiZXhwIjoxNTczMDM1NTc5fQ.cGcmt7d9IuKndvrqPpAH3Dvb3KyCOMqixUWgS7sg8r4"
+
+        backend = CustomOIDCBackend()
+        info = backend.get_userinfo(access_token, id_token, None)
+        assert info["email"] == "test@example.com"
+        assert info["first_name"] == "Test"
+        assert info["last_name"] == "User"

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
         name="javascript-catalog",
     ),
     url(r"^i18n/", include(("django.conf.urls.i18n", "i18n"), namespace="i18n")),
+    url(r"^oidc/", include("mozilla_django_oidc.urls")),
 ]
 
 if "django_cas_ng" in settings.INSTALLED_APPS:

--- a/storage_service/templates/login.html
+++ b/storage_service/templates/login.html
@@ -26,4 +26,9 @@
 <input type="hidden" name="next" value="{{ next }}" />
 </form>
 
+{% if oidc_enabled %}
+  <a href="{% url 'oidc_authentication_init' %}">Log in with OpenID Connect</a>
+{% endif %}
+
+
 {% endblock %}


### PR DESCRIPTION
Follows similar pattern to existing Shibboleth and LDAP support. Also supports automatic setup of OIDC URLs for Azure providers by supplying just the tenant ID.

Using an older version of the OIDC library because of the older version of Django currently used in Archivematica. It's been necessary to port a fix from more recent versions of the library, and I've included notes in the code about this.

Based on work from the Wellcome fork: https://github.com/wellcometrust/archivematica-storage-service/pull/13
Connected to archivematica/issues#1053
PR for Dashboard: https://github.com/artefactual/archivematica/pull/1536