### PR TITLE
Ensure cas_user_authenticated signal receiver is called

### DIFF
--- a/storage_service/common/__init__.py
+++ b/storage_service/common/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "common.apps.CommonAppConfig"

--- a/storage_service/common/apps.py
+++ b/storage_service/common/apps.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+
+class CommonAppConfig(AppConfig):
+    name = "common"
+
+    def ready(self):
+        import common.signals  # noqa: F401

--- a/storage_service/common/signals.py
+++ b/storage_service/common/signals.py
@@ -62,6 +62,8 @@ def cas_user_authenticated_callback(sender, **kwargs):
     if not settings.CAS_CHECK_ADMIN_ATTRIBUTES:
         return
 
+    LOGGER.debug("cas_user_authenticated signal received")
+
     username = kwargs.get("user")
     attributes = kwargs.get("attributes")
 

--- a/storage_service/storage_service/tests/test_cas.py
+++ b/storage_service/storage_service/tests/test_cas.py
@@ -13,7 +13,7 @@ except ImportError:
     from unittest import mock
 
 from common.backends import CustomCASBackend
-from storage_service.signals import _cas_user_is_administrator
+from common.signals import _cas_user_is_administrator
 
 TEST_CAS_USER = "casuser"
 TEST_CAS_ADMIN_ATTRIBUTE = "usertype"


### PR DESCRIPTION
This commit moves the signal receiver for `cas_user_authenticated` to the `common` app and adds a custom AppConfig which imports `common.signals` to ensure that this and any future Django signal receivers in the app work as expected.

I propose moving the signal receiver to `common` so it is easily located next to the other SSO backends and middleware, including the custom CAS backend.

Connected to https://github.com/archivematica/Issues/issues/1289