### PR TITLE
Update link to contributing agreement (SS)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,10 +134,15 @@ You can alter the commit history of a branch using git's powerful [interactive r
 
 ## Contributor's Agreement
 
-In order for the Archivematica development team to accept any patches or code commits, contributors must first sign this [Contributor's Agreement](https://wiki.archivematica.org/images/2/25/Contributor_agreement.txt).
-The Archivematica contributor's agreement is based almost verbatim on the [Apache Foundation](http://apache.org )'s individual [contributor license](http://www.apache.org/licenses/icla.txt).
+In order for the Archivematica development team to accept any patches or code
+commits, contributors must first sign this
+[Contributor's Agreement](https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf).
+The Archivematica contributor's agreement is based almost verbatim on the
+[Apache Foundation](http://apache.org )'s individual
+[contributor license](http://www.apache.org/licenses/icla.txt).
 
-If you have any questions or concerns about the Contributor's Agreement, please email us at agreement@artefactual.com to discuss them.
+If you have any questions or concerns about the Contributor's Agreement,
+please email us at agreement@artefactual.com to discuss them.
 
 ### Why do I have to sign a Contributor's Agreement?
 
@@ -151,8 +156,11 @@ This ensures our resources are devoted to making our project the best they can b
 
 ### How do I send in an agreement?
 
-Please print out, read, sign, and scan the [contributor agreement](https://wiki.archivematica.org/images/2/25/Contributor_agreement.txt) and email it to agreement@artefactual.com
-Alternatively, you may send an original signed agreement to:
+Please read and sign the
+[contributor agreement](https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf)
+and email it to agreement@artefactual.com.
+
+Alternatively, you may send a printed, signed agreement to:
 
     Artefactual Systems Inc.
     201 - 301 Sixth Street


### PR DESCRIPTION
Now points to a fillable PDF rather than the .txt file we had before.

I copied the sections verbatim from `artefactual/archivematica/CONTRIBUTING.md` so the formatting is a little different, but the text should be identical.