### PR TITLE
Add audit log middleware

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -120,6 +120,11 @@ of these settings or provide values to mandatory fields.
     - **Type:** `boolean`
     - **Default:** `false`
 
+- **`SS_AUDIT_LOG_MIDDLEWARE`**:
+    - **Description:** enable X-Username header with authenticated HTTP responses.
+    - **Type:** `boolean`
+    - **Default:** `false`
+
 The configuration of the database is also declared via environment variables. Storage Service looks up the `SS_DB_URL` environment string. If defined, its value is expected to follow the form described in the [dj-database-url docs](https://github.com/kennethreitz/dj-database-url#url-schema), e.g.: `mysql://username:password@192.168.1.20:3306/storage_service`. If undefined, Storage Service defaults to the `django.db.backends.sqlite3` [engine](https://docs.djangoproject.com/en/1.8/ref/settings/#engine) and expects the following environment variables to be defined:
 
 - **`SS_DB_NAME`**:

--- a/storage_service/common/middleware.py
+++ b/storage_service/common/middleware.py
@@ -16,6 +16,19 @@ if hasattr(settings, "LOGIN_EXEMPT_URLS"):
     EXEMPT_URLS += [compile(expr) for expr in settings.LOGIN_EXEMPT_URLS]
 
 
+class AuditLogMiddleware(object):
+    """Add X-Username header with authenticated user to responses."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if request.user.is_authenticated:
+            response["X-Username"] = request.user.get_username()
+        return response
+
+
 class LoginRequiredMiddleware(MiddlewareMixin):
     """
     Middleware that requires a user to be authenticated to view any page other

--- a/storage_service/common/tests/test_middleware.py
+++ b/storage_service/common/tests/test_middleware.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.test.client import Client
+
+
+class AuditLogMiddlewareTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User = get_user_model()
+        self.user = User.objects.create_user(username="testclient", password="test")
+        self.client.force_login(self.user)
+
+    def test_audit_log_middleware_adds_username(self):
+        """Test that X-Username is added for authenticated users."""
+        with self.modify_settings(
+            MIDDLEWARE={"append": "common.middleware.AuditLogMiddleware"}
+        ):
+            response = self.client.get("/")
+            self.assertTrue(response.has_header("X-Username"))
+            self.assertEqual(response["X-Username"], self.user.username)
+
+    def test_audit_log_middleware_unauthenticated(self):
+        """Test absence of X-Username header for unauthenticated users.
+
+        First we logout the authenticated user, and then we check for
+        the presence of X-Username in the response for a new request by
+        an unauthenticated user.
+        """
+        with self.modify_settings(
+            MIDDLEWARE={"append": "common.middleware.AuditLogMiddleware"}
+        ):
+            self.client.logout()
+
+            response = self.client.get(settings.LOGIN_URL)
+            self.assertFalse(response.has_header("X-Username"))

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -197,6 +197,10 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+AUDIT_LOG_MIDDLEWARE = is_true(environ.get("SS_AUDIT_LOG_MIDDLEWARE", "false"))
+if AUDIT_LOG_MIDDLEWARE:
+    MIDDLEWARE.append("common.middleware.AuditLogMiddleware")
 # ######## END MIDDLEWARE CONFIGURATION
 
 


### PR DESCRIPTION
This commit adds middleware which adds an `X-Username` header with the name of the authenticated user to each response sent from the Storage Service. This provides a mechanism for audit logging of user behaviour via the nginx access logs.

Connected to https://github.com/archivematica/Issues/issues/1341