### PR TITLE
Replicate AIP bag contents not container dir

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -610,7 +610,7 @@ class Package(models.Model):
         # Copy replicandum AIP from its source location to the SS
         src_space.move_to_storage_service(
             source_path=os.path.join(
-                replicandum_location.relative_path, replicandum_path
+                replicandum_location.relative_path, replicandum_path, ""
             ),
             destination_path=replica_package.current_path,
             destination_space=dest_space,


### PR DESCRIPTION
Ensure that during replication we're copying the AIP (bag) contents
and not the container directory. Copying the container directory
pushes the replicated structure one level further down than we expect
and so when we come to test for something, e.g. fixity, we cannot
find the structural aspects of the bag, e.g. manifests, to perform
validation.

Connected to archivematica/issues#1054