### PR TITLE
Package: convert size property to integer

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -909,6 +909,17 @@ class PackageResource(ModelResource):
         bundle.data["encrypted"] = encrypted
         return bundle
 
+    def dehydrate_size(self, bundle):
+        """Ensure that ``size`` is serialized as an integer.
+
+        This is needed because Tastypie doesn't know how to dehydrate
+        ``BigIntegerField`` (see django-tastypie/django-tastypie#299).
+        """
+        try:
+            return int(bundle.data["size"])
+        except (ValueError, TypeError, KeyError):
+            return 0
+
     def hydrate_current_location(self, bundle):
         """Customize unserialization of current_location.
 


### PR DESCRIPTION
Manually dehydrate `BigIntegerField` as an integer since Tastypie can't do
that for us (https://github.com/django-tastypie/django-tastypie/pull/299).

Connects to https://github.com/archivematica/Issues/issues/1094.