### PR TITLE
Ensure replication can store compressed AIPs 

### DIFF
--- a/storage_service/common/tests/test_utils.py
+++ b/storage_service/common/tests/test_utils.py
@@ -262,3 +262,31 @@ def test_get_format_info(compression, version, extension, program_name, transfor
     assert ext == extension
     assert program_name in prog_name
     assert fsentry.transform_files == transform
+
+
+@pytest.mark.parametrize(
+    "package_path,is_file",
+    [
+        (
+            "8ac0/d76b/b01e/47b1/8ca8/0fe8/0edb/e7b9/repl2-8ac0d76b-b01e-47b1-8ca8-0fe80edbe7b9.7z",
+            True,
+        ),
+        (
+            "cee5/a604/93d8/4253/a666/2f73/a19c/f835/repl13-cee5a604-93d8-4253-a666-2f73a19cf835.tar.gz",
+            True,
+        ),
+        (
+            "0eb3/ae66/2e7c/4982/bc85/23aa/697a/7dec/repl12-0eb3ae66-2e7c-4982-bc85-23aa697a7dec",
+            False,
+        ),
+        (
+            "ab9c/d802/7c7b/4377/8742/4685/d09b/6d75/repl11-ab9cd802-7c7b-4377-8742-4685d09b6d75.tar.bz2",
+            True,
+        ),
+    ],
+)
+def test_package_is_file(package_path, is_file):
+    """Ensure that we return is_file accurately for the types of path we will
+    see in the storage service.
+    """
+    assert utils.package_is_file(package_path) == is_file

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -632,3 +632,14 @@ def recalculate_size(rein_aip_internal_path):
     else:
         size = os.path.getsize(rein_aip_internal_path)
     return size
+
+
+def package_is_file(path):
+    """Rudimentary test to identify whether a path describes that of a file,
+    or a directory. As paths are usually abstract, i.e. stored in the database,
+    we can't (usually) simply test whether the object is a file on disk.
+    """
+    for ext in PACKAGE_EXTENSIONS:
+        if path.endswith(ext):
+            return True
+    return False

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -18,10 +18,12 @@ import re
 import scandir
 
 # This project, alphabetical
+from common import utils
 
 # This module, alphabetical
 from . import StorageException
 from .location import Location
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -207,6 +209,11 @@ class S3(models.Model):
         # strip leading slash on src_path
         src_path = src_path.lstrip("/").rstrip(".")
         dest_path = dest_path.rstrip(".")
+
+        # Directories need to have trailing slashes to ensure they are created
+        # on the staging path.
+        if not utils.package_is_file(dest_path):
+            dest_path = os.path.join(dest_path, "")
 
         objects = self.resource.Bucket(self.bucket_name).objects.filter(Prefix=src_path)
 


### PR DESCRIPTION
This PR corrects the previously introduced issue of not being able to detect the difference during replication between a file, e.g. `7z` package, vs. a directory, e.g. a standard bag. This would cause a transfer failure and only one of the two packages were stored. 

These changes match the current way that replication is implemented, but I feel that some refactoring can be done. 

**Updated 16 March 2020**

* https://github.com/artefactual/archivematica-storage-service/pull/524/commits/1c09d8b6dc3630763631bf86743dca9e75e6c04c sees the addition of a check to the S3 storage adapter that means staging path directories are created correctly. It therefore ensures that replication and fixity works as anticipated.

```
=======
Working
=======
NFS -> S3 (Compressed and Uncompressed) Fixity works on repl and orig.
NFS -> NFS (Compressed and Uncompressed) Fixity works on repl and orig.
S3 -> S3 (Compressed) Fixity works on repl and orig.
S3 -> NFS (Compressed) Fixity works on repl and orig.
S3 -> S3 (Uncompressed - Fixity works on repl and orig.
S3 -> NFS (Uncompressed - Fixity works on repl and orig.
```

I haven't been able to conceptualize a test for the S3 adapter in the time I have been looking at this today to make sure that this can be maintained properly. We might want to merge once a suitable test is in place. 

**10 March 2020**

This PR was incomplete, in that we did not capture all replication scenarios that exist in Archivematica now. I have described those below, and in the two failure states, the replication simply fails causing the ingest workflow to fail which is not ideal. Whomever picks this PR back up, might choose to base their work on what is here. Or may opt for something new. Its unfortunate I haven't been able to execute a solution at this time. 

```
=======
Working
=======
NFS -> S3 (Compressed and Uncompressed) Fixity works on repl and orig.
NFS -> NFS (Compressed and Uncompressed) Fixity works on repl and orig.
S3 -> S3 (Compressed) Fixity works on repl and orig.
S3 -> NFS (Compressed) Fixity works on repl and orig.
===========
Not working
===========
S3 -> S3 (Uncompressed - replicated package doesn't store, AIP does) Fixity works on orig.
S3 -> NFS (Uncompressed - replicated package doesn't store, AIP does) Fixity works on orig.
```
These replication configurations may form a test plan for acceptance of any fix here. 

I haven't been able to discern if it would be more desirable to simply undo https://github.com/artefactual/archivematica-storage-service/commit/9778b0fbcc842d6104df5c02926ae3e033209dbb until a later date or if it's just that now we're probing at replication we're seeing the implementation isn't quite right. IDK. 

Connected to archivematica/issues#1054 
Connected to archivematica/issues#1149
