### PR TITLE
Add description for default transfer source

### DIFF
--- a/storage_service/common/startup.py
+++ b/storage_service/common/startup.py
@@ -30,7 +30,7 @@ def startup():
         {
             "purpose": locations_models.Location.TRANSFER_SOURCE,
             "relative_path": "home",
-            "description": "",
+            "description": "Default transfer source",
             "default_setting": "default_transfer_source",
         },
         {

--- a/storage_service/locations/migrations/0027_update_default_transfer_source_description.py
+++ b/storage_service/locations/migrations/0027_update_default_transfer_source_description.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""Add description to default transfer source location."""
+from __future__ import absolute_import, unicode_literals
+import ast
+
+from django.db import migrations
+
+# We can't use apps.get_model for this model as we need to access class
+# attributes.
+from locations.models import Location
+
+
+DEFAULT_DESCRIPTION = "Default transfer source"
+
+
+def get_default_transfer_source_location_uuids(apps):
+    """Get the UUID of the default transfer source location.
+
+    There are two `administration.models.Settings` that track the
+    default transfer source location:
+
+    * `default_transfer_source` which is stored as an `ast` parseable
+      list of UUIDs
+
+    * `default_TS_location` which is stored as a UUID string
+
+    Since it is possible they get out of sync, we get them both here.
+    """
+    Settings = apps.get_model("administration", "Settings")
+    result = set()
+    for setting in Settings.objects.filter(
+        name__in=["default_transfer_source", "default_TS_location"]
+    ):
+        try:
+            value = ast.literal_eval(setting.value)
+        except (ValueError, SyntaxError):
+            value = [setting.value]
+        result.update(value)
+    return result
+
+
+def data_migration_down(apps, schema_editor):
+    Location.objects.filter(
+        purpose=Location.TRANSFER_SOURCE,
+        uuid__in=get_default_transfer_source_location_uuids(apps),
+        description=DEFAULT_DESCRIPTION,
+        enabled=True,
+    ).update(description="")
+
+
+def data_migration_up(apps, schema_editor):
+    Location.objects.filter(
+        purpose=Location.TRANSFER_SOURCE,
+        uuid__in=get_default_transfer_source_location_uuids(apps),
+        description="",
+        enabled=True,
+    ).update(description=DEFAULT_DESCRIPTION)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("locations", "0026_update_package_status")]
+
+    operations = [migrations.RunPython(data_migration_up, data_migration_down)]


### PR DESCRIPTION
This is how the default transfer source looks in the transfer browser now:

![Screenshot_2021-03-16 Archivematica Dashboard - Transfer](https://user-images.githubusercontent.com/560781/111392015-5d56c880-867b-11eb-8536-4d8f232d4c79.png)


Connected to https://github.com/archivematica/Issues/issues/31