### PR TITLE
Make password validation UX tweaks

### DIFF
--- a/storage_service/administration/views.py
+++ b/storage_service/administration/views.py
@@ -95,6 +95,12 @@ def user_edit(request, id):
         api_key.save()
         messages.success(request, _("Password changed."))
         return redirect("administration:user_list")
+    elif "password":
+        # Ensure user form information still displays after an invalid
+        # password change attempt.
+        user_form = settings_forms.UserChangeForm(
+            instance=edit_user, current_user=request.user
+        )
     return render(request, "administration/user_form.html", locals())
 
 


### PR DESCRIPTION
This commit resolves two issues identified during client testing of the password validation feature:

- Ensure that user attribute similarity validation works for all user attributes, not just username, by doing password validation in `UserCreationForm` after `self.instance` is updated with validated form data.
- Ensure user attributes do not disappear on edit user screen after an invalid password change attempt. This is a long-standing UX issue but was made more visible during QA for the password validation feature.

I also cleaned up the docstrings for the `UserCreationForm` and `UserChangeForm`.

Connected to archivematica/issues#1332