### PR TITLE
Replication work for NHA

### DIFF
--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -584,7 +584,13 @@ def removedirs(relative_path, base=None):
     """ Removes leaf directory of relative_path and all empty directories in
     relative_path, but nothing from base.
 
-    Cribbed from the implementation of os.removedirs. """
+    Cribbed from the implementation of os.removedirs.
+
+    :param relative_path: quad-dir structure,
+        e.g. aa9a/f3b1/32ae/4f3e/8841/0539/568c/43f2 (path-string)
+    :param base: root location of quad-dir structure,
+        e.g. /var/archivematica/storage_service (path-string, (optional))
+    """
     if not base:
         return os.removedirs(relative_path)
     try:

--- a/storage_service/locations/fixtures/arkivum.json
+++ b/storage_service/locations/fixtures/arkivum.json
@@ -1,7 +1,7 @@
 [
 {
-    "pk": 1, 
-    "model": "locations.arkivum", 
+    "pk": 1,
+    "model": "locations.arkivum",
     "fields": {
         "space": "6fb34c82-4222-425e-b0ea-30acfd31f52e",
         "host": "localhost:8443",
@@ -10,30 +10,30 @@
     }
 },
 {
-    "pk": 2, 
-    "model": "locations.space", 
+    "pk": 2,
+    "model": "locations.space",
     "fields": {
-        "last_verified": null, 
-        "used": 0, 
-        "verified": false, 
-        "uuid": "6fb34c82-4222-425e-b0ea-30acfd31f52e", 
-        "access_protocol": "ARKIVUM", 
-        "staging_path": "/var/archivematica/storage_service/", 
-        "path": "/mnt/arkivum", 
+        "last_verified": null,
+        "used": 0,
+        "verified": false,
+        "uuid": "6fb34c82-4222-425e-b0ea-30acfd31f52e",
+        "access_protocol": "ARKIVUM",
+        "staging_path": "/var/archivematica/storage_service/",
+        "path": "/mnt/arkivum",
         "size": null
     }
 },
 {
     "pk": 10,
-    "model": "locations.location", 
+    "model": "locations.location",
     "fields": {
-        "used": 0, 
-        "description": "Arkivum AS", 
-        "space": "6fb34c82-4222-425e-b0ea-30acfd31f52e", 
-        "enabled": true, 
-        "quota": null, 
+        "used": 0,
+        "description": "Arkivum AS",
+        "space": "6fb34c82-4222-425e-b0ea-30acfd31f52e",
+        "enabled": true,
+        "quota": null,
         "relative_path": "",
-        "purpose": "AS", 
+        "purpose": "AS",
         "uuid": "d9d7db26-f7a1-40aa-9db1-806b4d3a61cd"
     }
 },
@@ -50,7 +50,7 @@
     }
 },
 {
-    "pk": 10,
+    "pk": 98,
     "model": "locations.package",
     "fields": {
         "status": "STAGING",
@@ -66,7 +66,7 @@
     }
 },
 {
-    "pk": 11,
+    "pk": 99,
     "model": "locations.package",
     "fields": {
         "status": "STAGING",

--- a/storage_service/locations/fixtures/package.json
+++ b/storage_service/locations/fixtures/package.json
@@ -116,7 +116,7 @@
     }
 },
 {
- "pk": 7,
+    "pk": 7,
     "model": "locations.package",
     "fields": {
         "uuid": "88deec53-c7dc-4828-865c-7356386e9399",
@@ -164,6 +164,66 @@
         "package_type": "AIP",
         "status": "Uploaded",
         "misc_attributes": "{}"
+    }
+},
+{
+    "pk": 10,
+    "model": "locations.package",
+    "fields": {
+        "current_location": "615103f0-0ee0-4a12-ba17-43192d1143ea",
+        "current_path": "577f/74bd/a283/49e0/b4e2/f8ab/b81d/2566/0f-577f74bd-a283-49e0-b4e2-f8abb81d2566.7z",
+        "description": null,
+        "encryption_key_fingerprint": null,
+        "misc_attributes": "{}",
+        "origin_pipeline": null,
+        "package_type": "AIP",
+        "pointer_file_location": "",
+        "pointer_file_path": "577f/74bd/a283/49e0/b4e2/f8ab/b81d/2566/pointer.577f74bd-a283-49e0-b4e2-f8abb81d2566.xml",
+        "related_packages": [],
+        "replicated_package": "f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04",
+        "size": 299703,
+        "status": "UPLOADED",
+        "uuid": "577f74bd-a283-49e0-b4e2-f8abb81d2566"
+    }
+},
+{
+    "pk": 11,
+    "model": "locations.package",
+    "fields": {
+        "current_location": "615103f0-0ee0-4a12-ba17-43192d1143ea",
+        "current_path": "f0df/dc4c/7ba1/4e3f/a972/f2c5/5d87/0d04/0f-f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04.7z",
+        "description": null,
+        "encryption_key_fingerprint": null,
+        "misc_attributes": "{}",
+        "origin_pipeline": null,
+        "package_type": "AIP",
+        "pointer_file_location": "",
+        "pointer_file_path": "f0df/dc4c/7ba1/4e3f/a972/f2c5/5d87/0d04/pointer.f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04.xml",
+        "related_packages": [],
+        "replicated_package": null,
+        "size": 299703,
+        "status": "UPLOADED",
+        "uuid": "f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04"
+    }
+},
+{
+    "pk": 12,
+    "model": "locations.package",
+    "fields": {
+        "current_location": "615103f0-0ee0-4a12-ba17-43192d1143ea",
+        "current_path": "2f62/b030/c3f4/4ac1/950f/fe47/d0dd/cd14/0f-2f62b030-c3f4-4ac1-950f-fe47d0ddcd14.7z",
+        "description": null,
+        "encryption_key_fingerprint": null,
+        "misc_attributes": "{}",
+        "origin_pipeline": null,
+        "package_type": "AIP",
+        "pointer_file_location": "",
+        "pointer_file_path": "2f62/b030/c3f4/4ac1/950f/fe47/d0dd/cd14/pointer.2f62b030-c3f4-4ac1-950f-fe47d0ddcd14.xml",
+        "related_packages": [],
+        "replicated_package": "f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04",
+        "size": 299703,
+        "status": "UPLOADED",
+        "uuid": "2f62b030-c3f4-4ac1-950f-fe47d0ddcd14"
     }
 },
 {

--- a/storage_service/locations/tests/test_datatable.py
+++ b/storage_service/locations/tests/test_datatable.py
@@ -13,24 +13,28 @@ from locations import models
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_DIR = os.path.abspath(os.path.join(THIS_DIR, "..", "fixtures", ""))
 
+# There are 12 total packages in package.json.
+TOTAL_FIXTURE_PACKAGES = 12
+
 
 class TestDataTable(TestCase):
 
     fixtures = ["base.json", "package.json"]
 
     def test_initialization(self):
+        DISPLAY_LEN = 10
         datatable = datatable_utils.DataTable({})
         expected_params = {
             "search": "",
             "display_start": 0,
-            "display_length": 10,
+            "display_length": DISPLAY_LEN,
             "sorting_column": {},
             "echo": -1,
         }
         assert datatable.params == expected_params
-        assert datatable.total_records == 9
-        assert datatable.total_display_records == 9
-        assert len(datatable.packages) == 9
+        assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
+        assert datatable.total_display_records == TOTAL_FIXTURE_PACKAGES
+        assert len(datatable.packages) == DISPLAY_LEN
 
     def test_search_description(self):
         datatable = datatable_utils.DataTable(
@@ -49,7 +53,7 @@ class TestDataTable(TestCase):
             "echo": 1,
         }
         assert datatable.params == expected_params
-        assert datatable.total_records == 9
+        assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
         assert datatable.total_display_records == 1
         assert len(datatable.packages) == 1
 
@@ -70,7 +74,7 @@ class TestDataTable(TestCase):
             "echo": 1,
         }
         assert datatable.params == expected_params
-        assert datatable.total_records == 9
+        assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
         assert datatable.total_display_records == 3
         assert len(datatable.packages) == 3
 
@@ -91,30 +95,31 @@ class TestDataTable(TestCase):
             "echo": 1,
         }
         assert datatable.params == expected_params
-        assert datatable.total_records == 9
+        assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
         assert datatable.total_display_records == 3
         assert len(datatable.packages) == 3
 
     def test_search_status(self):
+        DISPLAY_LEN = 10
         datatable = datatable_utils.DataTable(
             {
                 "sSearch": "Uploaded",
                 "iDisplayStart": 0,
-                "iDisplayLength": 10,
+                "iDisplayLength": DISPLAY_LEN,
                 "sEcho": "1",
             }
         )
         expected_params = {
             "search": "Uploaded",
             "display_start": 0,
-            "display_length": 10,
+            "display_length": DISPLAY_LEN,
             "sorting_column": {},
             "echo": 1,
         }
         assert datatable.params == expected_params
-        assert datatable.total_records == 9
-        assert datatable.total_display_records == 9
-        assert len(datatable.packages) == 9
+        assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
+        assert datatable.total_display_records == TOTAL_FIXTURE_PACKAGES
+        assert len(datatable.packages) == DISPLAY_LEN
 
     def _create_replicas(self, uuid):
         test_location = models.Location.objects.get(
@@ -147,8 +152,11 @@ class TestDataTable(TestCase):
         return [replica.uuid for replica in aip.replicas.all()]
 
     def test_search_replica_of(self):
-        package_uuid = "0d4e739b-bf60-4b87-bc20-67a379b28cea"
-        replicas_uuids = self._create_replicas(package_uuid)
+        package_uuid = "f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04"
+        replicas_uuids = [
+            "2f62b030-c3f4-4ac1-950f-fe47d0ddcd14",
+            "577f74bd-a283-49e0-b4e2-f8abb81d2566",
+        ]
         datatable = datatable_utils.DataTable(
             {
                 "sSearch": package_uuid,
@@ -167,14 +175,17 @@ class TestDataTable(TestCase):
         # searching for the original package uuid should return its replicas too
         expected_packages_uuids = sorted([package_uuid] + replicas_uuids)
         assert datatable.params == expected_params
-        assert datatable.total_records == 11
-        assert datatable.total_display_records == 3
-        assert len(datatable.packages) == 3
+        assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
+        assert datatable.total_display_records == len(expected_packages_uuids)
+        assert len(datatable.packages) == len(expected_packages_uuids)
         assert sorted([p.uuid for p in datatable.packages]) == expected_packages_uuids
 
     def test_reverse_search_replica_of(self):
-        package_uuid = "0d4e739b-bf60-4b87-bc20-67a379b28cea"
-        replicas_uuids = self._create_replicas(package_uuid)
+        package_uuid = "f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04"
+        replicas_uuids = [
+            "2f62b030-c3f4-4ac1-950f-fe47d0ddcd14",
+            "577f74bd-a283-49e0-b4e2-f8abb81d2566",
+        ]
         datatable = datatable_utils.DataTable(
             {
                 "sSearch": replicas_uuids[0],
@@ -193,9 +204,9 @@ class TestDataTable(TestCase):
         # searching for the replica uuid should return its original package too
         expected_packages_uuids = sorted([package_uuid, replicas_uuids[0]])
         assert datatable.params == expected_params
-        assert datatable.total_records == 11
-        assert datatable.total_display_records == 2
-        assert len(datatable.packages) == 2
+        assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
+        assert datatable.total_display_records == len(expected_packages_uuids)
+        assert len(datatable.packages) == len(expected_packages_uuids)
         assert sorted([p.uuid for p in datatable.packages]) == expected_packages_uuids
 
     def test_sorting_uuid(self):
@@ -219,14 +230,15 @@ class TestDataTable(TestCase):
         assert datatable.params == expected_params
         expected_uuids = [
             "0d4e739b-bf60-4b87-bc20-67a379b28cea",
+            "2f62b030-c3f4-4ac1-950f-fe47d0ddcd14",
             "473a9398-0024-4804-81da-38946040c8af",
+            "577f74bd-a283-49e0-b4e2-f8abb81d2566",
             "6aebdb24-1b6b-41ab-b4a3-df9a73726a34",
             "708f7a1d-dda4-46c7-9b3e-99e188eeb04c",
             "79245866-ca80-4f84-b904-a02b3e0ab621",
             "88deec53-c7dc-4828-865c-7356386e9399",
             "9f260047-a9b7-4a75-bb6a-e8d94c83edd2",
             "a59033c2-7fa7-41e2-9209-136f07174692",
-            "e0a41934-c1d7-45ba-9a95-a7531c063ed1",
         ]
         assert [package.uuid for package in datatable.packages] == expected_uuids
 
@@ -235,7 +247,8 @@ class TestDataTable(TestCase):
         datatable = datatable_utils.DataTable(
             {"iDisplayStart": 0, "iDisplayLength": 10, "sEcho": "1"}
         )
-        assert datatable.total_records == 9
+        assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
+        TOTAL_RECORDS_IN_LOCATION = 9
         aip_storage_location = models.Location.objects.get(
             uuid="615103f0-0ee0-4a12-ba17-43192d1143ea"
         )
@@ -248,4 +261,4 @@ class TestDataTable(TestCase):
                 "location-uuid": aip_storage_location.uuid,
             }
         )
-        assert datatable.total_records == 6
+        assert datatable.total_records == TOTAL_RECORDS_IN_LOCATION

--- a/storage_service/locations/tests/test_package.py
+++ b/storage_service/locations/tests/test_package.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
+import datetime
 import os
 import pytest
 import shutil
 import tempfile
+import time
 import vcr
 
 import mock
@@ -19,26 +21,38 @@ import bagit
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_DIR = os.path.abspath(os.path.join(THIS_DIR, "..", "fixtures", ""))
 
+# Fixture files are not cleanly separated, with potential for
+# enumeration of PKs across both:
+#
+#   * 12 Packages in package.json
+#   * 2 packages in Arkivum.json
+#
+TOTAL_FIXTURE_PACKAGES = 14
+
 
 class TestPackage(TestCase):
 
     fixtures = ["base.json", "package.json", "arkivum.json", "callback.json"]
 
     def setUp(self):
-        self.package = models.Package.objects.all()[0]
+        packages = models.Package.objects.all()
+        assert (
+            len(packages) == TOTAL_FIXTURE_PACKAGES
+        ), "Packages not loaded from fixtures correctly, got '{}' expected '{}'".format(
+            len(packages), TOTAL_FIXTURE_PACKAGES
+        )
+
+        self.package = packages[0]
         self.mets_path = os.path.normpath(
             os.path.join(__file__, "..", "..", "fixtures")
         )
-        self.test_location = models.Location.objects.get(
-            uuid="615103f0-0ee0-4a12-ba17-43192d1143ea"
-        )
+
         # Set up locations to point to fixtures directory
-        self.test_location.relative_path = FIXTURES_DIR[1:]
-        self.test_location.save()
-        # SS int points at fixtures directory
-        models.Location.objects.filter(purpose="SS").update(
-            relative_path=FIXTURES_DIR[1:]
+        FIXTURE_DIR_NO_LEADING_SLASH = FIXTURES_DIR[1:]
+        self._point_location_at_on_disk_storage(
+            "615103f0-0ee0-4a12-ba17-43192d1143ea", FIXTURE_DIR_NO_LEADING_SLASH
         )
+
         # Arkivum space points at fixtures directory
         models.Space.objects.filter(uuid="6fb34c82-4222-425e-b0ea-30acfd31f52e").update(
             path=FIXTURES_DIR
@@ -49,15 +63,127 @@ class TestPackage(TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)
 
+    def _point_location_at_on_disk_storage(self, location_uuid, location_on_disk):
+        """Give tests the opportunity to modify the location of on-disk
+        storage.
+
+        :param location_uuid: the UUID of a storage location in the
+            test database.
+        :param location_on_disk: a folder, e.g. pointer to a temporary
+            location that the test may want to read from and write to.
+        """
+        self.test_location = models.Location.objects.get(uuid=location_uuid)
+        self.test_location.relative_path = location_on_disk
+        self.test_location.save()
+        models.Location.objects.filter(
+            purpose=models.Location.STORAGE_SERVICE_INTERNAL
+        ).update(relative_path=location_on_disk)
+
     def test_model_delete_from_storage(self):
+        """Test that the Space delete method is called once for the
+        deletion of an AIP from the storage service.
+        """
+
+        # Package that exists in the storage service.
         package = models.Package.objects.get(
             uuid="88deec53-c7dc-4828-865c-7356386e9399"
         )
+
+        # Assert that is hasn't been deleted already.
+        assert package.status == "Uploaded"
+
+        # Using our context manager make sure that the deletion happens
+        # once for our source object.
         with mock.patch("locations.models.Space.delete_path") as mocked_delete:
             package.delete_from_storage()
             assert mocked_delete.called
-            assert package.current_location.used == -package.size
-            assert package.current_location.space.used == -package.size
+
+        # Ensure that location properties are updated reflecting the
+        # size remaining.
+        assert package.current_location.used == -package.size
+        assert package.current_location.space.used == -package.size
+
+        # Ensure that the package status is accurately updated to
+        # DELETED.
+        assert package.status == models.Package.DELETED
+
+    def test_model_delete_from_storage_and_replicas(self):
+        """Test that Space delete method is called three times for a
+        package with two replicas. Once for the original package. Twice
+        for the two replicas.
+        """
+
+        # Package with two replicas in the storage service.
+        package = models.Package.objects.get(
+            uuid="f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04"
+        )
+
+        # Given our test object, make sure the replicas have equivalent
+        # status.
+        replicas = package._find_replicas()
+        assert package.status == models.Package.UPLOADED
+        assert replicas[0].status == models.Package.UPLOADED
+        assert replicas[1].status == models.Package.UPLOADED
+
+        # Using our context manager make sure that the deletion can be
+        # measured three times per our test parameters.
+        with mock.patch("locations.models.Space.delete_path") as mocked_delete:
+            package.delete_from_storage()
+            assert mocked_delete.called
+            assert mocked_delete.call_count == 3
+
+        # Ensure locations sizes are updated to reflect the size
+        # remaining.
+        assert package.current_location.used == -package.size
+        assert package.current_location.space.used == -package.size
+
+        # Ensure that the replicas and the original package have an
+        # updated status of DELETED.
+        replicas = package._find_replicas(status=models.Package.DELETED)
+        assert package.status == models.Package.DELETED
+        assert replicas[0].status == models.Package.DELETED
+        assert replicas[1].status == models.Package.DELETED
+
+    def test_model_delete_failure_with_replicas(self):
+        """If the deletion of an original package doesn't succeed for
+        some reason, we don't want to proceed to delete the replicas
+        associated with that package. That should be done as an
+        independent action by the user, otherwise they are paired
+        activities.
+        """
+
+        # Package with two replicas in the storage service.
+        package = models.Package.objects.get(
+            uuid="f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04"
+        )
+
+        # Store our original space and location values to test after
+        # our "failed" delete call.
+        original_location_used = package.current_location.used
+        original_space_used = package.current_location.space.used
+
+        # Using our context manager attempt to delete our package but
+        # make sure the correct behavior occurs when an exception is
+        # raised, e.g. NotImplementedError for a space without a storage
+        # service managed deletion capability.
+        with mock.patch(
+            "locations.models.Space.delete_path", side_effect=NotImplementedError
+        ) as mocked_delete:
+            package.delete_from_storage()
+            assert mocked_delete.called
+            assert mocked_delete.call_count == 1
+
+        # Ensure locations sizes are the same as they were because no
+        # deletion happened.
+        assert package.current_location.used == original_location_used
+        assert package.current_location.space.used == original_space_used
+
+        # Ensure that the replicas and the original package have not
+        # seen their status updated.
+        replicas = package._find_replicas()
+        assert package.status == models.Package.UPLOADED
+        assert replicas[0].status == models.Package.UPLOADED
+        assert replicas[1].status == models.Package.UPLOADED
 
     def test_view_package_delete(self):
         self.client.login(username="test", password="test")
@@ -393,7 +519,10 @@ class TestPackage(TestCase):
 
     @staticmethod
     def _test_bagit_structure(replica, replication_dir):
-        """Ensure the replicated bagit structure remains."""
+        """Ensure that the contents of a bag are consistent with the
+        contents that were created during testing so that we know
+        structure is preserved accurately.
+        """
         bag_contents = [
             "tagmanifest-md5.txt",
             "bagit.txt",
@@ -407,15 +536,19 @@ class TestPackage(TestCase):
         expected_bagit_structure = [
             os.path.join(expected_bag_path, bag_path) for bag_path in bag_contents
         ]
+        found_structure = []
         for subdir, _, files in os.walk(replica.current_location.full_path):
             for file_ in files:
-                file_path = os.path.join(subdir, file_)
-                if file_path not in expected_bagit_structure:
-                    pytest.fail(
-                        "Unexpected file in Bagit structure: {}".format(file_path)
-                    )
+                found_structure.append(os.path.join(subdir, file_))
+        assert set(found_structure) == set(
+            expected_bagit_structure
+        ), "unexpected bag structure found:"
 
     def test_replicate_aip_when_file(self):
+        """Ensure that a replica can be created and its resulting
+        properties are consistent for one of Archivematica's file-like
+        AIP package types, e.g. 7z.
+        """
         space_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="space")
         replication_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="replication")
         aip = models.Package.objects.get(uuid="88deec53-c7dc-4828-865c-7356386e9399")
@@ -426,6 +559,7 @@ class TestPackage(TestCase):
             relative_path=replication_dir,
             purpose=models.Location.REPLICATOR,
         )
+        assert aip.replicas.count() == 0
         aip.create_replicas()
         assert aip.replicas.count() == 1
         replica = aip.replicas.first()
@@ -441,6 +575,11 @@ class TestPackage(TestCase):
         assert os.path.isfile(repl_file_path)
 
     def test_replicate_aip(self):
+        """Ensure that a replica can be created and its resulting
+        properties and folder structure are consistent for a regular,
+        non-packed bag in Archivematica, e.g. Uncompressed and not 7z
+        etc.
+        """
         space_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="space")
         replication_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="replication")
         aip = models.Package.objects.get(uuid="0d4e739b-bf60-4b87-bc20-67a379b28cea")
@@ -451,7 +590,7 @@ class TestPackage(TestCase):
             relative_path=replication_dir,
             purpose=models.Location.REPLICATOR,
         )
-
+        assert aip.replicas.count() == 0
         aip.create_replicas()
         assert aip.replicas.count() == 1
         replica = aip.replicas.first()
@@ -461,6 +600,12 @@ class TestPackage(TestCase):
         self._test_bagit_structure(aip.replicas.first(), replication_dir)
 
     def test_replicate_aip_twice(self):
+        """Ensure that multiple replicas can be created and its
+        resulting properties and folder structure are consistent for a
+        regular, non-packed bag in Archivematica, e.g. Uncompressed and
+        not 7z etc. Make sure the properties correctly indicate two
+        replicas.
+        """
         space_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="space")
         replication_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="replication")
         replication_dir2 = tempfile.mkdtemp(dir=self.tmp_dir, prefix="replication")
@@ -478,6 +623,8 @@ class TestPackage(TestCase):
             purpose=models.Location.REPLICATOR,
         )
 
+        assert aip.replicas.count() == 0
+
         aip.create_replicas()
 
         assert aip.replicas.count() == 2
@@ -491,6 +638,11 @@ class TestPackage(TestCase):
 
     @mock.patch("locations.models.gpg._gpg_encrypt")
     def test_replicate_aip_gpg_encrypted(self, mock_encrypt):
+        """Ensure that a replica is created correctly for a replication
+        space created with a GPG encryption and ensure that the calls
+        made to correct it look correct and the replica's properties are
+        consistent.
+        """
         mock_encrypt.return_value = ("/a/fake/path", mock.Mock())
 
         space_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="space")
@@ -511,14 +663,202 @@ class TestPackage(TestCase):
             purpose=models.Location.REPLICATOR,
         )
 
+        assert aip.replicas.count() == 0
         aip.create_replicas()
         replica = aip.replicas.first()
 
+        assert aip.replicas.count() == 1
         assert replica is not None
         assert mock_encrypt.call_args_list == [
             mock.call(os.path.join(replica.full_path, ""), u"")
         ]
         self._test_bagit_structure(replica, replication_dir)
+
+    def test_deletion_and_creation_of_replicas_compressed(self):
+        """Ensure that when it is requested a replica be created, then
+        existing replicas are checked for and deleted if necessary, e.g.
+        during a reingest process. Ensure that a new replica is created
+        in its place which reflects the original's updated structure.
+        """
+        AIP_UUID = "f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04"
+        OLD_REPLICAS = [
+            "2f62b030-c3f4-4ac1-950f-fe47d0ddcd14",
+            "577f74bd-a283-49e0-b4e2-f8abb81d2566",
+        ]
+
+        space_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="space")
+        replication_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="replication")
+        aip = models.Package.objects.get(uuid=AIP_UUID)
+        aip.current_location.space.staging_path = space_dir
+        aip.current_location.space.save()
+        aip.current_location.replicators.create(
+            space=aip.current_location.space,
+            relative_path=replication_dir,
+            purpose=models.Location.REPLICATOR,
+        )
+
+        # Previous replicas for this package should be 2. Ensure that
+        # is correct and ensure that status for both is UPLOADED.
+        previous_replicas = models.Package.objects.filter(
+            replicated_package=AIP_UUID
+        ).all()
+        uploaded_repl = [
+            repl for repl in previous_replicas if repl.status == models.Package.UPLOADED
+        ]
+        assert (
+            len(set(uploaded_repl)) == len(set(previous_replicas)) == len(OLD_REPLICAS)
+        )
+
+        with mock.patch("locations.models.Space.move_rsync") as _:
+            aip.create_replicas()
+
+        # The replication process in the storage service will create
+        # only as many new replicas as there are enabled locations so
+        # in this scenario we will see two existing replicas deleted
+        # and one new replica created.
+        all_replicas = models.Package.objects.filter(replicated_package=AIP_UUID).all()
+        uploaded_repl = [
+            repl for repl in all_replicas if repl.status == models.Package.UPLOADED
+        ]
+        deleted_repl = [
+            repl for repl in all_replicas if repl.status == models.Package.DELETED
+        ]
+
+        # Make sure our counts are correct, 3 total, 2 deleted, 1 new
+        # (uploaded).
+        assert len(set(all_replicas)) == 3
+        assert len(set(deleted_repl)) == len(OLD_REPLICAS)
+        assert len(uploaded_repl) == 1
+
+        # Make sure the previous replicas we expected to be deleted were
+        # marked as deleted.
+        deleted_uuids = []
+        for package in deleted_repl:
+            deleted_uuids.append(package.uuid)
+        assert set(deleted_uuids) == set(OLD_REPLICAS)
+
+        # Finally make sure the database has given us a new UUID for the
+        # new replica.
+        assert uploaded_repl[0].uuid not in OLD_REPLICAS
+
+    @staticmethod
+    def _create_mutable_fixture_for_replication(package_name, files):
+        """Create a mutable fixture to test replication updates
+        file-level structures correctly during its replication routines
+        and perform other more sophisticated testing.
+
+        :param package_name: Name of the package directory.
+        :param files: A list of files to write into the package
+            directory.
+        :return: Location of what would be the AIPstore for storage
+            service functions to find any packages we create here.
+        """
+        DATA_TO_WRITE = "data"
+        tmp_dir = tempfile.mkdtemp()
+        aip_dir = os.path.join(tmp_dir, package_name)
+        os.mkdir(aip_dir)
+        for f in files:
+            with open(os.path.join(aip_dir, f), "w") as test_file:
+                test_file.write(DATA_TO_WRITE)
+        return tmp_dir
+
+    def test_deletion_and_creation_of_replicas_uncompressed(self):
+        """Ensure that an uncompressed package is created properly.
+        Because replication seeks to also update the package we try
+        adding new files, e.g. it could be through enabling
+        normalization during partial-reingest. Through these tests we
+        also verify some properties about those files which support the
+        storage service's preservation functions.
+        """
+        PACKAGE = "working_bag"
+        FILES = ["file_one", "file_two", "file_three"]
+        AIP_LOC = "615103f0-0ee0-4a12-ba17-43192d1143ea"
+
+        new_aip_store = self._create_mutable_fixture_for_replication(PACKAGE, FILES)
+        self._point_location_at_on_disk_storage(AIP_LOC, new_aip_store)
+
+        original_dir = os.path.join(new_aip_store, PACKAGE)
+
+        space_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="space")
+        replication_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="replication")
+        aip = models.Package.objects.get(uuid="0d4e739b-bf60-4b87-bc20-67a379b28cea")
+        aip.current_location.space.staging_path = space_dir
+        aip.current_location.space.save()
+        aip.current_location.replicators.create(
+            space=aip.current_location.space,
+            relative_path=replication_dir,
+            purpose=models.Location.REPLICATOR,
+        )
+
+        # Make sure there is no existing date polluting the tests.
+        assert aip.replicas.count() == 0
+
+        # Create the replica and assert some properties about it and
+        # the original AIP's relationships.
+        aip.create_replicas()
+        assert aip.replicas.count() == 1
+        replica = aip.replicas.first()
+        assert replica is not None
+        assert replica.origin_pipeline == aip.origin_pipeline
+        assert replica.replicas.count() == 0
+
+        # Ensure that our first replication was created as expected.
+        first_repl_uuid = replica.uuid
+        first_expected_repl = os.path.join(
+            replication_dir, utils.uuid_to_path(first_repl_uuid), PACKAGE
+        )
+        assert set(os.listdir(first_expected_repl)) == set(FILES)
+        assert replica.status == models.Package.UPLOADED
+
+        # Add some new data to our original package and create some
+        # properties that we can then measure.
+        FILE_TO_ADD = "new_normalization"
+        DATA_TO_ADD = "new data"
+        new_file = os.path.join(original_dir, FILE_TO_ADD)
+        with open(new_file, "w") as normalize_example:
+            normalize_example.write(DATA_TO_ADD)
+        # Because we have a mutable store to play with, we can have
+        # some more fun, so lets test preservation of dates during
+        # replication.
+        TEST_DATETIME = datetime.datetime(
+            year=1970, month=1, day=1, hour=22, minute=13, second=0
+        )
+        DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+        DATE_STRING = "1970-01-01T22:13:00"
+        mod_time = time.mktime(TEST_DATETIME.timetuple())
+        os.utime(new_file, (mod_time, mod_time))
+
+        # Create the replica and ensure the first one no-longer exists.
+        aip.create_replicas()
+        assert not os.path.isdir(first_expected_repl)
+
+        # We're only creating a second version of a replica so last() is
+        # available as a shortcut to get to it.
+        replica = aip.replicas.last()
+        second_repl_uuid = replica.uuid
+        second_expected_repl = os.path.join(
+            replication_dir, utils.uuid_to_path(second_repl_uuid), PACKAGE
+        )
+
+        # Ensure the replicated directory structure is what we expect.
+        assert set(os.listdir(second_expected_repl)) == set(FILES + [FILE_TO_ADD])
+
+        # Make sure the replicated statuses are correct.
+        assert aip.replicas.first().status == models.Package.DELETED
+        assert aip.replicas.last().status == models.Package.UPLOADED
+
+        new_replicated_file = os.path.join(second_expected_repl, FILE_TO_ADD)
+        repl_file_timestamp = os.path.getmtime(new_replicated_file)
+
+        # Ensure the timestamp is preserved.
+        pretty_timestamp = datetime.datetime.fromtimestamp(
+            repl_file_timestamp
+        ).strftime(DATE_FORMAT)
+        assert pretty_timestamp == TEST_DATETIME.strftime(DATE_FORMAT)
+        assert pretty_timestamp == DATE_STRING
+
+        # Ensure data was copied as expected.
+        assert os.path.getsize(new_replicated_file) == len(DATA_TO_ADD)
 
 
 class TestTransferPackage(TestCase):

--- a/storage_service/locations/tests/test_space.py
+++ b/storage_service/locations/tests/test_space.py
@@ -1,7 +1,13 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
+
+import os
+
 import pytest
 from scandir import scandir
+import shutil
 
+from locations.models import Space
 from locations.models.space import path2browse_dict
 
 
@@ -130,3 +136,390 @@ def test_path2browse_dict_object_counting_ignores_read_protected_directories(
             "tree_a.txt": {"size": 6},
         },
     }
+
+
+# AIP store directory structure with components of the quad structure
+# we're generating created specifically to share branches which pushes
+# the limit of "probability", but is not impossible.
+P1 = os.path.join("1111", "2222", "3333", "4444", "5555", "6666", "7777", "8888")
+P2 = os.path.join("1111", "2222", "3333", "4444", "5555", "6666", "8888", "9999")
+P3 = os.path.join("1111", "2222", "3333", "4444", "5555", "8888", "9999", "aaaa")
+P4 = os.path.join("1111", "2222", "3333", "4444", "8888", "9999", "aaaa", "bbbb")
+P5 = os.path.join("1111", "2222", "3333", "8888", "9999", "aaaa", "bbbb", "cccc")
+P6 = os.path.join("1111", "2222", "8888", "9999", "aaaa", "bbbb", "cccc", "dddd")
+P7 = os.path.join("1111", "8888", "9999", "aaaa", "bbbb", "cccc", "eeee", "eeee")
+
+# Once deleted per AIP at each location, the following paths should
+# remain, R = Remain.
+R1 = os.path.join("1111", "2222", "3333", "4444", "5555", "6666")
+R2 = os.path.join("1111", "2222", "3333", "4444", "5555", "6666")
+R3 = os.path.join("1111", "2222", "3333", "4444", "5555")
+R4 = os.path.join("1111", "2222", "3333", "4444")
+R5 = os.path.join("1111", "2222", "3333")
+R6 = os.path.join("1111", "2222")
+R7 = os.path.join("1111")
+
+# Once deleted per AIP at each location, the following paths should be
+# deleted, D = Deleted.
+D1 = os.path.join("1111", "2222", "3333", "4444", "5555", "6666", "7777")
+D2 = os.path.join("1111", "2222", "3333", "4444", "5555", "6666", "8888")
+D3 = os.path.join("1111", "2222", "3333", "4444", "5555", "8888")
+D4 = os.path.join("1111", "2222", "3333", "4444", "8888")
+D5 = os.path.join("1111", "2222", "3333", "8888")
+D6 = os.path.join("1111", "2222", "8888")
+D7 = os.path.join("1111", "8888")
+
+# Compressed or "packaged" AIP names to combine with the AIPstore dirs.
+C1 = "0a-11112222-3333-4444-5555-666677778888.7z"
+C2 = "0b-11112222-3333-4444-5555-666688889999.7z"
+C3 = "0c-11112222-3333-4444-5555-88889999aaaa.7z"
+C4 = "0d-11112222-3333-4444-8888-9999aaaabbbb.7z"
+C5 = "0e-11112222-3333-8888-9999-aaaabbbbcccc.7z"
+C6 = "0f-11112222-8888-9999-aaaa-bbbbccccdddd.tar.gz"
+C7 = "1a-11118888-9999-aaaa-bbbb-cccceeeeeeee.zip"
+
+MAGIC = "\x37\x7A\xBC\xAF\x27\x1C"
+
+AIPSTORE = "AIPstore"
+
+# Pair paths with AIP names. The P{no} prefix is used to simplify
+# the quad-path and the C{no} prefix is used to simplify the
+# compressed package directory.
+COMPRESSED_AIPS = [(P1, C1), (P2, C2), (P3, C3), (P4, C4), (P5, C5), (P6, C6), (P7, C7)]
+
+
+@pytest.fixture
+def aipstore_compressed(tmpdir):
+    """Create a structure simulating an AIPstore with an appropriate
+    level of complexity.
+
+    i.e.
+
+        └── 1111
+            ├── 2222
+            │   ├── 3333
+            │   │   ├── 4444
+            │   │   │   ├── 5555
+            │   │   │   │   ├── 6666
+            │   │   │   │   │   ├── 7777
+            │   │   │   │   │   │   └── 8888
+            │   │   │   │   │   │       └── 0a-11112222-3333-4444-5555-666677778888.7z
+            │   │   │   │   │   └── 8888
+            │   │   │   │   │       └── 9999
+            │   │   │   │   │   │       └── etc.
+            │   │   │   │   └── 8888
+            │   │   │   │       └── 9999
+            │   │   │   │           └── aaaa
+            │   │   │   └── 8888
+            │   │   │       └── 9999
+            │   │   │           └── aaaa
+            │   │   │               └── bbbb
+            │   │   └── 8888
+            │   │       └── 9999
+            │   │           └── aaaa
+            │   │               └── bbbb
+            │   │                   └── cccc
+            │   └── 8888
+            │       └── 9999
+            │           └── aaaa
+            │               └── bbbb
+            │                   └── cccc
+            │                       └── dddd
+            └── 8888
+                └── 9999
+                    └── aaaa
+                        └── bbbb
+                            └── cccc
+                                └── eeee
+                                    └── eeee
+
+    which is created using the following paths which we list to help
+    manual verification of this effort outside of pytest:
+
+        1111/2222/3333/4444/5555/6666/7777/8888/0a-11112222-3333-4444-5555-666677778888.7z
+        1111/2222/3333/4444/5555/6666/8888/9999/0b-11112222-3333-4444-5555-666688889999.7z
+        1111/2222/3333/4444/5555/8888/9999/aaaa/0c-11112222-3333-4444-5555-88889999aaaa.7z
+        1111/2222/3333/4444/8888/9999/aaaa/bbbb/0d-11112222-3333-4444-8888-9999aaaabbbb.7z
+        1111/2222/3333/8888/9999/aaaa/bbbb/cccc/0e-11112222-3333-8888-9999-aaaabbbbcccc.7z
+        1111/2222/8888/9999/aaaa/bbbb/cccc/dddd/0f-11112222-8888-9999-aaaa-bbbbccccdddd.tar.gz
+        1111/8888/9999/aaaa/bbbb/cccc/eeee/eeee/1a-11118888-9999-aaaa-bbbb-cccceeeeeeee.zip
+
+    The quad-structure is described in the documentation:
+
+        * Docs: https://git.io/JLP2b
+
+    :returns: (path to AIPstore (py.path, list of all paths, package
+        file (tuple)} (tuple)
+    """
+    aipstore = tmpdir.mkdir(AIPSTORE)
+    aipstore_path = str(aipstore)
+
+    AIP_QUAD_PATH = 0
+    COMPRESSED_PACKAGE_DIR = 1
+
+    for path in COMPRESSED_AIPS:
+        path_to_write_to = os.path.join(aipstore_path, path[AIP_QUAD_PATH])
+        os.makedirs(path_to_write_to)
+        package_file = os.path.join(
+            aipstore_path, path[AIP_QUAD_PATH], path[COMPRESSED_PACKAGE_DIR]
+        )
+        with open(package_file, "wb") as package:
+            package.write(MAGIC)
+        assert os.path.exists(package_file)
+        assert os.path.isfile(package_file)
+
+    return aipstore
+
+
+@pytest.mark.parametrize(
+    "path, aip_name, remaining_directory, deleted_directory",
+    [
+        (P1, C1, R1, D1),
+        (P2, C2, R2, D2),
+        (P3, C3, R3, D3),
+        (P4, C4, R4, D4),
+        (P5, C5, R5, D5),
+        (P6, C6, R6, D6),
+        (P7, C7, R7, D7),
+    ],
+)
+def test_delete_compressed_path_local(
+    aipstore_compressed, path, aip_name, mocker, remaining_directory, deleted_directory
+):
+    """Test that local compressed or packaged paths e.g. tar.gz are
+    deleted as expected.
+    """
+
+    # Initialize our space and create a path to delete.
+    sp = Space()
+    path_to_delete = os.path.join(str(aipstore_compressed), path, aip_name)
+
+    # rmtree is used to delete directories, we want to make sure we
+    # don't call it from the delete function.
+    mocker.patch("shutil.rmtree", side_effect=shutil.rmtree)
+
+    # Make sure there is something to delete and delete it.
+    assert os.path.exists(path_to_delete)
+    sp._delete_path_local(path_to_delete)
+
+    # Verify that we called shutil was not called to remove a file.
+    shutil.rmtree.assert_not_called()
+
+    # Make sure the path is gone.
+    assert not os.path.exists(path_to_delete)
+
+    # Make sure that the AIPSTORE part of the path is preserved.
+    aipstore = str(aipstore_compressed).split(path, 1)[0]
+    assert os.path.exists(aipstore)
+
+    # Assert none of the other AIPs have been deleted as a result of
+    # the function.
+    assert len(COMPRESSED_AIPS) > 0
+    for aip_path, filename in COMPRESSED_AIPS:
+        remaining_aip = os.path.join(aip_path, filename)
+        test_dir = os.path.join(path, aip_name)
+        if remaining_aip == test_dir:
+            continue
+        remaining_aip = os.path.join(str(aipstore_compressed), remaining_aip)
+        assert os.path.exists(remaining_aip)
+        assert os.path.isfile(remaining_aip)
+
+    # Ensure that the correct parts of the quad-directory structure
+    # remain.
+    assert os.path.exists(os.path.join(aipstore, remaining_directory))
+    assert not os.path.exists(os.path.join(aipstore, deleted_directory))
+
+
+# Uncompressed AIP names to combine with the AIPstore dirs.
+U1 = "0a-11112222-3333-4444-5555-666677778888"
+U2 = "0b-11112222-3333-4444-5555-666688889999"
+U3 = "0c-11112222-3333-4444-5555-88889999aaaa"
+U4 = "0d-11112222-3333-4444-8888-9999aaaabbbb"
+U5 = "0e-11112222-3333-8888-9999-aaaabbbbcccc"
+U6 = "0f-11112222-8888-9999-aaaa-bbbbccccdddd"
+U7 = "1a-11118888-9999-aaaa-bbbb-cccceeeeeeee"
+
+# Pair paths with AIP names. The P{no} prefix is used to simplify
+# the quad-path and the U{no} prefix is used to simplify the
+# uncompressed package directory.
+UNCOMPRESSED_AIPS = [
+    (P1, U1),
+    (P2, U2),
+    (P3, U3),
+    (P4, U4),
+    (P5, U5),
+    (P6, U6),
+    (P7, U7),
+]
+
+
+@pytest.fixture
+def aipstore_uncompressed(tmpdir):
+    """Create a structure simulating an AIPstore with an appropriate
+    level of complexity.
+
+    i.e.
+
+        └── 1111
+            ├── 2222
+            │   ├── 3333
+            │   │   ├── 4444
+            │   │   │   ├── 5555
+            │   │   │   │   ├── 6666
+            │   │   │   │   │   ├── 7777
+            │   │   │   │   │   │   └── 8888
+            │   │   │   │   │   │       └── 0a-11112222-3333-4444-5555-666677778888
+            │   │   │   │   │   └── 8888
+            │   │   │   │   │       └── 9999
+            │   │   │   │   │   │       └── etc.
+            │   │   │   │   └── 8888
+            │   │   │   │       └── 9999
+            │   │   │   │           └── aaaa
+            │   │   │   └── 8888
+            │   │   │       └── 9999
+            │   │   │           └── aaaa
+            │   │   │               └── bbbb
+            │   │   └── 8888
+            │   │       └── 9999
+            │   │           └── aaaa
+            │   │               └── bbbb
+            │   │                   └── cccc
+            │   └── 8888
+            │       └── 9999
+            │           └── aaaa
+            │               └── bbbb
+            │                   └── cccc
+            │                       └── dddd
+            └── 8888
+                └── 9999
+                    └── aaaa
+                        └── bbbb
+                            └── cccc
+                                └── eeee
+                                    └── eeee
+
+    which is created using the following paths which we list to help
+    manual verification of this effort outside of pytest:
+
+        1111/2222/3333/4444/5555/6666/7777/8888/0a-11112222-3333-4444-5555-666677778888/some-manifest
+        1111/2222/3333/4444/5555/6666/8888/9999/0b-11112222-3333-4444-5555-666688889999/some-manifest
+        1111/2222/3333/4444/5555/8888/9999/aaaa/0c-11112222-3333-4444-5555-88889999aaaa/some-manifest
+        1111/2222/3333/4444/8888/9999/aaaa/bbbb/0d-11112222-3333-4444-8888-9999aaaabbbb/some-manifest
+        1111/2222/3333/8888/9999/aaaa/bbbb/cccc/0e-11112222-3333-8888-9999-aaaabbbbcccc/some-manifest
+        1111/2222/8888/9999/aaaa/bbbb/cccc/dddd/0f-11112222-8888-9999-aaaa-bbbbccccdddd/some-manifest
+        1111/8888/9999/aaaa/bbbb/cccc/eeee/eeee/1a-11118888-9999-aaaa-bbbb-cccceeeeeeee/some-manifest
+
+    The quad-structure is described in the documentation:
+
+        * Docs: https://git.io/JLP2b
+
+    :returns: (path to AIPstore (py.path, list of all paths, package
+        dirs (tuple)} (tuple)
+    """
+    aipstore = tmpdir.mkdir(AIPSTORE)
+    aipstore_path = str(aipstore)
+
+    some_file_name = "some-manifest"
+    some_data = "some_data"
+
+    for path, aip_name in UNCOMPRESSED_AIPS:
+        # Write some data to simulate an actual package in the storage
+        # service.
+        path_to_write_to = os.path.join(aipstore_path, path, aip_name)
+        os.makedirs(path_to_write_to)
+        some_file = os.path.join(aipstore_path, path, aip_name, some_file_name)
+        with open(some_file, "wb") as _some_file:
+            _some_file.write(some_data)
+        assert os.path.exists(some_file)
+
+    return aipstore
+
+
+@pytest.mark.parametrize(
+    "path, aip_name, remaining_directory, deleted_directory",
+    [
+        (P1, U1, R1, D1),
+        (P2, U2, R2, D2),
+        (P3, U3, R3, D3),
+        (P4, U4, R4, D4),
+        (P5, U5, R5, D5),
+        (P6, U6, R6, D6),
+        (P7, U7, R7, D7),
+    ],
+)
+def test_delete_uncompressed_path_local(
+    aipstore_uncompressed,
+    path,
+    aip_name,
+    remaining_directory,
+    deleted_directory,
+    mocker,
+):
+    """Test that local uncompressed paths are deleted as expected."""
+
+    # Initialize our space and create a path to delete.
+    sp = Space()
+    path_to_delete = os.path.join(str(aipstore_uncompressed), path, aip_name)
+
+    # rmtree is used to delete directories, we want to make sure we
+    # do call it from the delete function.
+    mocker.patch("shutil.rmtree", side_effect=shutil.rmtree)
+
+    # Make sure there is something to delete and delete it.
+    assert os.path.exists(path_to_delete)
+    sp._delete_path_local(path_to_delete)
+
+    # Verify that we called shutil to remove a directory, not a file.
+    shutil.rmtree.assert_called_with(path_to_delete)
+
+    # Make sure the path is gone.
+    assert not os.path.exists(path_to_delete)
+
+    # Make sure that the AIPSTORE part of the path is preserved.
+    aipstore = str(aipstore_uncompressed).split(path, 1)[0]
+    assert os.path.exists(aipstore)
+
+    # Assert none of the other AIPs have been deleted as a result of
+    # the function.
+    assert len(UNCOMPRESSED_AIPS) > 0
+    for aip_path, filename in UNCOMPRESSED_AIPS:
+        remaining_aip = os.path.join(aip_path, filename)
+        test_dir = os.path.join(path, aip_name)
+        if remaining_aip == test_dir:
+            continue
+        remaining_aip = os.path.join(str(aipstore_uncompressed), remaining_aip)
+        assert os.path.exists(remaining_aip)
+        # Ensure the package contains our simple manifest sample data.
+        assert len(os.listdir(remaining_aip)) == 1
+        assert os.listdir(remaining_aip)[0] == "some-manifest"
+
+    # Ensure that the correct parts of the quad-directory structure
+    # remain.
+    assert os.path.exists(os.path.join(aipstore, remaining_directory))
+    assert not os.path.exists(os.path.join(aipstore, deleted_directory))
+
+
+def test_delete_non_existant_path_local(tmpdir, aipstore_uncompressed):
+    """Test the behavior when deleting non-existent paths and ensure
+    that when this is attempted there are no negative effects on the
+    AIP store.
+    """
+
+    # Initialize our space and create a path to delete.
+    sp = Space()
+    path_to_delete = os.path.join(str(tmpdir), "does-not-exist")
+
+    # Make sure the path is essentially a nonsense path.
+    assert not os.path.exists(path_to_delete)
+
+    # There is no specific behavior for a path that doesn't exist, the
+    # function will fall through to a return of None.
+    assert sp._delete_path_local(path_to_delete) is None
+
+    # However unlikely, and in lieu of any other useful tests, make sure
+    # that there are no other side-effects i.e. the AIPstore is not affected.
+    assert len(UNCOMPRESSED_AIPS) > 0
+    for aip_path, filename in UNCOMPRESSED_AIPS:
+        remaining_aip = os.path.join(aip_path, filename)
+        remaining_aip = os.path.join(str(aipstore_uncompressed), remaining_aip)
+        assert os.path.exists(remaining_aip)


### PR DESCRIPTION
This PR implements three key components of replication and AIP deletion:

1. We now clean up AIP store quad-directory structures and do so safely.
2. When reingest is called in Archivematica replicas associated with that package are deleted. 
3. When reingest is called in Archivematica new replicas are created.

_**NB.** Contains the two commits from https://github.com/artefactual/archivematica-storage-service/pull/544 as they were used for reference as the work began and I anticipate merging on top of a `qa` branch with those in it anyway._

Testing has been added to back up these assertions trying to cover a wide-number of tests, including a handful of tests which ask digital-preservation like questions around file-properties. 

Tests have been implemented in `pytest` where possible, but the package suite is still in Python's unit test framework. They arei verbose. 

Small refactors have been done in functions we are working with, and those are documented in code, and in separate commits. Documentation of code has also been done in select cases and will largely be in separate commits. 

Connected to https://github.com/archivematica/Issues/issues/985
Connected to https://github.com/archivematica/Issues/issues/359

**Docs needed (note to self)**

* As well as: https://github.com/archivematica/Issues/issues/685
* Reingest now becomes a strategy for creating new replicas in new locations,
* As well as removing old replicas from old locations.
