### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -25,7 +25,7 @@ requests==2.21.0
 requests-oauthlib==1.2.0
 sword2==0.2.1
 whitenoise==3.3.0
-agentarchives==0.4.0
+agentarchives==0.6.0
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
 prometheus_client==0.7.1
 django-prometheus==1.0.15

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=base.txt base.in
 #
-agentarchives==0.4.0
+agentarchives==0.6.0
 babel==2.7.0              # via oslo.i18n
 bagit==1.7.0
 boto3==1.9.174

--- a/requirements/local.in
+++ b/requirements/local.in
@@ -12,4 +12,4 @@ psycopg2==2.7.1
 # For managing translation strings on Transifex
 transifex-client==0.12.2
 
-pip-tools==4.3.0
+pip-tools==5.1.2

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=local.txt local.in
 #
-agentarchives==0.4.0
+agentarchives==0.6.0
 babel==2.7.0
 bagit==1.7.0
 boto3==1.9.174
@@ -60,7 +60,7 @@ oslo.serialization==2.29.2
 oslo.utils==3.42.1
 pathlib2==2.3.5
 pbr==5.4.4
-pip-tools==4.3.0
+pip-tools==5.1.2
 positional==1.2.1
 prometheus-client==0.7.1
 psycopg2==2.7.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=production.txt production.in
 #
-agentarchives==0.4.0
+agentarchives==0.6.0
 babel==2.7.0
 bagit==1.7.0
 boto3==1.9.174

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=test.txt test.in
 #
-agentarchives==0.4.0
+agentarchives==0.6.0
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via jsonschema, pytest
 aws-sam-translator==1.19.1  # via cfn-lint
@@ -145,6 +145,3 @@ whitenoise==3.3.0
 wrapt==1.11.2
 xmltodict==0.12.0         # via moto
 zipp==0.6.0               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
- Use the latest version of agentarchives.
- Upgrade pip-tools to be able to compile that upgrade.

Refs https://github.com/archivematica/Issues/issues/813.