### PR TITLE
Restore GPG transform keys

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,7 +15,7 @@ gunicorn==19.9.0
 jsonfield==2.0.1
 logutils==0.3.4.1
 lxml==3.7.3
-git+https://github.com/artefactual-labs/mets-reader-writer.git@6e84511ece705118b3a373ce5ad4af67e12e94e7#egg=metsrw
+metsrw==0.3.15
 ndg-httpsclient==0.4.2
 pathlib2==2.3.5
 python-gnupg==0.4.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,7 +15,7 @@ gunicorn==19.9.0
 jsonfield==2.0.1
 logutils==0.3.4.1
 lxml==3.7.3
-metsrw==0.3.14
+git+https://github.com/artefactual-labs/mets-reader-writer.git@6e84511ece705118b3a373ce5ad4af67e12e94e7#egg=metsrw
 ndg-httpsclient==0.4.2
 pathlib2==2.3.5
 python-gnupg==0.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ django==1.8.19
 docutils==0.15.2          # via botocore
 enum34==1.1.6             # via cryptography, oslo.config
 funcsigs==1.0.2           # via debtcollector, oslo.utils
-future==0.18.2            # via metsrw
+future==0.18.2
 futures==3.2.0
 gevent==1.3.6
 greenlet==0.4.15          # via gevent
@@ -40,7 +40,7 @@ keystoneauth1==3.18.0     # via python-keystoneclient
 logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
-metsrw==0.3.14
+git+https://github.com/artefactual-labs/mets-reader-writer.git@6e84511ece705118b3a373ce5ad4af67e12e94e7#egg=metsrw
 monotonic==1.5            # via oslo.utils
 msgpack==0.6.2            # via oslo.serialization
 mysqlclient==1.4.6        # via agentarchives
@@ -75,7 +75,7 @@ requests==2.21.0
 rfc3986==1.3.2            # via oslo.config
 s3transfer==0.2.1         # via boto3
 scandir==1.10.0
-six==1.13.0               # via cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, stevedore
+six==1.13.0               # via cryptography, debtcollector, django-extensions, keystoneauth1, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, stevedore
 stevedore==1.31.0         # via keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1
 urllib3==1.24.3           # via botocore, requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ django==1.8.19
 docutils==0.15.2          # via botocore
 enum34==1.1.6             # via cryptography, oslo.config
 funcsigs==1.0.2           # via debtcollector, oslo.utils
-future==0.18.2
+future==0.18.2            # via metsrw
 futures==3.2.0
 gevent==1.3.6
 greenlet==0.4.15          # via gevent
@@ -40,7 +40,7 @@ keystoneauth1==3.18.0     # via python-keystoneclient
 logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
-git+https://github.com/artefactual-labs/mets-reader-writer.git@6e84511ece705118b3a373ce5ad4af67e12e94e7#egg=metsrw
+metsrw==0.3.15
 monotonic==1.5            # via oslo.utils
 msgpack==0.6.2            # via oslo.serialization
 mysqlclient==1.4.6        # via agentarchives
@@ -75,7 +75,7 @@ requests==2.21.0
 rfc3986==1.3.2            # via oslo.config
 s3transfer==0.2.1         # via boto3
 scandir==1.10.0
-six==1.13.0               # via cryptography, debtcollector, django-extensions, keystoneauth1, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, stevedore
+six==1.13.0               # via cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, stevedore
 stevedore==1.31.0         # via keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1
 urllib3==1.24.3           # via botocore, requests

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -45,7 +45,7 @@ logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
 markupsafe==1.1.1         # via jinja2
-git+https://github.com/artefactual-labs/mets-reader-writer.git@6e84511ece705118b3a373ce5ad4af67e12e94e7#egg=metsrw
+metsrw==0.3.15
 monotonic==1.5
 msgpack==0.6.2
 mysqlclient==1.4.6

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -45,7 +45,7 @@ logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
 markupsafe==1.1.1         # via jinja2
-metsrw==0.3.14
+git+https://github.com/artefactual-labs/mets-reader-writer.git@6e84511ece705118b3a373ce5ad4af67e12e94e7#egg=metsrw
 monotonic==1.5
 msgpack==0.6.2
 mysqlclient==1.4.6

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -41,7 +41,7 @@ keystoneauth1==3.18.0
 logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
-metsrw==0.3.14
+git+https://github.com/artefactual-labs/mets-reader-writer.git@6e84511ece705118b3a373ce5ad4af67e12e94e7#egg=metsrw
 monotonic==1.5
 msgpack==0.6.2
 mysqlclient==1.4.6

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -41,7 +41,7 @@ keystoneauth1==3.18.0
 logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
-git+https://github.com/artefactual-labs/mets-reader-writer.git@6e84511ece705118b3a373ce5ad4af67e12e94e7#egg=metsrw
+metsrw==0.3.15
 monotonic==1.5
 msgpack==0.6.2
 mysqlclient==1.4.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -72,7 +72,7 @@ logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
 markupsafe==1.1.1         # via jinja2
-git+https://github.com/artefactual-labs/mets-reader-writer.git@6e84511ece705118b3a373ce5ad4af67e12e94e7#egg=metsrw
+metsrw==0.3.15
 mock==3.0.5               # via moto, pytest-mock, responses, vcrpy
 monotonic==1.5
 more-itertools==5.0.0     # via pytest, zipp

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -72,7 +72,7 @@ logutils==0.3.4.1
 git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
 lxml==3.7.3
 markupsafe==1.1.1         # via jinja2
-metsrw==0.3.14
+git+https://github.com/artefactual-labs/mets-reader-writer.git@6e84511ece705118b3a373ce5ad4af67e12e94e7#egg=metsrw
 mock==3.0.5               # via moto, pytest-mock, responses, vcrpy
 monotonic==1.5
 more-itertools==5.0.0     # via pytest, zipp

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -2655,7 +2655,7 @@ class Package(models.Model):
             )
             # Since a new event has been created based on the new compression
             # mechanism we reset the old decompression transforms
-            self._remove_decompression_transforms(aip)
+            self._filter_and_remove_decompression_transforms(aip)
             # Add the new compression event
             aip.add_premis_event(compression_event)
             self._update_pointer_file(compression, mets, path=updated_aip_path)
@@ -2678,7 +2678,7 @@ class Package(models.Model):
         """
         return transform_file.get("TYPE") or transform_file.get("type")
 
-    def _remove_decompression_transforms(self, aip):
+    def _filter_and_remove_decompression_transforms(self, aip):
         aip.transform_files = [
             transform_file
             for transform_file in aip.transform_files

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -2648,11 +2648,15 @@ class Package(models.Model):
             # Update pointer file
             mets = metsrw.METSDocument.fromfile(self.full_pointer_file_path)
             aip = mets.get_file(type="Archival Information Package")
-            # Add compression event (if compressed)
+            # Create a new compression event
             event_detail = utils.get_compression_event_detail(compression)
             compression_event = premis.create_premis_aip_compression_event(
                 event_detail, ""
             )
+            # Since a new event has been created based on the new compression
+            # mechanism we reset the old decompression transforms
+            self._remove_decompression_transforms(aip)
+            # Add the new compression event
             aip.add_premis_event(compression_event)
             self._update_pointer_file(compression, mets, path=updated_aip_path)
         elif was_compressed:
@@ -2664,6 +2668,23 @@ class Package(models.Model):
     # ==========================================================================
     # END Private methods for ``finish_reingest``
     # ==========================================================================
+
+    def _get_transform_file_type(self, transform_file):
+        """Get the type of a transform file entry.
+
+        Keys are converted to uppercase by metsrw.FSEntry.__init__
+        but they are handled in lowercase in other modules here in the
+        Storage Service.
+        """
+        return transform_file.get("TYPE") or transform_file.get("type")
+
+    def _remove_decompression_transforms(self, aip):
+        aip.transform_files = [
+            transform_file
+            for transform_file in aip.transform_files
+            if self._get_transform_file_type(transform_file)
+            != utils.DECOMPRESS_TRANSFORM_TYPE
+        ]
 
     def _update_pointer_file(self, compression, mets, path=None):
         """Update the AIP's pointer file at the end of re-ingest."""
@@ -2687,7 +2708,10 @@ class Package(models.Model):
             checksum = utils.generate_checksum(path, "sha512")
 
         transform_types = set(
-            [transform.get("type") for transform in aip.transform_files]
+            [
+                self._get_transform_file_type(transform_file)
+                for transform_file in aip.transform_files
+            ]
         )
         if "decryption" in transform_types:
             transform_order = 2  # encryption is a prior transformation


### PR DESCRIPTION
This PR sets a [custom version of the `metsrw`](https://github.com/artefactual-labs/mets-reader-writer/pull/78) that parses `mets:transformFile` subelements when the pointer file is read during reingest.

It also resets previous decompression transforms since a new compression event is generated at the end of reingest. This matches the old behaviour explained in this https://github.com/archivematica/Issues/issues/803#issuecomment-579890818

An old deprecated AMAUAT has also been restored to help testing this in https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/156

Connected to https://github.com/archivematica/Issues/issues/803