### PR TITLE
Use server-side processing for fixity checks table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,4 @@ ENV DJANGO_SETTINGS_MODULE storage_service.settings.production
 
 EXPOSE 8000
 
-ENTRYPOINT /usr/local/bin/gunicorn --config=/etc/archivematica/storage-service.gunicorn-config.py storage_service.wsgi:application
+ENTRYPOINT ["/usr/local/bin/gunicorn", "--config=/etc/archivematica/storage-service.gunicorn-config.py", "storage_service.wsgi:application"]

--- a/storage_service/locations/datatable_utils.py
+++ b/storage_service/locations/datatable_utils.py
@@ -60,7 +60,7 @@ class PackageDataTable(object):
             search = self.params["search"]
             # remove any leading slashes so we can search in relative paths
             search_as_path = search.lstrip(os.path.sep)
-            search_filter |= (
+            search_filter &= (
                 Q(uuid__icontains=search)
                 | Q(description__icontains=search)
                 | Q(origin_pipeline__uuid__icontains=search)
@@ -191,7 +191,7 @@ class FixityLogDataTable(PackageDataTable):
         self.echo = self.params["echo"]
         if self.params["search"]:
             search = self.params["search"]
-            search_filter |= Q(error_details__icontains=search)
+            search_filter &= Q(error_details__icontains=search)
         queryset = self.model.objects.filter(search_filter).distinct()
         self.total_display_records = queryset.count()
         self.records = self.get_records(queryset)

--- a/storage_service/locations/fixtures/fixity_log.json
+++ b/storage_service/locations/fixtures/fixity_log.json
@@ -4,9 +4,39 @@
     "model": "locations.fixitylog", 
     "fields": {
         "package": "e0a41934-c1d7-45ba-9a95-a7531c063ed1",
-        "success": true,
+        "success": false,
         "error_details": "Checksum failed.",
         "datetime_reported": "2015-12-15T03:00:05.020871Z"
+    }
+},
+{
+    "pk": 2,
+    "model": "locations.fixitylog",
+    "fields": {
+        "package": "e0a41934-c1d7-45ba-9a95-a7531c063ed1",
+        "success": true,
+        "error_details": "",
+        "datetime_reported": "2016-12-15T03:00:05.020871Z"
+    }
+},
+{
+    "pk": 3,
+    "model": "locations.fixitylog",
+    "fields": {
+        "package": "e0a41934-c1d7-45ba-9a95-a7531c063ed1",
+        "success": false,
+        "error_details": "Other thing failed.",
+        "datetime_reported": "2017-12-15T03:00:05.020871Z"
+    }
+},
+{
+    "pk": 4,
+    "model": "locations.fixitylog",
+    "fields": {
+        "package": "79245866-ca80-4f84-b904-a02b3e0ab621",
+        "success": true,
+        "error_details": "",
+        "datetime_reported": "2018-12-15T03:00:05.020871Z"
     }
 }
 ]

--- a/storage_service/locations/tests/test_datatable.py
+++ b/storage_service/locations/tests/test_datatable.py
@@ -17,13 +17,13 @@ FIXTURES_DIR = os.path.abspath(os.path.join(THIS_DIR, "..", "fixtures", ""))
 TOTAL_FIXTURE_PACKAGES = 12
 
 
-class TestDataTable(TestCase):
+class TestPackageDataTable(TestCase):
 
     fixtures = ["base.json", "package.json"]
 
     def test_initialization(self):
         DISPLAY_LEN = 10
-        datatable = datatable_utils.DataTable({})
+        datatable = datatable_utils.PackageDataTable({})
         expected_params = {
             "search": "",
             "display_start": 0,
@@ -34,10 +34,10 @@ class TestDataTable(TestCase):
         assert datatable.params == expected_params
         assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
         assert datatable.total_display_records == TOTAL_FIXTURE_PACKAGES
-        assert len(datatable.packages) == DISPLAY_LEN
+        assert len(datatable.records) == DISPLAY_LEN
 
     def test_search_description(self):
-        datatable = datatable_utils.DataTable(
+        datatable = datatable_utils.PackageDataTable(
             {
                 "sSearch": "Small bagged package",
                 "iDisplayStart": 0,
@@ -55,10 +55,10 @@ class TestDataTable(TestCase):
         assert datatable.params == expected_params
         assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
         assert datatable.total_display_records == 1
-        assert len(datatable.packages) == 1
+        assert len(datatable.records) == 1
 
     def test_search_current_path(self):
-        datatable = datatable_utils.DataTable(
+        datatable = datatable_utils.PackageDataTable(
             {
                 "sSearch": "working_bag",
                 "iDisplayStart": 0,
@@ -76,10 +76,10 @@ class TestDataTable(TestCase):
         assert datatable.params == expected_params
         assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
         assert datatable.total_display_records == 3
-        assert len(datatable.packages) == 3
+        assert len(datatable.records) == 3
 
     def test_search_type(self):
-        datatable = datatable_utils.DataTable(
+        datatable = datatable_utils.PackageDataTable(
             {
                 "sSearch": "Transfer",
                 "iDisplayStart": 0,
@@ -97,11 +97,11 @@ class TestDataTable(TestCase):
         assert datatable.params == expected_params
         assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
         assert datatable.total_display_records == 3
-        assert len(datatable.packages) == 3
+        assert len(datatable.records) == 3
 
     def test_search_status(self):
         DISPLAY_LEN = 10
-        datatable = datatable_utils.DataTable(
+        datatable = datatable_utils.PackageDataTable(
             {
                 "sSearch": "Uploaded",
                 "iDisplayStart": 0,
@@ -119,7 +119,7 @@ class TestDataTable(TestCase):
         assert datatable.params == expected_params
         assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
         assert datatable.total_display_records == TOTAL_FIXTURE_PACKAGES
-        assert len(datatable.packages) == DISPLAY_LEN
+        assert len(datatable.records) == DISPLAY_LEN
 
     def _create_replicas(self, uuid):
         test_location = models.Location.objects.get(
@@ -134,7 +134,7 @@ class TestDataTable(TestCase):
         space_dir = tempfile.mkdtemp(dir=tmp_dir, prefix="space")
         replication_dir = tempfile.mkdtemp(dir=tmp_dir, prefix="replication")
         replication_dir2 = tempfile.mkdtemp(dir=tmp_dir, prefix="replication")
-        aip = models.Package.objects.get(uuid=uuid)
+        aip = models.models.Package.objects.get(uuid=uuid)
         aip.current_location.space.staging_path = space_dir
         aip.current_location.space.save()
         aip.current_location.replicators.create(
@@ -157,7 +157,7 @@ class TestDataTable(TestCase):
             "2f62b030-c3f4-4ac1-950f-fe47d0ddcd14",
             "577f74bd-a283-49e0-b4e2-f8abb81d2566",
         ]
-        datatable = datatable_utils.DataTable(
+        datatable = datatable_utils.PackageDataTable(
             {
                 "sSearch": package_uuid,
                 "iDisplayStart": 0,
@@ -177,8 +177,8 @@ class TestDataTable(TestCase):
         assert datatable.params == expected_params
         assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
         assert datatable.total_display_records == len(expected_packages_uuids)
-        assert len(datatable.packages) == len(expected_packages_uuids)
-        assert sorted([p.uuid for p in datatable.packages]) == expected_packages_uuids
+        assert len(datatable.records) == len(expected_packages_uuids)
+        assert sorted([p.uuid for p in datatable.records]) == expected_packages_uuids
 
     def test_reverse_search_replica_of(self):
         package_uuid = "f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04"
@@ -186,7 +186,7 @@ class TestDataTable(TestCase):
             "2f62b030-c3f4-4ac1-950f-fe47d0ddcd14",
             "577f74bd-a283-49e0-b4e2-f8abb81d2566",
         ]
-        datatable = datatable_utils.DataTable(
+        datatable = datatable_utils.PackageDataTable(
             {
                 "sSearch": replicas_uuids[0],
                 "iDisplayStart": 0,
@@ -206,15 +206,16 @@ class TestDataTable(TestCase):
         assert datatable.params == expected_params
         assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
         assert datatable.total_display_records == len(expected_packages_uuids)
-        assert len(datatable.packages) == len(expected_packages_uuids)
-        assert sorted([p.uuid for p in datatable.packages]) == expected_packages_uuids
+        assert len(datatable.records) == len(expected_packages_uuids)
+        assert sorted([p.uuid for p in datatable.records]) == expected_packages_uuids
 
-    def test_sorting_uuid(self):
-        datatable = datatable_utils.DataTable(
+    def test_sorting_uuid_ascending(self):
+        datatable = datatable_utils.PackageDataTable(
             {
                 "iSortingCols": 1,
                 "iSortCol_0": 0,
                 "bSortable_0": "true",
+                "sSortDir_0": "asc",
                 "iDisplayStart": 0,
                 "iDisplayLength": 10,
                 "sEcho": "1",
@@ -240,11 +241,78 @@ class TestDataTable(TestCase):
             "9f260047-a9b7-4a75-bb6a-e8d94c83edd2",
             "a59033c2-7fa7-41e2-9209-136f07174692",
         ]
-        assert [package.uuid for package in datatable.packages] == expected_uuids
+        assert [package.uuid for package in datatable.records] == expected_uuids
+
+    def test_sorting_uuid_descending(self):
+        datatable = datatable_utils.PackageDataTable(
+            {
+                "iSortingCols": 1,
+                "iSortCol_0": 0,
+                "bSortable_0": "true",
+                "sSortDir_0": "desc",
+                "iDisplayStart": 0,
+                "iDisplayLength": 10,
+                "sEcho": "1",
+            }
+        )
+        expected_params = {
+            "search": "",
+            "display_start": 0,
+            "display_length": 10,
+            "sorting_column": {"index": 0, "direction": "desc"},
+            "echo": 1,
+        }
+        assert datatable.params == expected_params
+        expected_uuids = [
+            "f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04",
+            "e0a41934-c1d7-45ba-9a95-a7531c063ed1",
+            "a59033c2-7fa7-41e2-9209-136f07174692",
+            "9f260047-a9b7-4a75-bb6a-e8d94c83edd2",
+            "88deec53-c7dc-4828-865c-7356386e9399",
+            "79245866-ca80-4f84-b904-a02b3e0ab621",
+            "708f7a1d-dda4-46c7-9b3e-99e188eeb04c",
+            "6aebdb24-1b6b-41ab-b4a3-df9a73726a34",
+            "577f74bd-a283-49e0-b4e2-f8abb81d2566",
+            "473a9398-0024-4804-81da-38946040c8af",
+        ]
+        assert [package.uuid for package in datatable.records] == expected_uuids
+
+    def test_sorting_by_full_path_helper(self):
+        datatable = datatable_utils.PackageDataTable(
+            {
+                "iSortingCols": 1,
+                "iSortCol_0": 2,
+                "bSortable_2": "true",
+                "iDisplayStart": 0,
+                "iDisplayLength": 10,
+                "sEcho": "1",
+            }
+        )
+        expected_params = {
+            "search": "",
+            "display_start": 0,
+            "display_length": 10,
+            "sorting_column": {"index": 2, "direction": "asc"},
+            "echo": 1,
+        }
+        assert datatable.params == expected_params
+        expected_paths = [
+            "/2f62/b030/c3f4/4ac1/950f/fe47/d0dd/cd14/0f-2f62b030-c3f4-4ac1-950f-fe47d0ddcd14.7z",
+            "/577f/74bd/a283/49e0/b4e2/f8ab/b81d/2566/0f-577f74bd-a283-49e0-b4e2-f8abb81d2566.7z",
+            "/broken_bag",
+            "/dev/null/a.bz2.tricky.7z.package-473a9398-0024-4804-81da-38946040c8af.7z",
+            "/dev/null/empty-transfer-79245866-ca80-4f84-b904-a02b3e0ab621",
+            "/dev/null/images-transfer-de1b31fa-97dd-48e0-8417-03be78359531",
+            "/dev/null/tar_gz_package-473a9398-0024-4804-81da-38946040c8af.tar.gz",
+            "/dev/null/transfer-with-one-file-a59033c2-7fa7-41e2-9209-136f07174692",
+            "/f0df/dc4c/7ba1/4e3f/a972/f2c5/5d87/0d04/0f-f0dfdc4c-7ba1-4e3f-a972-f2c55d870d04.7z",
+            "/working_bag",
+        ]
+        assert [package.full_path for package in datatable.records] == expected_paths
 
     def test_packages_are_filtered_by_location(self):
         # count all packages with no filtering
-        datatable = datatable_utils.DataTable(
+        datatable = datatable_utils.PackageDataTable(
             {"iDisplayStart": 0, "iDisplayLength": 10, "sEcho": "1"}
         )
         assert datatable.total_records == TOTAL_FIXTURE_PACKAGES
@@ -253,7 +321,7 @@ class TestDataTable(TestCase):
             uuid="615103f0-0ee0-4a12-ba17-43192d1143ea"
         )
         # count packages only from that location
-        datatable = datatable_utils.DataTable(
+        datatable = datatable_utils.PackageDataTable(
             {
                 "iDisplayStart": 0,
                 "iDisplayLength": 10,

--- a/storage_service/locations/tests/test_fixity_log.py
+++ b/storage_service/locations/tests/test_fixity_log.py
@@ -10,10 +10,9 @@ class TestFixityLog(TestCase):
 
     def setUp(self):
         self.fl_object = models.FixityLog.objects.all()[0]
-        # self.auth = requests.auth.HTTPBasicAuth(self.ds_object.user, self.ds_object.password)
 
     def test_has_required_attributes(self):
         assert self.fl_object.package
-        assert self.fl_object.success
+        assert not self.fl_object.success
         assert self.fl_object.error_details
         assert self.fl_object.datetime_reported

--- a/storage_service/locations/urls.py
+++ b/storage_service/locations/urls.py
@@ -58,6 +58,7 @@ urlpatterns = [
         views.package_fixity,
         name="package_fixity",
     ),
+    url(r"^fixity_ajax/$", views.fixity_logs_ajax, name="fixity_logs_ajax"),
     # Pipelines
     url(r"^pipelines/$", views.pipeline_list, name="pipeline_list"),
     url(r"^pipelines/create/$", views.pipeline_edit, name="pipeline_create"),

--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -80,10 +80,10 @@ def package_list(request):
 
 
 def package_list_ajax(request):
-    datatable = datatable_utils.DataTable(request.GET)
+    datatable = datatable_utils.PackageDataTable(request.GET)
     data = []
     csrf_token = get_token(request)
-    for package in datatable.packages:
+    for package in datatable.records:
         data.append(
             get_template("snippets/package_row.html")
             .render(

--- a/storage_service/static/js/project.js
+++ b/storage_service/static/js/project.js
@@ -48,6 +48,26 @@ var setPackagesDataTable = function (options) {
   );
 };
 
+var setFixityLogsDataTable = function (options) {
+  var $userDataEl = $("#user-data-packages");
+  var uri = $userDataEl.data("uri") || "/";
+  var package_uuid = $userDataEl.data("package-uuid");
+  var filter;
+  if (typeof package_uuid === "string" && package_uuid.length) {
+    // this will get to the request.GET query dict
+    // as package-uuid=<location>
+    filter = { name: "package-uuid", value: package_uuid };
+  }
+  $(".fixity-logs-datatable").dataTable(
+    getAjaxDataTableOptions(
+      options,
+      uri + "fixity_ajax",
+      $(".fixity-logs-datatable thead th"),
+      filter
+    )
+  );
+};
+
 var setDataTables = function () {
   var dataTableOptions = {
     // List of language strings from https://datatables.net/reference/option/language
@@ -78,6 +98,7 @@ var setDataTables = function () {
   };
   $(".datatable").dataTable(dataTableOptions);
   setPackagesDataTable(dataTableOptions);
+  setFixityLogsDataTable(dataTableOptions);
 };
 
 $(document).ready(function () {

--- a/storage_service/static/js/project.js
+++ b/storage_service/static/js/project.js
@@ -1,7 +1,7 @@
 var getAjaxDataTableOptions = function (options, ajaxSource, headers, filter) {
   var result = {};
-  for (var k in options) {
-    result[k] = options[k];
+  for (var key in options) {
+    result[key] = options[key];
   }
   // enable server-side processing
   result["bServerSide"] = true;
@@ -62,8 +62,8 @@ var setFixityLogsDataTable = function (options) {
   var customOptions = {
     aaSorting: [[0, "desc"]],
   };
-  for (var k in options) {
-    customOptions[k] = options[k];
+  for (var key in options) {
+    customOptions[key] = options[key];
   }
   $(".fixity-logs-datatable").dataTable(
     getAjaxDataTableOptions(

--- a/storage_service/static/js/project.js
+++ b/storage_service/static/js/project.js
@@ -58,9 +58,16 @@ var setFixityLogsDataTable = function (options) {
     // as package-uuid=<location>
     filter = { name: "package-uuid", value: package_uuid };
   }
+  // initially sort the table by date column, newest first
+  var customOptions = {
+    aaSorting: [[0, "desc"]],
+  };
+  for (var k in options) {
+    customOptions[k] = options[k];
+  }
   $(".fixity-logs-datatable").dataTable(
     getAjaxDataTableOptions(
-      options,
+      customOptions,
       uri + "fixity_ajax",
       $(".fixity-logs-datatable thead th"),
       filter

--- a/storage_service/static/js/project.js
+++ b/storage_service/static/js/project.js
@@ -1,7 +1,54 @@
-$(document).ready(function () {
+var getAjaxDataTableOptions = function (options, ajaxSource, headers, filter) {
+  var result = {};
+  for (var k in options) {
+    result[k] = options[k];
+  }
+  // enable server-side processing
+  result["bServerSide"] = true;
+  result["bProcessing"] = true;
+  result["sAjaxSource"] = ajaxSource;
+  if (undefined !== filter) {
+    result["fnServerParams"] = function (data) {
+      data.push(filter);
+    };
+  }
+  var columns = [];
+  // for each column create a function that replaces the
+  // table cell content with the HTML returned by the server
+  headers.each(function (i, header) {
+    columns.push({
+      mData: function (source) {
+        var $tr = $(Object.values(source).join(""));
+        return $tr.find("td").eq(i).html();
+      },
+      bSortable: $(header).hasClass("sortable"),
+    });
+  });
+  result["aoColumns"] = columns;
+  return result;
+};
+
+var setPackagesDataTable = function (options) {
   var $userDataEl = $("#user-data-packages");
   var uri = $userDataEl.data("uri") || "/";
   var location = $userDataEl.data("location-uuid");
+  var filter;
+  if (typeof location === "string" && location.length) {
+    // this will get to the request.GET query dict
+    // as location-uuid=<location>
+    filter = { name: "location-uuid", value: location };
+  }
+  $(".packages-datatable").dataTable(
+    getAjaxDataTableOptions(
+      options,
+      uri + "packages_ajax",
+      $(".packages-datatable thead th"),
+      filter
+    )
+  );
+};
+
+var setDataTables = function () {
   var dataTableOptions = {
     // List of language strings from https://datatables.net/reference/option/language
     oLanguage: {
@@ -29,38 +76,12 @@ $(document).ready(function () {
       },
     },
   };
-  // separate options for packages table
-  var packagesDataTableOptions = {};
-  for (var k in dataTableOptions) {
-    packagesDataTableOptions[k] = dataTableOptions[k];
-  }
-  // enable server-side processing
-  packagesDataTableOptions["bServerSide"] = true;
-  packagesDataTableOptions["bProcessing"] = true;
-  packagesDataTableOptions["sAjaxSource"] = uri + "packages_ajax";
-  if (typeof location === "string" && location.length) {
-    packagesDataTableOptions["fnServerParams"] = function (data) {
-      // this will get to the request.GET query dict
-      data.push({ name: "location-uuid", value: location });
-    };
-  }
-  var columns = [];
-  // for each column create a function that replaces the
-  // table cell content with the HTML returned by the server
-  $(".packages-datatable thead th").each(function (i, header) {
-    columns.push({
-      mData: function (source) {
-        var $tr = $(Object.values(source).join(""));
-        return $tr.find("td").eq(i).html();
-      },
-      bSortable: $(header).hasClass("sortable"),
-    });
-  });
-  packagesDataTableOptions["aoColumns"] = columns;
-
   $(".datatable").dataTable(dataTableOptions);
-  $(".packages-datatable").dataTable(packagesDataTableOptions);
+  setPackagesDataTable(dataTableOptions);
+};
 
+$(document).ready(function () {
+  setDataTables();
   $("body").on("click", "a.request-delete", function (event) {
     var self = $(event.target);
     var uuid = self.data("package-uuid");

--- a/storage_service/storage_service/settings/local.py
+++ b/storage_service/storage_service/settings/local.py
@@ -31,6 +31,7 @@ else:
 # DEBUG CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#debug
 DEBUG = True
+TEMPLATES[0]["OPTIONS"]["debug"] = True
 # ######## END DEBUG CONFIGURATION
 
 

--- a/storage_service/templates/locations/fixity_results.html
+++ b/storage_service/templates/locations/fixity_results.html
@@ -6,22 +6,7 @@
 {% block content %}
 
 {% if log_entries %}
-  <table class="datatable">
-    <thead>
-      <tr>
-        <th>{% trans "Date" %}</th>
-        <th>{% trans "Error" %}</th>
-      </tr>
-    </thead>
-    <tbody>
-    {% for entry in log_entries %}
-      <tr>
-        <td>{{ entry.datetime_reported }}</td>
-        <td>{{ entry.error_details }}</td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
+  {% include "snippets/fixity_logs_table.html" %}
 {% else %}
   <p>{% trans "No fixity checks found." %}</p>
 {% endif %}

--- a/storage_service/templates/snippets/fixity_log_row.html
+++ b/storage_service/templates/snippets/fixity_log_row.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+      <tr>
+        <td>{{ entry.datetime_reported }}</td>
+        <td>{{ entry.error_details }}</td>
+      </tr>

--- a/storage_service/templates/snippets/fixity_logs_table.html
+++ b/storage_service/templates/snippets/fixity_logs_table.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+  <table class="fixity-logs-datatable">
+    <thead>
+      <tr>
+        <th class="sortable">{% trans "Date" %}</th>
+        <th class="sortable">{% trans "Error" %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td colspan="2" class="dataTables_empty">{% trans "Loading data from server" %}</td>
+      </tr>
+    </tbody>
+  </table>
+  <div id="user-data-packages" style="display: none;"
+       data-uri="{{ uri }}"
+       data-package-uuid="{{ package_uuid }}">


### PR DESCRIPTION
This extends the [DataTable](http://legacy.datatables.net/) server-side processing functionality added in https://github.com/artefactual/archivematica-storage-service/pull/470 to the Packages tables and applies it to the Fixity Checks view to sort entries by date.

I also enabled template debugging in the local settings to ease this kind of fixes.

Connected to https://github.com/archivematica/Issues/issues/1196