### PR TITLE
Update how integration worfklow triggers

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,10 @@
 name: Integration
 on:
-- push
-- pull_request
+  pull_request:
+  push:
+    branches:
+    - qa/**
+    - stable/**
 jobs:
   integration:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Change the way that the integration workflow is triggered. We want to trigger
the workflow on push and pull requests but only for the qa and stable branches.

Connects to https://github.com/archivematica/Issues/issues/1149.