### PR TITLE
Add gettext package dependency

### DIFF
--- a/osdeps/CentOS-7.json
+++ b/osdeps/CentOS-7.json
@@ -24,6 +24,7 @@
    { "name": "openssl-devel", "state": "latest"},
    { "name": "gcc", "state": "latest"},
    { "name": "gcc-c++", "state": "latest"},
+   { "name": "gettext", "state": "latest"},
    { "name": "p7zip", "state": "latest"},
    { "name": "p7zip-plugins", "state": "latest"},
    { "name": "gnupg", "state": "latest"},

--- a/osdeps/RedHat-7.json
+++ b/osdeps/RedHat-7.json
@@ -24,6 +24,7 @@
    { "name": "openssl-devel", "state": "latest"},
    { "name": "gcc", "state": "latest"},
    { "name": "gcc-c++", "state": "latest"},
+   { "name": "gettext", "state": "latest"},
    { "name": "p7zip", "state": "latest"},
    { "name": "p7zip-plugins", "state": "latest"},
    { "name": "gnupg", "state": "latest"},

--- a/osdeps/Ubuntu-16.json
+++ b/osdeps/Ubuntu-16.json
@@ -22,6 +22,7 @@
    { "name": "libffi-dev", "state": "latest"},
    { "name": "libssl-dev", "state": "latest"},
    { "name": "gcc", "state": "latest"},
+   { "name": "gettext", "state": "latest"},
    { "name": "gnupg", "state": "latest"},
    { "name": "rng-tools", "state": "latest"},
    { "name": "libsasl2-dev", "state": "latest"},

--- a/osdeps/Ubuntu-18.json
+++ b/osdeps/Ubuntu-18.json
@@ -25,6 +25,7 @@
    { "name": "libffi-dev", "state": "latest"},
    { "name": "libssl-dev", "state": "latest"},
    { "name": "gcc", "state": "latest"},
+   { "name": "gettext", "state": "latest"},
    { "name": "gnupg1", "state": "latest"},
    { "name": "rng-tools", "state": "latest"},
    { "name": "libsasl2-dev", "state": "latest"},


### PR DESCRIPTION
It's needed to run the compilemessages django command

Fixes https://github.com/archivematica/Issues/issues/1421.
Connects to https://github.com/archivematica/Issues/issues/1317.
Connects to https://github.com/archivematica/Issues/issues/1319.