### PR TITLE
Update requirements against pip-compile 5.1.2

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,6 +11,7 @@ django-tastypie==0.14.3
 futures==3.3.0; python_version < '3.0'  # used by gunicorn's async workers
 gevent==1.3.6  # used by gunicorn's async workers
 gunicorn==19.9.0
+importlib_resources~=1.4
 jsonfield==2.0.1
 logutils==0.3.4.1
 lxml==3.7.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,48 +4,52 @@
 #
 #    pip-compile --output-file=base.txt base.in
 #
-agentarchives==0.6.0
+agentarchives==0.6.0      # via -r base.in
 babel==2.8.0              # via oslo.i18n
-bagit==1.7.0
-boto3==1.9.174
-botocore==1.12.253
-brotli==0.5.2
-certifi==2020.4.5.1       # via requests
+bagit==1.7.0              # via -r base.in
+boto3==1.9.174            # via -r base.in
+botocore==1.12.253        # via -r base.in, boto3, s3transfer
+brotli==0.5.2             # via -r base.in
+certifi==2020.6.20        # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, zipp
 cryptography==2.9.2       # via pyopenssl
 debtcollector==1.22.0     # via oslo.config, oslo.utils, python-keystoneclient
-defusedxml==0.5.0
-django-auth-ldap==1.3.0
-django-extensions==1.7.9
-django-prometheus==1.0.15
-git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
-django-tastypie==0.14.3
-django==1.11.29
+defusedxml==0.5.0         # via -r base.in
+django-auth-ldap==1.3.0   # via -r base.in
+django-extensions==1.7.9  # via -r base.in
+django-prometheus==1.0.15  # via -r base.in
+git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.in
+django-tastypie==0.14.3   # via -r base.in
+django==1.11.29           # via -r base.in, django-auth-ldap, jsonfield
 docutils==0.15.2          # via botocore
 enum34==1.1.10            # via cryptography, oslo.config
 funcsigs==1.0.2           # via debtcollector, oslo.utils
 future==0.18.2            # via metsrw
-futures==3.3.0 ; python_version < "3.0"
-gevent==1.3.6
-greenlet==0.4.15          # via gevent
-gunicorn==19.9.0
+futures==3.3.0 ; python_version < "3.0"  # via -r base.in, python-swiftclient, s3transfer
+gevent==1.3.6             # via -r base.in
+greenlet==0.4.16          # via gevent
+gunicorn==19.9.0          # via -r base.in
 httplib2==0.18.1          # via sword2
 idna==2.8                 # via requests
+importlib-metadata==1.7.0  # via importlib-resources
+importlib-resources==1.5.0  # via -r base.in, netaddr
 ipaddress==1.0.23         # via cryptography
 iso8601==0.1.12           # via keystoneauth1, oslo.utils
 jmespath==0.10.0          # via boto3, botocore
-jsonfield==2.0.1
-keystoneauth1==4.0.0      # via python-keystoneclient
-logutils==0.3.4.1
-git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
-lxml==3.7.3
-metsrw==0.3.15
+jsonfield==2.0.1          # via -r base.in
+keystoneauth1==4.0.1      # via python-keystoneclient
+logutils==0.3.4.1         # via -r base.in
+git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername  # via -r base.in
+lxml==3.7.3               # via -r base.in, metsrw
+metsrw==0.3.15            # via -r base.in
 monotonic==1.5            # via oslo.utils
 msgpack==1.0.0            # via oslo.serialization
 mysqlclient==1.4.6        # via agentarchives
-ndg-httpsclient==0.4.2
-netaddr==0.7.19           # via oslo.config, oslo.utils
+ndg-httpsclient==0.4.2    # via -r base.in
+netaddr==0.8.0            # via oslo.config, oslo.utils
 netifaces==0.10.9         # via oslo.utils
 oauthlib==3.1.0           # via requests-oauthlib
 os-service-types==1.7.0   # via keystoneauth1
@@ -53,31 +57,34 @@ oslo.config==7.0.0        # via python-keystoneclient
 oslo.i18n==3.25.1         # via oslo.config, oslo.utils, python-keystoneclient
 oslo.serialization==2.29.2  # via python-keystoneclient
 oslo.utils==3.42.1        # via oslo.serialization, python-keystoneclient
-pathlib2==2.3.5 ; python_version < "3.0"
+pathlib2==2.3.5 ; python_version < "3.0"  # via -r base.in, importlib-metadata, importlib-resources
 pbr==5.4.5                # via debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
 positional==1.2.1         # via python-keystoneclient
-prometheus-client==0.7.1
+prometheus-client==0.7.1  # via -r base.in, django-prometheus
 pyasn1-modules==0.2.8     # via python-ldap
 pyasn1==0.4.8             # via pyasn1-modules, python-ldap
 pycparser==2.20           # via cffi
 pyopenssl==19.1.0         # via ndg-httpsclient
 pyparsing==2.4.7          # via oslo.utils
 python-dateutil==2.8.1    # via botocore, django-tastypie
-python-gnupg==0.4.0
-python-keystoneclient==3.10.0
-python-ldap==3.2.0
+python-gnupg==0.4.0       # via -r base.in
+python-keystoneclient==3.10.0  # via -r base.in
+python-ldap==3.2.0        # via -r base.in, django-auth-ldap
 python-mimeparse==1.6.0   # via django-tastypie
-python-swiftclient==3.3.0
+python-swiftclient==3.3.0  # via -r base.in
 pytz==2020.1              # via babel, django, oslo.serialization, oslo.utils
 pyyaml==5.3.1             # via oslo.config, oslo.serialization
-requests-oauthlib==1.2.0
-requests==2.21.0
+requests-oauthlib==1.2.0  # via -r base.in
+requests==2.21.0          # via -r base.in, agentarchives, keystoneauth1, oslo.config, python-keystoneclient, python-swiftclient, requests-oauthlib
 rfc3986==1.4.0            # via oslo.config
 s3transfer==0.2.1         # via boto3
-scandir==1.10.0
-six==1.15.0               # via cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, stevedore
+scandir==1.10.0           # via -r base.in, pathlib2
+singledispatch==3.4.0.3   # via importlib-resources
+six==1.15.0               # via cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore
 stevedore==1.32.0         # via keystoneauth1, oslo.config, python-keystoneclient
-sword2==0.2.1
+sword2==0.2.1             # via -r base.in
+typing==3.7.4.2           # via importlib-resources
 urllib3==1.24.3           # via botocore, requests
-whitenoise==3.3.0
+whitenoise==3.3.0         # via -r base.in
 wrapt==1.12.1             # via debtcollector, positional
+zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,93 +4,100 @@
 #
 #    pip-compile --output-file=local.txt local.in
 #
-agentarchives==0.6.0
-babel==2.8.0
-bagit==1.7.0
-boto3==1.9.174
-botocore==1.12.253
-brotli==0.5.2
-certifi==2020.4.5.1
-cffi==1.14.0
-chardet==3.0.4
+agentarchives==0.6.0      # via -r base.txt
+babel==2.8.0              # via -r base.txt, oslo.i18n
+bagit==1.7.0              # via -r base.txt
+boto3==1.9.174            # via -r base.txt
+botocore==1.12.253        # via -r base.txt, boto3, s3transfer
+brotli==0.5.2             # via -r base.txt
+certifi==2020.6.20        # via -r base.txt, requests
+cffi==1.14.0              # via -r base.txt, cryptography
+chardet==3.0.4            # via -r base.txt, requests
 click==7.1.2              # via pip-tools
-cryptography==2.9.2
-debtcollector==1.22.0
-defusedxml==0.5.0
-dj-database-url==0.4.2
-django-auth-ldap==1.3.0
-django-extensions==1.7.9
-django-prometheus==1.0.15
-git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
-django-tastypie==0.14.3
-django==1.11.29
-docutils==0.15.2
-enum34==1.1.10
-funcsigs==1.0.2
-future==0.18.2
-futures==3.3.0 ; python_version < "3.0"
-gevent==1.3.6
-greenlet==0.4.15
-gunicorn==19.9.0
-httplib2==0.18.1
-idna==2.8
-ipaddress==1.0.23
-ipython==1.1.0
-iso8601==0.1.12
+configparser==4.0.2       # via -r base.txt, importlib-metadata
+contextlib2==0.6.0.post1  # via -r base.txt, importlib-metadata, importlib-resources, zipp
+cryptography==2.9.2       # via -r base.txt, pyopenssl
+debtcollector==1.22.0     # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
+defusedxml==0.5.0         # via -r base.txt
+dj-database-url==0.4.2    # via -r local.in
+django-auth-ldap==1.3.0   # via -r base.txt
+django-extensions==1.7.9  # via -r base.txt
+django-prometheus==1.0.15  # via -r base.txt
+git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
+django-tastypie==0.14.3   # via -r base.txt
+django==1.11.29           # via -r base.txt, django-auth-ldap, jsonfield
+docutils==0.15.2          # via -r base.txt, botocore, sphinx
+enum34==1.1.10            # via -r base.txt, cryptography, oslo.config
+funcsigs==1.0.2           # via -r base.txt, debtcollector, oslo.utils
+future==0.18.2            # via -r base.txt, metsrw
+futures==3.3.0 ; python_version < "3.0"  # via -r base.txt, python-swiftclient, s3transfer
+gevent==1.3.6             # via -r base.txt
+greenlet==0.4.16          # via -r base.txt, gevent
+gunicorn==19.9.0          # via -r base.txt
+httplib2==0.18.1          # via -r base.txt, sword2
+idna==2.8                 # via -r base.txt, requests
+importlib-metadata==1.7.0  # via -r base.txt, importlib-resources
+importlib-resources==1.5.0  # via -r base.txt, netaddr
+ipaddress==1.0.23         # via -r base.txt, cryptography
+ipython==1.1.0            # via -r local.in
+iso8601==0.1.12           # via -r base.txt, keystoneauth1, oslo.utils
 jinja2==2.11.2            # via sphinx
-jmespath==0.10.0
-jsonfield==2.0.1
-keystoneauth1==4.0.0
-logutils==0.3.4.1
-git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
-lxml==3.7.3
+jmespath==0.10.0          # via -r base.txt, boto3, botocore
+jsonfield==2.0.1          # via -r base.txt
+keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
+logutils==0.3.4.1         # via -r base.txt
+git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername  # via -r base.txt
+lxml==3.7.3               # via -r base.txt, metsrw
 markupsafe==1.1.1         # via jinja2
-metsrw==0.3.15
-monotonic==1.5
-msgpack==1.0.0
-mysqlclient==1.4.6
-ndg-httpsclient==0.4.2
-netaddr==0.7.19
-netifaces==0.10.9
-oauthlib==3.1.0
-os-service-types==1.7.0
-oslo.config==7.0.0
-oslo.i18n==3.25.1
-oslo.serialization==2.29.2
-oslo.utils==3.42.1
-pathlib2==2.3.5 ; python_version < "3.0"
-pbr==5.4.5
-pip-tools==5.1.2
-positional==1.2.1
-prometheus-client==0.7.1
-psycopg2==2.7.1
-pyasn1-modules==0.2.8
-pyasn1==0.4.8
-pycparser==2.20
+metsrw==0.3.15            # via -r base.txt
+monotonic==1.5            # via -r base.txt, oslo.utils
+msgpack==1.0.0            # via -r base.txt, oslo.serialization
+mysqlclient==1.4.6        # via -r base.txt, agentarchives
+ndg-httpsclient==0.4.2    # via -r base.txt
+netaddr==0.8.0            # via -r base.txt, oslo.config, oslo.utils
+netifaces==0.10.9         # via -r base.txt, oslo.utils
+oauthlib==3.1.0           # via -r base.txt, requests-oauthlib
+os-service-types==1.7.0   # via -r base.txt, keystoneauth1
+oslo.config==7.0.0        # via -r base.txt, python-keystoneclient
+oslo.i18n==3.25.1         # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
+oslo.serialization==2.29.2  # via -r base.txt, python-keystoneclient
+oslo.utils==3.42.1        # via -r base.txt, oslo.serialization, python-keystoneclient
+pathlib2==2.3.5 ; python_version < "3.0"  # via -r base.txt, importlib-metadata, importlib-resources
+pbr==5.4.5                # via -r base.txt, debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
+pip-tools==5.1.2          # via -r local.in
+positional==1.2.1         # via -r base.txt, python-keystoneclient
+prometheus-client==0.7.1  # via -r base.txt, django-prometheus
+psycopg2==2.7.1           # via -r local.in
+pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
+pyasn1==0.4.8             # via -r base.txt, pyasn1-modules, python-ldap
+pycparser==2.20           # via -r base.txt, cffi
 pygments==2.5.2           # via sphinx
-pyopenssl==19.1.0
-pyparsing==2.4.7
-python-dateutil==2.8.1
-python-gnupg==0.4.0
-python-keystoneclient==3.10.0
-python-ldap==3.2.0
-python-mimeparse==1.6.0
-python-swiftclient==3.3.0
-pytz==2020.1
-pyyaml==5.3.1
-requests-oauthlib==1.2.0
-requests==2.21.0
-rfc3986==1.4.0
-s3transfer==0.2.1
-scandir==1.10.0
-six==1.15.0
-sphinx==1.2b1
-stevedore==1.32.0
-sword2==0.2.1
-transifex-client==0.12.2
-urllib3==1.24.3
-whitenoise==3.3.0
-wrapt==1.12.1
+pyopenssl==19.1.0         # via -r base.txt, ndg-httpsclient
+pyparsing==2.4.7          # via -r base.txt, oslo.utils
+python-dateutil==2.8.1    # via -r base.txt, botocore, django-tastypie
+python-gnupg==0.4.0       # via -r base.txt
+python-keystoneclient==3.10.0  # via -r base.txt
+python-ldap==3.2.0        # via -r base.txt, django-auth-ldap
+python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
+python-swiftclient==3.3.0  # via -r base.txt
+pytz==2020.1              # via -r base.txt, babel, django, oslo.serialization, oslo.utils
+pyyaml==5.3.1             # via -r base.txt, oslo.config, oslo.serialization
+requests-oauthlib==1.2.0  # via -r base.txt
+requests==2.21.0          # via -r base.txt, agentarchives, keystoneauth1, oslo.config, python-keystoneclient, python-swiftclient, requests-oauthlib
+rfc3986==1.4.0            # via -r base.txt, oslo.config
+s3transfer==0.2.1         # via -r base.txt, boto3
+scandir==1.10.0           # via -r base.txt, pathlib2
+singledispatch==3.4.0.3   # via -r base.txt, importlib-resources
+six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore, transifex-client
+sphinx==1.2b1             # via -r local.in
+stevedore==1.32.0         # via -r base.txt, keystoneauth1, oslo.config, python-keystoneclient
+sword2==0.2.1             # via -r base.txt
+transifex-client==0.12.2  # via -r local.in
+typing==3.7.4.2           # via -r base.txt, importlib-resources
+urllib3==1.24.3           # via -r base.txt, botocore, requests, transifex-client
+whitenoise==3.3.0         # via -r base.txt
+wrapt==1.12.1             # via -r base.txt, debtcollector, positional
+zipp==1.2.0               # via -r base.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,82 +4,89 @@
 #
 #    pip-compile --output-file=production.txt production.in
 #
-agentarchives==0.6.0
-babel==2.8.0
-bagit==1.7.0
-boto3==1.9.174
-botocore==1.12.253
-brotli==0.5.2
-certifi==2020.4.5.1
-cffi==1.14.0
-chardet==3.0.4
-cryptography==2.9.2
-debtcollector==1.22.0
-defusedxml==0.5.0
-dj-database-url==0.4.2
-django-auth-ldap==1.3.0
-django-extensions==1.7.9
-django-prometheus==1.0.15
-git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
-django-tastypie==0.14.3
-django==1.11.29
-docutils==0.15.2
-enum34==1.1.10
-funcsigs==1.0.2
-future==0.18.2
-futures==3.3.0 ; python_version < "3.0"
-gevent==1.3.6
-greenlet==0.4.15
-gunicorn==19.9.0
-httplib2==0.18.1
-idna==2.8
-ipaddress==1.0.23
-iso8601==0.1.12
-jmespath==0.10.0
-jsonfield==2.0.1
-keystoneauth1==4.0.0
-logutils==0.3.4.1
-git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
-lxml==3.7.3
-metsrw==0.3.15
-monotonic==1.5
-msgpack==1.0.0
-mysqlclient==1.4.6
-ndg-httpsclient==0.4.2
-netaddr==0.7.19
-netifaces==0.10.9
-oauthlib==3.1.0
-os-service-types==1.7.0
-oslo.config==7.0.0
-oslo.i18n==3.25.1
-oslo.serialization==2.29.2
-oslo.utils==3.42.1
-pathlib2==2.3.5 ; python_version < "3.0"
-pbr==5.4.5
-positional==1.2.1
-prometheus-client==0.7.1
-psycopg2==2.7.1
-pyasn1-modules==0.2.8
-pyasn1==0.4.8
-pycparser==2.20
-pyopenssl==19.1.0
-pyparsing==2.4.7
-python-dateutil==2.8.1
-python-gnupg==0.4.0
-python-keystoneclient==3.10.0
-python-ldap==3.2.0
-python-mimeparse==1.6.0
-python-swiftclient==3.3.0
-pytz==2020.1
-pyyaml==5.3.1
-requests-oauthlib==1.2.0
-requests==2.21.0
-rfc3986==1.4.0
-s3transfer==0.2.1
-scandir==1.10.0
-six==1.15.0
-stevedore==1.32.0
-sword2==0.2.1
-urllib3==1.24.3
-whitenoise==3.3.0
-wrapt==1.12.1
+agentarchives==0.6.0      # via -r base.txt
+babel==2.8.0              # via -r base.txt, oslo.i18n
+bagit==1.7.0              # via -r base.txt
+boto3==1.9.174            # via -r base.txt
+botocore==1.12.253        # via -r base.txt, boto3, s3transfer
+brotli==0.5.2             # via -r base.txt
+certifi==2020.6.20        # via -r base.txt, requests
+cffi==1.14.0              # via -r base.txt, cryptography
+chardet==3.0.4            # via -r base.txt, requests
+configparser==4.0.2       # via -r base.txt, importlib-metadata
+contextlib2==0.6.0.post1  # via -r base.txt, importlib-metadata, importlib-resources, zipp
+cryptography==2.9.2       # via -r base.txt, pyopenssl
+debtcollector==1.22.0     # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
+defusedxml==0.5.0         # via -r base.txt
+dj-database-url==0.4.2    # via -r production.in
+django-auth-ldap==1.3.0   # via -r base.txt
+django-extensions==1.7.9  # via -r base.txt
+django-prometheus==1.0.15  # via -r base.txt
+git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
+django-tastypie==0.14.3   # via -r base.txt
+django==1.11.29           # via -r base.txt, django-auth-ldap, jsonfield
+docutils==0.15.2          # via -r base.txt, botocore
+enum34==1.1.10            # via -r base.txt, cryptography, oslo.config
+funcsigs==1.0.2           # via -r base.txt, debtcollector, oslo.utils
+future==0.18.2            # via -r base.txt, metsrw
+futures==3.3.0 ; python_version < "3.0"  # via -r base.txt, python-swiftclient, s3transfer
+gevent==1.3.6             # via -r base.txt
+greenlet==0.4.16          # via -r base.txt, gevent
+gunicorn==19.9.0          # via -r base.txt
+httplib2==0.18.1          # via -r base.txt, sword2
+idna==2.8                 # via -r base.txt, requests
+importlib-metadata==1.7.0  # via -r base.txt, importlib-resources
+importlib-resources==1.5.0  # via -r base.txt, netaddr
+ipaddress==1.0.23         # via -r base.txt, cryptography
+iso8601==0.1.12           # via -r base.txt, keystoneauth1, oslo.utils
+jmespath==0.10.0          # via -r base.txt, boto3, botocore
+jsonfield==2.0.1          # via -r base.txt
+keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
+logutils==0.3.4.1         # via -r base.txt
+git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername  # via -r base.txt
+lxml==3.7.3               # via -r base.txt, metsrw
+metsrw==0.3.15            # via -r base.txt
+monotonic==1.5            # via -r base.txt, oslo.utils
+msgpack==1.0.0            # via -r base.txt, oslo.serialization
+mysqlclient==1.4.6        # via -r base.txt, agentarchives
+ndg-httpsclient==0.4.2    # via -r base.txt
+netaddr==0.8.0            # via -r base.txt, oslo.config, oslo.utils
+netifaces==0.10.9         # via -r base.txt, oslo.utils
+oauthlib==3.1.0           # via -r base.txt, requests-oauthlib
+os-service-types==1.7.0   # via -r base.txt, keystoneauth1
+oslo.config==7.0.0        # via -r base.txt, python-keystoneclient
+oslo.i18n==3.25.1         # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
+oslo.serialization==2.29.2  # via -r base.txt, python-keystoneclient
+oslo.utils==3.42.1        # via -r base.txt, oslo.serialization, python-keystoneclient
+pathlib2==2.3.5 ; python_version < "3.0"  # via -r base.txt, importlib-metadata, importlib-resources
+pbr==5.4.5                # via -r base.txt, debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
+positional==1.2.1         # via -r base.txt, python-keystoneclient
+prometheus-client==0.7.1  # via -r base.txt, django-prometheus
+psycopg2==2.7.1           # via -r production.in
+pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
+pyasn1==0.4.8             # via -r base.txt, pyasn1-modules, python-ldap
+pycparser==2.20           # via -r base.txt, cffi
+pyopenssl==19.1.0         # via -r base.txt, ndg-httpsclient
+pyparsing==2.4.7          # via -r base.txt, oslo.utils
+python-dateutil==2.8.1    # via -r base.txt, botocore, django-tastypie
+python-gnupg==0.4.0       # via -r base.txt
+python-keystoneclient==3.10.0  # via -r base.txt
+python-ldap==3.2.0        # via -r base.txt, django-auth-ldap
+python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
+python-swiftclient==3.3.0  # via -r base.txt
+pytz==2020.1              # via -r base.txt, babel, django, oslo.serialization, oslo.utils
+pyyaml==5.3.1             # via -r base.txt, oslo.config, oslo.serialization
+requests-oauthlib==1.2.0  # via -r base.txt
+requests==2.21.0          # via -r base.txt, agentarchives, keystoneauth1, oslo.config, python-keystoneclient, python-swiftclient, requests-oauthlib
+rfc3986==1.4.0            # via -r base.txt, oslo.config
+s3transfer==0.2.1         # via -r base.txt, boto3
+scandir==1.10.0           # via -r base.txt, pathlib2
+singledispatch==3.4.0.3   # via -r base.txt, importlib-resources
+six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore
+stevedore==1.32.0         # via -r base.txt, keystoneauth1, oslo.config, python-keystoneclient
+sword2==0.2.1             # via -r base.txt
+typing==3.7.4.2           # via -r base.txt, importlib-resources
+urllib3==1.24.3           # via -r base.txt, botocore, requests
+whitenoise==3.3.0         # via -r base.txt
+wrapt==1.12.1             # via -r base.txt, debtcollector, positional
+zipp==1.2.0               # via -r base.txt, importlib-metadata, importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,152 +4,153 @@
 #
 #    pip-compile --output-file=test.txt test.in
 #
-agentarchives==0.6.0
+agentarchives==0.6.0      # via -r base.txt
 appdirs==1.4.4            # via virtualenv
 atomicwrites==1.4.0       # via pytest
 attrs==19.3.0             # via jsonschema, pytest
-aws-sam-translator==1.23.0  # via cfn-lint
-aws-xray-sdk==2.5.0       # via moto
-babel==2.8.0
+aws-sam-translator==1.25.0  # via cfn-lint
+aws-xray-sdk==2.6.0       # via moto
+babel==2.8.0              # via -r base.txt, oslo.i18n
+backports.functools-lru-cache==1.6.1  # via wcwidth
 backports.shutil-get-terminal-size==1.0.0  # via ipython
 backports.ssl-match-hostname==3.7.0.1  # via docker
 backports.tempfile==1.0   # via moto
 backports.weakref==1.0.post1  # via backports.tempfile
-bagit==1.7.0
-boto3==1.9.174
+bagit==1.7.0              # via -r base.txt
+boto3==1.9.174            # via -r base.txt, aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.253
-brotli==0.5.2
-certifi==2020.4.5.1
-cffi==1.14.0
-cfn-lint==0.32.1          # via moto
-chardet==3.0.4
+botocore==1.12.253        # via -r base.txt, aws-xray-sdk, boto3, moto, s3transfer
+brotli==0.5.2             # via -r base.txt
+certifi==2020.6.20        # via -r base.txt, requests
+cffi==1.14.0              # via -r base.txt, cryptography
+cfn-lint==0.33.2          # via moto
+chardet==3.0.4            # via -r base.txt, requests
 click==7.1.2              # via pip-tools
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, vcrpy, virtualenv, zipp
+configparser==4.0.2       # via -r base.txt, importlib-metadata
+contextlib2==0.6.0.post1  # via -r base.txt, importlib-metadata, importlib-resources, vcrpy, zipp
 cookies==2.2.1            # via responses
-coverage==4.2
-cryptography==2.9.2
-debtcollector==1.22.0
+coverage==4.2             # via -r test.in, pytest-cov
+cryptography==2.9.2       # via -r base.txt, moto, pyopenssl
+debtcollector==1.22.0     # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
 decorator==4.4.2          # via ipython, networkx, traitlets
-defusedxml==0.5.0
-distlib==0.3.0            # via virtualenv
-django-auth-ldap==1.3.0
-django-extensions==1.7.9
-django-prometheus==1.0.15
-git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
-django-tastypie==0.14.3
-django==1.11.29
-docker==4.2.0             # via moto
-docutils==0.15.2
+defusedxml==0.5.0         # via -r base.txt
+distlib==0.3.1            # via virtualenv
+django-auth-ldap==1.3.0   # via -r base.txt
+django-extensions==1.7.9  # via -r base.txt
+django-prometheus==1.0.15  # via -r base.txt
+git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
+django-tastypie==0.14.3   # via -r base.txt
+django==1.11.29           # via -r base.txt, django-auth-ldap, jsonfield
+docker==4.2.2             # via moto
+docutils==0.15.2          # via -r base.txt, botocore
 ecdsa==0.15               # via python-jose
-enum34==1.1.10
+enum34==1.1.10            # via -r base.txt, aws-sam-translator, aws-xray-sdk, cryptography, oslo.config, traitlets
 filelock==3.0.12          # via tox, virtualenv
-funcsigs==1.0.2
-functools32==3.2.3.post2 ; python_version < "3.0"
-future==0.18.2
-futures==3.3.0 ; python_version < "3.0"
-gevent==1.3.6
-greenlet==0.4.15
-gunicorn==19.9.0
-httplib2==0.18.1
-idna==2.8
-importlib-metadata==1.6.0  # via importlib-resources, jsonpickle, jsonschema, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via cfn-lint, virtualenv
-ipaddress==1.0.23
-ipdb==0.13.2
+funcsigs==1.0.2           # via -r base.txt, debtcollector, mock, oslo.utils, pytest
+functools32==3.2.3.post2 ; python_version < "3.0"  # via -r test.in, jsonschema
+future==0.18.2            # via -r base.txt, aws-xray-sdk, metsrw
+futures==3.3.0 ; python_version < "3.0"  # via -r base.txt, python-swiftclient, s3transfer
+gevent==1.3.6             # via -r base.txt
+greenlet==0.4.16          # via -r base.txt, gevent
+gunicorn==19.9.0          # via -r base.txt
+httplib2==0.18.1          # via -r base.txt, sword2
+idna==2.8                 # via -r base.txt, moto, requests
+importlib-metadata==1.7.0  # via -r base.txt, importlib-resources, jsonpickle, jsonschema, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via -r base.txt, cfn-lint, netaddr, virtualenv
+ipaddress==1.0.23         # via -r base.txt, cryptography, docker
+ipdb==0.13.3              # via -r test.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.10.0           # via ipdb
-iso8601==0.1.12
+iso8601==0.1.12           # via -r base.txt, keystoneauth1, oslo.utils
 jinja2==2.11.2            # via moto
-jmespath==0.10.0
+jmespath==0.10.0          # via -r base.txt, boto3, botocore
 jsondiff==1.1.2           # via moto
-jsonfield==2.0.1
-jsonpatch==1.25           # via cfn-lint
+jsonfield==2.0.1          # via -r base.txt
+jsonpatch==1.26           # via cfn-lint
 jsonpickle==1.4.1         # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
 jsonschema==3.2.0         # via aws-sam-translator, cfn-lint
 junit-xml==1.9            # via cfn-lint
-keystoneauth1==4.0.0
-logutils==0.3.4.1
-git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
-lxml==3.7.3
+keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
+logutils==0.3.4.1         # via -r base.txt
+git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername  # via -r base.txt
+lxml==3.7.3               # via -r base.txt, metsrw
 markupsafe==1.1.1         # via jinja2
-metsrw==0.3.15
+metsrw==0.3.15            # via -r base.txt
 mock==3.0.5               # via moto, pytest-mock, responses, vcrpy
-monotonic==1.5
+monotonic==1.5            # via -r base.txt, oslo.utils
 more-itertools==5.0.0     # via pytest
-moto==1.3.8
-msgpack==1.0.0
-mysqlclient==1.4.6
-ndg-httpsclient==0.4.2
-netaddr==0.7.19
-netifaces==0.10.9
+moto==1.3.8               # via -r test.in
+msgpack==1.0.0            # via -r base.txt, oslo.serialization
+mysqlclient==1.4.6        # via -r base.txt, agentarchives
+ndg-httpsclient==0.4.2    # via -r base.txt
+netaddr==0.8.0            # via -r base.txt, oslo.config, oslo.utils
+netifaces==0.10.9         # via -r base.txt, oslo.utils
 networkx==2.2             # via cfn-lint
-oauthlib==3.1.0
-os-service-types==1.7.0
-oslo.config==7.0.0
-oslo.i18n==3.25.1
-oslo.serialization==2.29.2
-oslo.utils==3.42.1
+oauthlib==3.1.0           # via -r base.txt, requests-oauthlib
+os-service-types==1.7.0   # via -r base.txt, keystoneauth1
+oslo.config==7.0.0        # via -r base.txt, python-keystoneclient
+oslo.i18n==3.25.1         # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
+oslo.serialization==2.29.2  # via -r base.txt, python-keystoneclient
+oslo.utils==3.42.1        # via -r base.txt, oslo.serialization, python-keystoneclient
 packaging==20.4           # via tox
-pathlib2==2.3.5 ; python_version < "3.0"
-pbr==5.4.5
+pathlib2==2.3.5 ; python_version < "3.0"  # via -r base.txt, cfn-lint, importlib-metadata, importlib-resources, ipython, pickleshare, pytest, pytest-django, virtualenv
+pbr==5.4.5                # via -r base.txt, debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==3.7.0
+pip-tools==3.7.0          # via -r test.in
 pluggy==0.13.1            # via pytest, tox
-positional==1.2.1
-prometheus-client==0.7.1
+positional==1.2.1         # via -r base.txt, python-keystoneclient
+prometheus-client==0.7.1  # via -r base.txt, django-prometheus
 prompt-toolkit==1.0.18    # via ipython
 ptyprocess==0.6.0         # via pexpect
-py==1.8.1                 # via pytest, tox
-pyasn1-modules==0.2.8
-pyasn1==0.4.8
-pycparser==2.20
+py==1.9.0                 # via pytest, tox
+pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
+pyasn1==0.4.8             # via -r base.txt, pyasn1-modules, python-jose, python-ldap, rsa
+pycparser==2.20           # via -r base.txt, cffi
 pygments==2.5.2           # via ipython
-pyopenssl==19.1.0
-pyparsing==2.4.7
+pyopenssl==19.1.0         # via -r base.txt, ndg-httpsclient
+pyparsing==2.4.7          # via -r base.txt, oslo.utils, packaging
 pyrsistent==0.16.0        # via jsonschema
-pytest-cov==2.4.0
-pytest-django==3.9.0
-pytest-mock==1.13.0
-pytest==3.8.0
-python-dateutil==2.8.1
-python-gnupg==0.4.0
+pytest-cov==2.4.0         # via -r test.in
+pytest-django==3.9.0      # via -r test.in
+pytest-mock==1.13.0       # via -r test.in
+pytest==3.8.0             # via -r test.in, pytest-cov, pytest-django, pytest-mock
+python-dateutil==2.8.1    # via -r base.txt, botocore, django-tastypie, moto
+python-gnupg==0.4.0       # via -r base.txt
 python-jose==3.1.0        # via moto
-python-keystoneclient==3.10.0
-python-ldap==3.2.0
-python-mimeparse==1.6.0
-python-swiftclient==3.3.0
-pytz==2020.1
-pyyaml==5.3.1
-requests-oauthlib==1.2.0
-requests==2.21.0
-responses==0.10.14        # via moto
-rfc3986==1.4.0
-rsa==4.0                  # via python-jose
-s3transfer==0.2.1
-scandir==1.10.0
+python-keystoneclient==3.10.0  # via -r base.txt
+python-ldap==3.2.0        # via -r base.txt, django-auth-ldap
+python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
+python-swiftclient==3.3.0  # via -r base.txt
+pytz==2020.1              # via -r base.txt, babel, django, moto, oslo.serialization, oslo.utils
+pyyaml==5.3.1             # via -r base.txt, cfn-lint, moto, oslo.config, oslo.serialization, vcrpy
+requests-oauthlib==1.2.0  # via -r base.txt
+requests==2.21.0          # via -r base.txt, agentarchives, docker, keystoneauth1, moto, oslo.config, python-keystoneclient, python-swiftclient, requests-oauthlib, responses
+responses==0.10.15        # via moto
+rfc3986==1.4.0            # via -r base.txt, oslo.config
+rsa==4.5                  # via python-jose
+s3transfer==0.2.1         # via -r base.txt, boto3
+scandir==1.10.0           # via -r base.txt, pathlib2
 simplegeneric==0.8.1      # via ipython
-singledispatch==3.4.0.3   # via importlib-resources
-six==1.15.0
-stevedore==1.32.0
-sword2==0.2.1
+singledispatch==3.4.0.3   # via -r base.txt, importlib-resources
+six==1.15.0               # via -r base.txt, aws-sam-translator, cfn-lint, cryptography, debtcollector, django-extensions, docker, ecdsa, jsonschema, junit-xml, keystoneauth1, metsrw, mock, more-itertools, moto, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pyrsistent, pytest, python-dateutil, python-jose, python-keystoneclient, python-swiftclient, responses, singledispatch, stevedore, tox, traitlets, vcrpy, virtualenv, websocket-client
+stevedore==1.32.0         # via -r base.txt, keystoneauth1, oslo.config, python-keystoneclient
+sword2==0.2.1             # via -r base.txt
 toml==0.10.1              # via tox
-tox==3.15.1
+tox==3.16.1               # via -r test.in
 traitlets==4.3.3          # via ipython
-typing==3.7.4.1           # via importlib-resources
-urllib3==1.24.3
-vcrpy==3.0.0
-virtualenv==20.0.21       # via tox
-wcwidth==0.1.9            # via prompt-toolkit
+typing==3.7.4.2           # via -r base.txt, importlib-resources
+urllib3==1.24.3           # via -r base.txt, botocore, requests
+vcrpy==3.0.0              # via -r test.in
+virtualenv==20.0.26       # via tox
+wcwidth==0.2.5            # via prompt-toolkit
 websocket-client==0.57.0  # via docker
 werkzeug==1.0.1           # via moto
-whitenoise==3.3.0
-wrapt==1.12.1
+whitenoise==3.3.0         # via -r base.txt
+wrapt==1.12.1             # via -r base.txt, aws-xray-sdk, debtcollector, positional, vcrpy
 xmltodict==0.12.0         # via moto
-zipp==1.2.0               # via importlib-metadata, importlib-resources
+zipp==1.2.0               # via -r base.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Importlib-resources have been pinned per the advice [here](https://github.com/jazzband/pip-tools/issues/1174)

The commit doesn't update any other output from pip-compile other than those resolved by the pip-tools/pip-compile utility. 

Connected to archivematica/Issues#1252
Connected to archivematica/Issues#1253

