### PR TITLE
S3 increased timeouts and config debugging

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -125,6 +125,11 @@ of these settings or provide values to mandatory fields.
     - **Type:** `boolean`
     - **Default:** `false`
 
+- **`SS_S3_TIMEOUTS`**:
+    - **Description:** read and connect timeouts for S3 matching your implementation's recommended defaults.
+    - **Type:** `integer`
+    - **Default:** `900`
+
 The configuration of the database is also declared via environment variables. Storage Service looks up the `SS_DB_URL` environment string. If defined, its value is expected to follow the form described in the [dj-database-url docs](https://github.com/kennethreitz/dj-database-url#url-schema), e.g.: `mysql://username:password@192.168.1.20:3306/storage_service`. If undefined, Storage Service defaults to the `django.db.backends.sqlite3` [engine](https://docs.djangoproject.com/en/1.8/ref/settings/#engine) and expects the following environment variables to be defined:
 
 - **`SS_DB_NAME`**:
@@ -260,17 +265,17 @@ These variables specify the behaviour of LDAP authentication. If `SS_LDAP_AUTHEN
     - **Description:** LDAP "bind DN"; the object to authenticate against the LDAP server with, in order
     to lookup users, e.g. "cn=admin,dc=example,dc=com".  Empty string for anonymous.
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_BIND_PASSWORD`**:
     - **Description:** Password for the LDAP bind DN.
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_USER_SEARCH_BASE_DN`**:
     - **Description:** Base LDAP DN for user search, e.g. "ou=users,dc=example,dc=com".
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_USER_SEARCH_BASE_FILTERSTR`**:
     - **Description:** Filter for identifying LDAP user objects, e.g. "(uid=%(user)s)". The `%(user)s`
@@ -283,48 +288,48 @@ These variables specify the behaviour of LDAP authentication. If `SS_LDAP_AUTHEN
     - **Description:** Template for LDAP user search, e.g. "uid=%(user)s,ou=users,dc=example,dc=com".
     Not applicable if `AUTH_LDAP_USER_SEARCH_BASE_DN` is set.
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_GROUP_IS_ACTIVE`**:
     - **Description:** Template for LDAP group used to set the Django user `is_active` flag, e.g.
     "cn=active,ou=django,ou=groups,dc=example,dc=com".
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_GROUP_IS_STAFF`**:
     - **Description:** Template for LDAP group used to set the Django user `is_staff` flag, e.g.
     "cn=staff,ou=django,ou=groups,dc=example,dc=com".
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_GROUP_IS_SUPERUSER`**:
     - **Description:** Template for LDAP group used to set the Django user `is_superuser` flag, e.g.
     "cn=admins,ou=django,ou=groups,dc=example,dc=com".
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_GROUP_SEARCH_BASE_DN`**:
     - **Description:** Base LDAP DN for group search, e.g. "ou=django,ou=groups,dc=example,dc=com".
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_GROUP_SEARCH_FILTERSTR`**:
     - **Description:** Filter for identifying LDAP group objects, e.g. "(objectClass=groupOfNames)".
     This variable is only used if `AUTH_LDAP_GROUP_SEARCH_BASE_DN` is not empty.
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_REQUIRE_GROUP`**:
     - **Description:** Filter for a group that LDAP users must belong to in order to authenticate, e.g.
     "cn=enabled,ou=django,ou=groups,dc=example,dc=com"
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_DENY_GROUP`**:
     - **Description:** Filter for a group that LDAP users must _not_ belong to in order to authenticate,
     e.g. "cn=disabled,ou=django,ou=groups,dc=example,dc=com"
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_FIND_GROUP_PERMS`**:
     - **Description:** If we should use LDAP group membership to calculate group permissions.
@@ -350,28 +355,28 @@ These variables specify the behaviour of LDAP authentication. If `SS_LDAP_AUTHEN
 - **`AUTH_LDAP_PROTOCOL_VERSION`**:
     - **Description:** If set, forces LDAP protocol version 3.
     - **Type:** `integer`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_TLS_CACERTFILE`**:
     - **Description:** Path to a custom LDAP certificate authority file.
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_TLS_CERTFILE`**:
     - **Description:** Path to a custom LDAP certificate file.
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_TLS_KEYFILE`**:
     - **Description:** Path to a custom LDAP key file (matching the cert given in `AUTH_LDAP_TLS_CERTFILE`).
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AUTH_LDAP_TLS_REQUIRE_CERT`**:
     - **Description:** How strict to be regarding TLS cerfiticate verification. Allowed values are "never",
     "allow", "try", "demand", or "hard". Corresponds to the TLSVerifyClient OpenLDAP setting.
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 ### CAS-specific environment variables
 
@@ -426,37 +431,37 @@ These variables specify the behaviour of OpenID Connect (OIDC) authentication. I
 - **`OIDC_RP_CLIENT_ID`**:
     - **Description:** OIDC client ID
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`OIDC_RP_CLIENT_SECRET`**:
     - **Description:** OIDC client secret
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AZURE_TENANT_ID`**:
     - **Description:** Azure Active Directory Tenant ID - if this is provided, the endpoint URLs will be automatically generated from this.
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`OIDC_OP_AUTHORIZATION_ENDPOINT`**:
     - **Description:** URL of OIDC provider authorization endpoint
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`OIDC_OP_TOKEN_ENDPOINT`**:
     - **Description:** URL of OIDC provider token endpoint
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`OIDC_OP_USER_ENDPOINT`**:
     - **Description:** URL of OIDC provider userinfo endpoint
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`OIDC_OP_JWKS_ENDPOINT`**:
     - **Description:** URL of OIDC provider JWKS endpoint
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`OIDC_RP_SIGN_ALGO`**:
     - **Description:** Algorithm used by the ID provider to sign ID tokens
@@ -470,31 +475,86 @@ These variables can be set to allow AWS authentication for S3 storage spaces as 
 - **`AWS_ACCESS_KEY_ID`**:
     - **Description:** Access key for AWS authentication
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 - **`AWS_SECRET_ACCESS_KEY`**:
     - **Description:** Secret key associated with the access key
     - **Type:** `string`
-    - **Default:** ``
+    - **Default:** `''`
 
 ## Logging configuration
 
-Storage Service 0.10.0 and earlier releases are configured by default to log to
-the `/var/log/archivematica/storage-service` directory, such as
-`/var/log/archivematica/storage-service/storage_service.log`. Starting with
-Storage Service 0.11.0, logging configuration defaults to using stdout and
-stderr for all logs. If no changes are made to the new default configuration
-logs will be handled by whichever process is managing Archivematica's services.
-For example on Ubuntu 16.04, Ubuntu 18.04 or CentOS 7, Archivematica's processes
-are managed by systemd. Logs for the Storage Service can be accessed using
-`sudo journalctl -u archivematica-storage-service`. When running Archivematica
-using docker, `docker-compose logs` commands can be used to access the logs from
-different containers.
+Logging configuration defaults for all logs to using `stdout` and `stderr`
+unless they are configured to do otherwise. If there are no changes to the
+default configuration they will be handled by whichever process is managing
+Archivematica's services. For example, on Ubuntu 16.04, Ubuntu 18.04 or
+CentOS 7, Archivematica's processes are managed by `systemd`. Logs for the
+Storage Service can be accessed using `sudo journalctl -u archivematica-storage
+-service`.
 
-The Storage Service will look in `/etc/archivematica` for a file called
-`storageService.logging.json`, and if found, this file will override the default
-behaviour described above.
+When running Archivematica using docker, `docker-compose logs` commands can be
+used to access the logs from different containers, e.g. `docker-compose logs
+-f archivematica-storage-service`.
 
-The [`storageService.logging.json`](./storageService.logging.json) file in this
-directory provides an example that implements the logging behaviour used in
-Storage Service 0.10.0 and earlier.
+### Overriding the logging configuration
+
+Via the Django configuration settings, i.e. [base.py][django-config], the
+storage service will look for a file in `/etc/archivematica/` called
+`storageService.logging.json`. If this file is found it can be used to override
+the default logging behavior.
+
+The [`storageService.logging.json`](./storageService.logging.json) file found
+in this installation directory provides an example that is configured to output
+to a logs directory: `/var/log/archivematica/storage-service`, i.e.
+`/var/log/archivematica/storage-service/storage_service.log`.
+
+### Increase or decrease the logging output
+
+Archivematica uses Python's standard approach to logging. There is a hierarchy
+of logging levels, at each level, more or less output can be configured. The
+values run from DEBUG (verbose) to CRITICAL (less verbose) as follows:
+
+* DEBUG.
+* INFO.
+* WARNING.
+* ERROR.
+* CRITICAL.
+
+The [Python documentation][python-docs] provides greater explanation.
+
+Though best efforts are taken to include the most useful information for
+debugging as possible your mileage may vary in debugging Archivematica or the
+Storage Service depending on the way the developer has written any particular
+module.
+
+This is largely the same with external libraries, however, increasing their
+logging level can make available more information that isn't output by choice
+in the storage service's modules. Take for example the S3 Boto3 adapter.
+Logging can be changed from INFO to DEBUG to reveal more detailed information
+about a file transfer:
+
+```js
+    "boto3": {"level": "INFO"}, // becomes "boto3.*": {"level": "DEBUG"},
+    "botocore": {"level": "INFO"} // becomes "botocore.*": {"level": "DEBUG"}
+```
+
+Debug logging should never be used on a production server without the full
+implications being understood. The Boto3 developers, for example, ask users
+to [heed their warning][boto3]:
+
+> Warning: Be aware that when logging anything from 'botocore' the full wire
+trace will appear in your logs. If your payloads contain sensitive data this
+should not be used in production.
+
+More information can be configured in Archivematica's Storage Service logging
+for additional Django web-framework components, SWORD2, and Boto3 which is used
+to manage data transfer and communication between the Storage Service and S3.
+
+New [issues][gh-issues] or pull-requests can be submitted in support of
+additional logging wherever it is needed by maintainers of Archivematica's
+services.
+
+[python-docs]: https://docs.python.org/3/howto/logging.html#when-to-use-logging
+[boto3]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/boto3.html#boto3.set_stream
+[django-config]: https://github.com/artefactual/archivematica-storage-service/blob/1adaea28b8853308b8220c493d836eb9d50eb975/storage_service/storage_service/settings/base.py
+[gh-issues]: https://github.com/archivematica/issues

--- a/install/storageService.logging.json
+++ b/install/storageService.logging.json
@@ -70,7 +70,9 @@
     },
     "sword2": {
       "level": "INFO"
-    }
+    },
+    "boto3": {"level": "INFO"},
+    "botocore": {"level": "INFO"}
   },
   "root": {
     "handlers": [

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -8,6 +8,7 @@ import pprint
 from functools import wraps
 
 # Core Django, alphabetical
+from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
@@ -79,19 +80,21 @@ class S3(models.Model):
     @property
     def resource(self):
         if not hasattr(self, "_resource"):
+            config = botocore.config.Config(
+                connect_timeout=settings.S3_TIMEOUTS, read_timeout=settings.S3_TIMEOUTS
+            )
             boto_args = {
                 "service_name": "s3",
                 "endpoint_url": self.endpoint_url,
                 "region_name": self.region,
+                "config": config,
             }
             if self.access_key_id and self.secret_access_key:
                 boto_args.update(
                     aws_access_key_id=self.access_key_id,
                     aws_secret_access_key=self.secret_access_key,
                 )
-
             self._resource = boto3.resource(**boto_args)
-
         return self._resource
 
     @boto_exception

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -13,6 +13,9 @@ from sys import path
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
 
+# S3 adapter configuration.
+from .components.s3 import *
+
 from storage_service.settings.helpers import get_env_variable, is_true
 
 try:
@@ -290,6 +293,8 @@ LOGGING = {
         "common": {"level": "DEBUG"},
         "locations": {"level": "DEBUG"},
         "sword2": {"level": "INFO"},
+        "boto3": {"level": "INFO"},
+        "botocore": {"level": "INFO"},
     },
     "root": {"handlers": ["console"], "level": "WARNING"},
 }

--- a/storage_service/storage_service/settings/components/s3.py
+++ b/storage_service/storage_service/settings/components/s3.py
@@ -1,0 +1,16 @@
+"""Configure S3
+
+From here we can configure aspects of S3 in the Storage Service.
+"""
+from os import environ
+
+from django.core.exceptions import ImproperlyConfigured
+
+# Read and connect timeouts for S3. Ideally these will match the
+# defaults recommended by your S3 implementation.
+S3_TIMEOUTS = 900
+try:
+    S3_TIMEOUTS = int(environ.get("SS_S3_TIMEOUTS", S3_TIMEOUTS))
+except ValueError:
+    err_msg = "S3 timeout value configured incorrectly in the environment - please check the 'S3_TIMEOUTS' variable"
+    raise ImproperlyConfigured(err_msg)


### PR DESCRIPTION
Introduces a configuration block for S3 which will be useful for more fine-grained control in future. In this instance it allows us to increase the S3 timeout to enable big packages to be sent over the wire where we were seeing some system limits breached before. The default 60 second timeout was too short and so we have opted for 900 which is referenced in a clients S3 implementation from Hitachi. 

Users can now control Boto3 logging more easily using the standard mechanisms available in the Storage Service through Python's logging implementation. The logging README has been brought up to date and is hopefully a little more user-friendly. We would like more than just developers to make use of the logging abilities of the storage service for debugging. 

This PR is complemented with a [storage service docs](https://github.com/artefactual/archivematica-storage-service-docs/pull/45) PR that will help users of the S3 service. 

Connected to archivematica/issues#1346