### PR TITLE
Remove redundant compression event on reingest

### DIFF
--- a/storage_service/common/tests/test_utils.py
+++ b/storage_service/common/tests/test_utils.py
@@ -254,7 +254,7 @@ def test_get_format_info(compression, version, extension, program_name, transfor
     consistent.
     """
     fsentry = FSEntry()
-    vers, ext, prog_name = utils.get_compression_transforms(fsentry, compression, 1)
+    vers, ext, prog_name = utils.set_compression_transforms(fsentry, compression, 1)
     assert version in vers
     assert ext == extension
     assert program_name in prog_name

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -463,16 +463,18 @@ def get_compression_event_detail(compression):
     return event_detail
 
 
-def get_compression_transforms(aip, compression, transform_order):
-    """Return command for compressing the package
+def set_compression_transforms(aip, compression, transform_order):
+    """Set transform files based on the compression mechanism.
 
+    Return information for compressing the package
+
+    :param aip: metsrw FSEntry representing the AIP
     :param compression: one of the constants in ``COMPRESSION_ALGORITHMS``.
-    :param extract_path: target path for the compressed file
-    :param basename: base name of the file (without extension)
-    :param full_path: Path of source files
-    :returns: (command, compressed_filename) where
-        `command` is the compression command (as a list of strings)
-        `compressed_filename` is the full path to the compressed file
+    :param transform_order: initial order for the transforms
+    :returns: (version, extension, program_name) where
+        `version` is the version of the program to compress the AIP
+        `extension` is the file extension of the compressed AIP
+        `program_name` is the name of the program to compress the AIP
     """
     if compression in (COMPRESSION_7Z_BZIP, COMPRESSION_7Z_LZMA, COMPRESSION_7Z_COPY):
         if compression == COMPRESSION_7Z_BZIP:

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -2648,16 +2648,9 @@ class Package(models.Model):
             # Update pointer file
             mets = metsrw.METSDocument.fromfile(self.full_pointer_file_path)
             aip = mets.get_file(type="Archival Information Package")
-            # Create a new compression event
-            event_detail = utils.get_compression_event_detail(compression)
-            compression_event = premis.create_premis_aip_compression_event(
-                event_detail, ""
-            )
-            # Since a new event has been created based on the new compression
-            # mechanism we reset the old decompression transforms
+            # Reset existing decompression transforms before setting new ones
+            # based on the current compression mechanism
             self._filter_and_remove_decompression_transforms(aip)
-            # Add the new compression event
-            aip.add_premis_event(compression_event)
             self._update_pointer_file(compression, mets, path=updated_aip_path)
         elif was_compressed:
             # AIP used to be compressed, but is no longer so delete pointer file

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -2717,7 +2717,7 @@ class Package(models.Model):
             transform_order = 2  # encryption is a prior transformation
         else:
             transform_order = 1
-        version, extension, program_name = utils.get_compression_transforms(
+        version, extension, program_name = utils.set_compression_transforms(
             aip, compression, transform_order
         )
         transform_count = len(aip.transform_files)


### PR DESCRIPTION
This PR removes a redundant PREMIS `compression` event in the pointer file of reingested AIPs.

An extra commit has been added to update the name and docstring of a helper used to set compression transforms on the AIP's `FSEntry`.

Connected to https://github.com/archivematica/Issues/issues/1062