### PR TITLE
Log traceback when the watchdog loop catches an exception

### DIFF
--- a/storage_service/locations/metrics.py
+++ b/storage_service/locations/metrics.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import time
+from contextlib import contextmanager
+
+from prometheus_client import Counter, Gauge
+
+
+async_manager_running_tasks = Gauge(
+    "async_manager_running_tasks",
+    "Number of tasks being executed",
+)
+
+async_manager_watchdog_time_counter = Counter(
+    "async_manager_watchdog_loop_duration_seconds",
+    ("Total time taken by a watchdog loop iteration in seconds"),
+)
+
+
+@contextmanager
+def watchdog_loop_timer():
+    start_time = time.time()
+    try:
+        yield
+    finally:
+        duration = time.time() - start_time
+        async_manager_watchdog_time_counter.inc(duration)

--- a/storage_service/locations/models/async_manager.py
+++ b/storage_service/locations/models/async_manager.py
@@ -127,6 +127,11 @@ class AsyncManager(object):
     def _wrap_task(task, task_fn):
         """Run a function, capturing its output/errors in `task`"""
 
+        # Share stack of the caller with the task thread, excluding this func.
+        stack = traceback.extract_stack()[:-2]
+        message = "Caller's traceback (most recent call last):\n"
+        message += "".join(traceback.format_list(stack))
+
         def wrapper(*args, **kwargs):
             value = error = None
 
@@ -134,7 +139,7 @@ class AsyncManager(object):
                 value = task_fn(*args, **kwargs)
             except Exception as e:
                 error = e
-                LOGGER.exception("Task threw an error: " + str(e))
+                LOGGER.exception("Task threw an error: " + str(e) + "\n" + message)
 
             if error:
                 task.was_error = True

--- a/storage_service/locations/models/async_manager.py
+++ b/storage_service/locations/models/async_manager.py
@@ -59,7 +59,7 @@ class AsyncManager(object):
                 with metrics.watchdog_loop_timer():
                     AsyncManager._watchdog_loop()
             except Exception as e:
-                LOGGER.warning("Failure in watchdog thread: %s", e)
+                LOGGER.warning("Failure in watchdog thread: %s", e, exc_info=True)
 
             time.sleep(WATCHDOG_POLL_SECONDS)
 


### PR DESCRIPTION
For users relying on the Async API, the watchdog loop was only reporting warning messages when exceptions were detected. f89404a424b1eba3565a67d742b45e60d238e139 updates the logging entry so it includes the traceback (fixing https://github.com/archivematica/Issues/issues/742).

Additionally, this pull request (1) changes the logging of deferred tasks so it includes the traceback of the caller's frame, and (2) updates the watchdog loop so it reports currently running tasks using a gauge metric, removing unnecessary logging filling up our log streams.