### PR TITLE
Add management task to (re)create AIP replicas

### DIFF
--- a/storage_service/common/management/commands/__init__.py
+++ b/storage_service/common/management/commands/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from django.core.management.base import BaseCommand
+
+
+class StorageServiceCommand(BaseCommand):
+    def success(self, message):
+        self.stdout.write(self.style.SUCCESS(message))
+
+    def error(self, message):
+        self.stdout.write(self.style.ERROR(message))
+
+    def warning(self, message):
+        self.stdout.write(self.style.WARNING(message))
+
+    def info(self, message):
+        self.stdout.write(message)


### PR DESCRIPTION
Connected to https://github.com/archivematica/Issues/issues/1209

This commit introduces a new management command for the Storage Service which can be used to  create new replicas for all AIPs in an AIP Store location (specified with `--location`, defaults to default AIP Store). When called with the `-d/--delete` option, the command will first delete existing replicas of AIPs prior to creating new ones. This should allow Support to fix the issue in the linked issue by creating new AIP replicas.

Two questions for the reviewer that I'd like a second opinion/pointer for:

1. Currently, when called with the `--delete` argument, this command deletes the replicas from both the filesystem and the database. Would it be better to keep the entries for the deleted replicas in the database and change their status to "DELETED", rather than delete them outright from the database?
2. I'm suppressing most of the Storage Service log messages to make the terminal output for this command more clear, but these DEBUG messages are slipping through: `DEBUG     2020-10-13 09:12:37  locations.models.async_manager:async_manager:_watchdog_loop:123:  Watchdog sees 0 tasks running`. Any idea how to successfully suppress these as well?