### PR TITLE
Update lxml and cryptography

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,7 +13,7 @@ gunicorn==19.9.0
 importlib_resources~=1.4
 jsonfield==2.0.1
 logutils==0.3.4.1
-lxml==3.7.3
+lxml~=4.6
 metsrw==0.3.15
 ndg-httpsclient==0.4.2
 pathlib2==2.3.5; python_version < '3.0'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,17 +5,17 @@
 #    pip-compile --output-file=base.txt base.in
 #
 agentarchives==0.6.0      # via -r base.in
-babel==2.8.0              # via oslo.i18n
+babel==2.9.0              # via oslo.i18n
 bagit==1.7.0              # via -r base.in
 boto3==1.9.174            # via -r base.in
 botocore==1.12.253        # via -r base.in, boto3, s3transfer
 brotli==0.5.2             # via -r base.in
-certifi==2020.6.20        # via requests
-cffi==1.14.1              # via cryptography
+certifi==2020.12.5        # via requests
+cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, zipp
-cryptography==3.0         # via josepy, mozilla-django-oidc, pyopenssl
+cryptography==3.3.1       # via josepy, mozilla-django-oidc, pyopenssl
 debtcollector==1.22.0     # via oslo.config, oslo.utils, python-keystoneclient
 defusedxml==0.5.0         # via -r base.in
 django-auth-ldap==1.3.0   # via -r base.in
@@ -31,24 +31,24 @@ funcsigs==1.0.2           # via debtcollector, oslo.utils
 future==0.18.2            # via metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r base.in, python-swiftclient, s3transfer
 gevent==1.3.6             # via -r base.in
-greenlet==0.4.16          # via gevent
+greenlet==1.0.0           # via gevent
 gunicorn==19.9.0          # via -r base.in
 httplib2==0.18.1          # via sword2
 idna==2.8                 # via requests
-importlib-metadata==1.7.0  # via importlib-resources
+importlib-metadata==2.1.1  # via importlib-resources
 importlib-resources==1.5.0  # via -r base.in, netaddr
 ipaddress==1.0.23         # via cryptography
-iso8601==0.1.12           # via keystoneauth1, oslo.utils
+iso8601==0.1.13           # via keystoneauth1, oslo.utils
 jmespath==0.10.0          # via boto3, botocore
-josepy==1.3.0             # via mozilla-django-oidc
+josepy==1.6.0             # via mozilla-django-oidc
 jsonfield==2.0.1          # via -r base.in
 keystoneauth1==4.0.1      # via python-keystoneclient
 logutils==0.3.4.1         # via -r base.in
-lxml==3.7.3               # via -r base.in, metsrw, python-cas
+lxml==4.6.2               # via -r base.in, metsrw, python-cas
 metsrw==0.3.15            # via -r base.in
 monotonic==1.5            # via oslo.utils
-mozilla-django-oidc==1.2.3  # via -r base.in
-msgpack==1.0.0            # via oslo.serialization
+mozilla-django-oidc==1.2.4  # via -r base.in
+msgpack==1.0.2            # via oslo.serialization
 mysqlclient==1.4.6        # via agentarchives
 ndg-httpsclient==0.4.2    # via -r base.in
 netaddr==0.8.0            # via oslo.config, oslo.utils
@@ -60,13 +60,13 @@ oslo.i18n==3.25.1         # via oslo.config, oslo.utils, python-keystoneclient
 oslo.serialization==2.29.2  # via python-keystoneclient
 oslo.utils==3.42.1        # via oslo.serialization, python-keystoneclient
 pathlib2==2.3.5 ; python_version < "3.0"  # via -r base.in, importlib-metadata, importlib-resources
-pbr==5.4.5                # via debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
+pbr==5.5.1                # via debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
 positional==1.2.1         # via python-keystoneclient
 prometheus-client==0.7.1  # via -r base.in, django-prometheus
 pyasn1-modules==0.2.8     # via python-ldap
 pyasn1==0.4.8             # via pyasn1-modules, python-ldap
 pycparser==2.20           # via cffi
-pyopenssl==19.1.0         # via josepy, ndg-httpsclient
+pyopenssl==20.0.1         # via josepy, ndg-httpsclient
 pyparsing==2.4.7          # via oslo.utils
 python-cas==1.5.0         # via django-cas-ng
 python-dateutil==2.8.1    # via botocore, django-tastypie
@@ -75,8 +75,8 @@ python-keystoneclient==3.10.0  # via -r base.in
 python-ldap==3.2.0        # via -r base.in, django-auth-ldap
 python-mimeparse==1.6.0   # via django-tastypie
 python-swiftclient==3.3.0  # via -r base.in
-pytz==2020.1              # via babel, django, oslo.serialization, oslo.utils
-pyyaml==5.3.1             # via oslo.config, oslo.serialization
+pytz==2020.5              # via babel, django, oslo.serialization, oslo.utils
+pyyaml==5.4.1             # via oslo.config, oslo.serialization
 requests-oauthlib==1.2.0  # via -r base.in
 requests==2.21.0          # via -r base.in, agentarchives, keystoneauth1, mozilla-django-oidc, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib
 rfc3986==1.4.0            # via oslo.config

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -5,17 +5,17 @@
 #    pip-compile --output-file=local.txt local.in
 #
 agentarchives==0.6.0      # via -r base.txt
-babel==2.8.0              # via -r base.txt, oslo.i18n
+babel==2.9.0              # via -r base.txt, oslo.i18n
 bagit==1.7.0              # via -r base.txt
 boto3==1.9.174            # via -r base.txt
 botocore==1.12.253        # via -r base.txt, boto3, s3transfer
 brotli==0.5.2             # via -r base.txt
-certifi==2020.6.20        # via -r base.txt, requests
-cffi==1.14.1              # via -r base.txt, cryptography
+certifi==2020.12.5        # via -r base.txt, requests
+cffi==1.14.4              # via -r base.txt, cryptography
 chardet==3.0.4            # via -r base.txt, requests
 configparser==4.0.2       # via -r base.txt, importlib-metadata
 contextlib2==0.6.0.post1  # via -r base.txt, importlib-metadata, importlib-resources, zipp
-cryptography==3.0         # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
+cryptography==3.3.1       # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
 debtcollector==1.22.0     # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
 defusedxml==0.5.0         # via -r base.txt
 dj-database-url==0.4.2    # via -r local.in
@@ -32,27 +32,27 @@ funcsigs==1.0.2           # via -r base.txt, debtcollector, oslo.utils
 future==0.18.2            # via -r base.txt, metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r base.txt, python-swiftclient, s3transfer
 gevent==1.3.6             # via -r base.txt
-greenlet==0.4.16          # via -r base.txt, gevent
+greenlet==1.0.0           # via -r base.txt, gevent
 gunicorn==19.9.0          # via -r base.txt
 httplib2==0.18.1          # via -r base.txt, sword2
 idna==2.8                 # via -r base.txt, requests
-importlib-metadata==1.7.0  # via -r base.txt, importlib-resources
+importlib-metadata==2.1.1  # via -r base.txt, importlib-resources
 importlib-resources==1.5.0  # via -r base.txt, netaddr
 ipaddress==1.0.23         # via -r base.txt, cryptography
 ipython==1.1.0            # via -r local.in
-iso8601==0.1.12           # via -r base.txt, keystoneauth1, oslo.utils
+iso8601==0.1.13           # via -r base.txt, keystoneauth1, oslo.utils
 jinja2==2.11.2            # via sphinx
 jmespath==0.10.0          # via -r base.txt, boto3, botocore
-josepy==1.3.0             # via -r base.txt, mozilla-django-oidc
+josepy==1.6.0             # via -r base.txt, mozilla-django-oidc
 jsonfield==2.0.1          # via -r base.txt
 keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base.txt
-lxml==3.7.3               # via -r base.txt, metsrw, python-cas
+lxml==4.6.2               # via -r base.txt, metsrw, python-cas
 markupsafe==1.1.1         # via jinja2
 metsrw==0.3.15            # via -r base.txt
 monotonic==1.5            # via -r base.txt, oslo.utils
-mozilla-django-oidc==1.2.3  # via -r base.txt
-msgpack==1.0.0            # via -r base.txt, oslo.serialization
+mozilla-django-oidc==1.2.4  # via -r base.txt
+msgpack==1.0.2            # via -r base.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.4.2    # via -r base.txt
 netaddr==0.8.0            # via -r base.txt, oslo.config, oslo.utils
@@ -64,7 +64,7 @@ oslo.i18n==3.25.1         # via -r base.txt, oslo.config, oslo.utils, python-key
 oslo.serialization==2.29.2  # via -r base.txt, python-keystoneclient
 oslo.utils==3.42.1        # via -r base.txt, oslo.serialization, python-keystoneclient
 pathlib2==2.3.5 ; python_version < "3.0"  # via -r base.txt, importlib-metadata, importlib-resources
-pbr==5.4.5                # via -r base.txt, debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
+pbr==5.5.1                # via -r base.txt, debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
 positional==1.2.1         # via -r base.txt, python-keystoneclient
 prometheus-client==0.7.1  # via -r base.txt, django-prometheus
 psycopg2==2.7.1           # via -r local.in
@@ -72,7 +72,7 @@ pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r base.txt, cffi
 pygments==2.5.2           # via sphinx
-pyopenssl==19.1.0         # via -r base.txt, josepy, ndg-httpsclient
+pyopenssl==20.0.1         # via -r base.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via -r base.txt, oslo.utils
 python-cas==1.5.0         # via -r base.txt, django-cas-ng
 python-dateutil==2.8.1    # via -r base.txt, botocore, django-tastypie
@@ -81,8 +81,8 @@ python-keystoneclient==3.10.0  # via -r base.txt
 python-ldap==3.2.0        # via -r base.txt, django-auth-ldap
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
 python-swiftclient==3.3.0  # via -r base.txt
-pytz==2020.1              # via -r base.txt, babel, django, oslo.serialization, oslo.utils
-pyyaml==5.3.1             # via -r base.txt, oslo.config, oslo.serialization
+pytz==2020.5              # via -r base.txt, babel, django, oslo.serialization, oslo.utils
+pyyaml==5.4.1             # via -r base.txt, oslo.config, oslo.serialization
 requests-oauthlib==1.2.0  # via -r base.txt
 requests==2.21.0          # via -r base.txt, agentarchives, keystoneauth1, mozilla-django-oidc, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib
 rfc3986==1.4.0            # via -r base.txt, oslo.config

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,17 +5,17 @@
 #    pip-compile --output-file=production.txt production.in
 #
 agentarchives==0.6.0      # via -r base.txt
-babel==2.8.0              # via -r base.txt, oslo.i18n
+babel==2.9.0              # via -r base.txt, oslo.i18n
 bagit==1.7.0              # via -r base.txt
 boto3==1.9.174            # via -r base.txt
 botocore==1.12.253        # via -r base.txt, boto3, s3transfer
 brotli==0.5.2             # via -r base.txt
-certifi==2020.6.20        # via -r base.txt, requests
-cffi==1.14.1              # via -r base.txt, cryptography
+certifi==2020.12.5        # via -r base.txt, requests
+cffi==1.14.4              # via -r base.txt, cryptography
 chardet==3.0.4            # via -r base.txt, requests
 configparser==4.0.2       # via -r base.txt, importlib-metadata
 contextlib2==0.6.0.post1  # via -r base.txt, importlib-metadata, importlib-resources, zipp
-cryptography==3.0         # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
+cryptography==3.3.1       # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
 debtcollector==1.22.0     # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
 defusedxml==0.5.0         # via -r base.txt
 dj-database-url==0.4.2    # via -r production.in
@@ -32,24 +32,24 @@ funcsigs==1.0.2           # via -r base.txt, debtcollector, oslo.utils
 future==0.18.2            # via -r base.txt, metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r base.txt, python-swiftclient, s3transfer
 gevent==1.3.6             # via -r base.txt
-greenlet==0.4.16          # via -r base.txt, gevent
+greenlet==1.0.0           # via -r base.txt, gevent
 gunicorn==19.9.0          # via -r base.txt
 httplib2==0.18.1          # via -r base.txt, sword2
 idna==2.8                 # via -r base.txt, requests
-importlib-metadata==1.7.0  # via -r base.txt, importlib-resources
+importlib-metadata==2.1.1  # via -r base.txt, importlib-resources
 importlib-resources==1.5.0  # via -r base.txt, netaddr
 ipaddress==1.0.23         # via -r base.txt, cryptography
-iso8601==0.1.12           # via -r base.txt, keystoneauth1, oslo.utils
+iso8601==0.1.13           # via -r base.txt, keystoneauth1, oslo.utils
 jmespath==0.10.0          # via -r base.txt, boto3, botocore
-josepy==1.3.0             # via -r base.txt, mozilla-django-oidc
+josepy==1.6.0             # via -r base.txt, mozilla-django-oidc
 jsonfield==2.0.1          # via -r base.txt
 keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base.txt
-lxml==3.7.3               # via -r base.txt, metsrw, python-cas
+lxml==4.6.2               # via -r base.txt, metsrw, python-cas
 metsrw==0.3.15            # via -r base.txt
 monotonic==1.5            # via -r base.txt, oslo.utils
-mozilla-django-oidc==1.2.3  # via -r base.txt
-msgpack==1.0.0            # via -r base.txt, oslo.serialization
+mozilla-django-oidc==1.2.4  # via -r base.txt
+msgpack==1.0.2            # via -r base.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.4.2    # via -r base.txt
 netaddr==0.8.0            # via -r base.txt, oslo.config, oslo.utils
@@ -61,14 +61,14 @@ oslo.i18n==3.25.1         # via -r base.txt, oslo.config, oslo.utils, python-key
 oslo.serialization==2.29.2  # via -r base.txt, python-keystoneclient
 oslo.utils==3.42.1        # via -r base.txt, oslo.serialization, python-keystoneclient
 pathlib2==2.3.5 ; python_version < "3.0"  # via -r base.txt, importlib-metadata, importlib-resources
-pbr==5.4.5                # via -r base.txt, debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
+pbr==5.5.1                # via -r base.txt, debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
 positional==1.2.1         # via -r base.txt, python-keystoneclient
 prometheus-client==0.7.1  # via -r base.txt, django-prometheus
 psycopg2==2.7.1           # via -r production.in
 pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r base.txt, cffi
-pyopenssl==19.1.0         # via -r base.txt, josepy, ndg-httpsclient
+pyopenssl==20.0.1         # via -r base.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via -r base.txt, oslo.utils
 python-cas==1.5.0         # via -r base.txt, django-cas-ng
 python-dateutil==2.8.1    # via -r base.txt, botocore, django-tastypie
@@ -77,8 +77,8 @@ python-keystoneclient==3.10.0  # via -r base.txt
 python-ldap==3.2.0        # via -r base.txt, django-auth-ldap
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
 python-swiftclient==3.3.0  # via -r base.txt
-pytz==2020.1              # via -r base.txt, babel, django, oslo.serialization, oslo.utils
-pyyaml==5.3.1             # via -r base.txt, oslo.config, oslo.serialization
+pytz==2020.5              # via -r base.txt, babel, django, oslo.serialization, oslo.utils
+pyyaml==5.4.1             # via -r base.txt, oslo.config, oslo.serialization
 requests-oauthlib==1.2.0  # via -r base.txt
 requests==2.21.0          # via -r base.txt, agentarchives, keystoneauth1, mozilla-django-oidc, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib
 rfc3986==1.4.0            # via -r base.txt, oslo.config

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,22 +7,22 @@
 agentarchives==0.6.0      # via -r base.txt
 appdirs==1.4.4            # via virtualenv
 atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via pytest
-babel==2.8.0              # via -r base.txt, oslo.i18n
+attrs==20.3.0             # via pytest
+babel==2.9.0              # via -r base.txt, oslo.i18n
 backports.functools-lru-cache==1.6.1  # via wcwidth
 backports.shutil-get-terminal-size==1.0.0  # via ipython
 bagit==1.7.0              # via -r base.txt
 boto3==1.9.174            # via -r base.txt
 botocore==1.12.253        # via -r base.txt, boto3, s3transfer
 brotli==0.5.2             # via -r base.txt
-certifi==2020.6.20        # via -r base.txt, requests
-cffi==1.14.1              # via -r base.txt, cryptography
+certifi==2020.12.5        # via -r base.txt, requests
+cffi==1.14.4              # via -r base.txt, cryptography
 chardet==3.0.4            # via -r base.txt, requests
 click==7.1.2              # via pip-tools
 configparser==4.0.2       # via -r base.txt, importlib-metadata
 contextlib2==0.6.0.post1  # via -r base.txt, importlib-metadata, importlib-resources, vcrpy, zipp
 coverage==4.2             # via -r test.in, pytest-cov
-cryptography==3.0         # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
+cryptography==3.3.1       # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
 debtcollector==1.22.0     # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
 decorator==4.4.2          # via ipython, traitlets
 defusedxml==0.5.0         # via -r base.txt
@@ -42,29 +42,29 @@ functools32==3.2.3.post2 ; python_version < "3.0"  # via -r test.in
 future==0.18.2            # via -r base.txt, metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r base.txt, python-swiftclient, s3transfer
 gevent==1.3.6             # via -r base.txt
-greenlet==0.4.16          # via -r base.txt, gevent
+greenlet==1.0.0           # via -r base.txt, gevent
 gunicorn==19.9.0          # via -r base.txt
 httplib2==0.18.1          # via -r base.txt, sword2
 idna==2.8                 # via -r base.txt, requests
-importlib-metadata==1.7.0  # via -r base.txt, importlib-resources, pluggy, tox, virtualenv
+importlib-metadata==2.1.1  # via -r base.txt, importlib-resources, pluggy, tox, virtualenv
 importlib-resources==1.5.0  # via -r base.txt, netaddr, virtualenv
 ipaddress==1.0.23         # via -r base.txt, cryptography
-ipdb==0.13.3              # via -r test.in
+ipdb==0.13.4              # via -r test.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.10.0           # via ipdb
-iso8601==0.1.12           # via -r base.txt, keystoneauth1, oslo.utils
+iso8601==0.1.13           # via -r base.txt, keystoneauth1, oslo.utils
 jmespath==0.10.0          # via -r base.txt, boto3, botocore
-josepy==1.3.0             # via -r base.txt, mozilla-django-oidc
+josepy==1.6.0             # via -r base.txt, mozilla-django-oidc
 jsonfield==2.0.1          # via -r base.txt
 keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base.txt
-lxml==3.7.3               # via -r base.txt, metsrw, python-cas
+lxml==4.6.2               # via -r base.txt, metsrw, python-cas
 metsrw==0.3.15            # via -r base.txt
 mock==3.0.5               # via pytest-mock, vcrpy
 monotonic==1.5            # via -r base.txt, oslo.utils
 more-itertools==5.0.0     # via pytest
-mozilla-django-oidc==1.2.3  # via -r base.txt
-msgpack==1.0.0            # via -r base.txt, oslo.serialization
+mozilla-django-oidc==1.2.4  # via -r base.txt
+msgpack==1.0.2            # via -r base.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.4.2    # via -r base.txt
 netaddr==0.8.0            # via -r base.txt, oslo.config, oslo.utils
@@ -75,9 +75,9 @@ oslo.config==7.0.0        # via -r base.txt, python-keystoneclient
 oslo.i18n==3.25.1         # via -r base.txt, oslo.config, oslo.utils, python-keystoneclient
 oslo.serialization==2.29.2  # via -r base.txt, python-keystoneclient
 oslo.utils==3.42.1        # via -r base.txt, oslo.serialization, python-keystoneclient
-packaging==20.4           # via tox
+packaging==20.8           # via tox
 pathlib2==2.3.5 ; python_version < "3.0"  # via -r base.txt, importlib-metadata, importlib-resources, ipython, pickleshare, pytest, pytest-django, virtualenv
-pbr==5.4.5                # via -r base.txt, debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
+pbr==5.5.1                # via -r base.txt, debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pip-tools==5.1.2          # via -r test.in
@@ -85,16 +85,16 @@ pluggy==0.13.1            # via pytest, tox
 positional==1.2.1         # via -r base.txt, python-keystoneclient
 prometheus-client==0.7.1  # via -r base.txt, django-prometheus
 prompt-toolkit==1.0.18    # via ipython
-ptyprocess==0.6.0         # via pexpect
-py==1.9.0                 # via pytest, tox
+ptyprocess==0.7.0         # via pexpect
+py==1.10.0                # via pytest, tox
 pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r base.txt, cffi
 pygments==2.5.2           # via ipython
-pyopenssl==19.1.0         # via -r base.txt, josepy, ndg-httpsclient
+pyopenssl==20.0.1         # via -r base.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via -r base.txt, oslo.utils, packaging
 pytest-cov==2.4.0         # via -r test.in
-pytest-django==3.9.0      # via -r test.in
+pytest-django==3.10.0     # via -r test.in
 pytest-mock==1.13.0       # via -r test.in
 pytest==3.8.0             # via -r test.in, pytest-cov, pytest-django, pytest-mock
 python-cas==1.5.0         # via -r base.txt, django-cas-ng
@@ -104,8 +104,8 @@ python-keystoneclient==3.10.0  # via -r base.txt
 python-ldap==3.2.0        # via -r base.txt, django-auth-ldap
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
 python-swiftclient==3.3.0  # via -r base.txt
-pytz==2020.1              # via -r base.txt, babel, django, oslo.serialization, oslo.utils
-pyyaml==5.3.1             # via -r base.txt, oslo.config, oslo.serialization, vcrpy
+pytz==2020.5              # via -r base.txt, babel, django, oslo.serialization, oslo.utils
+pyyaml==5.4.1             # via -r base.txt, oslo.config, oslo.serialization, vcrpy
 requests-oauthlib==1.2.0  # via -r base.txt
 requests==2.21.0          # via -r base.txt, agentarchives, keystoneauth1, mozilla-django-oidc, oslo.config, python-cas, python-keystoneclient, python-swiftclient, requests-oauthlib
 rfc3986==1.4.0            # via -r base.txt, oslo.config
@@ -113,16 +113,16 @@ s3transfer==0.2.1         # via -r base.txt, boto3
 scandir==1.10.0           # via -r base.txt, pathlib2
 simplegeneric==0.8.1      # via ipython
 singledispatch==3.4.0.3   # via -r base.txt, importlib-resources
-six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, mock, more-itertools, mozilla-django-oidc, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pytest, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore, tox, traitlets, vcrpy, virtualenv
+six==1.15.0               # via -r base.txt, cryptography, debtcollector, django-extensions, josepy, keystoneauth1, metsrw, mock, more-itertools, mozilla-django-oidc, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pytest, python-cas, python-dateutil, python-keystoneclient, python-swiftclient, singledispatch, stevedore, tox, traitlets, vcrpy, virtualenv
 stevedore==1.32.0         # via -r base.txt, keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1             # via -r base.txt
-toml==0.10.1              # via tox
-tox==3.19.0               # via -r test.in
+toml==0.10.2              # via tox
+tox==3.21.3               # via -r test.in
 traitlets==4.3.3          # via ipython
 typing==3.7.4.3           # via -r base.txt, importlib-resources
 urllib3==1.24.3           # via -r base.txt, botocore, requests
 vcrpy==3.0.0              # via -r test.in
-virtualenv==20.0.30       # via tox
+virtualenv==20.4.0        # via tox
 wcwidth==0.2.5            # via prompt-toolkit
 whitenoise==3.3.0         # via -r base.txt
 wrapt==1.12.1             # via -r base.txt, debtcollector, positional, vcrpy


### PR DESCRIPTION
Using "lxml~=4.6". Other dependencies without fixed constrains are updated too.

Connects to https://github.com/archivematica/Issues/issues/1317.