### PR TITLE
Generate and upload coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,13 +1,15 @@
 [run]
 
 omit =
-	**/migrations/*
-	**/south_migrations/*
-	**/settings/*
-	**/wsgi.py
-	**/tests/*
-	**/manage.py
-	setup.py
+    **/migrations/*
+    **/south_migrations/*
+    **/management/commands/*
+    **/settings/*
+    **/wsgi.py
+    **/tests/*
+    **/wsgi.py
+    **/manage.py
+    setup.py
 
 source = .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,11 @@ jobs:
           - name: "py27"
             python-version: "2.7"
             toxenv: "py27"
+            coverage: true
           - name: "py27-checkformigrations"
             python-version: "2.7"
             toxenv: "checkformigrations"
+            coverage: false
     steps:
       - name: "Check out repository"
         uses: "actions/checkout@v2"
@@ -52,11 +54,27 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
       - name: "Run tox"
+        if: "! matrix.coverage"
         env:
           TOXENV: ${{ matrix.toxenv }}
           PYTEST_ADDOPTS: -vv
         run: |
           tox
+      - name: "Run tox with coverage"
+        if: "matrix.coverage"
+        env:
+          TOXENV: ${{ matrix.toxenv }}
+          PYTEST_ADDOPTS: -vv --cov storage_service --cov-config=.coveragerc --cov-report xml:coverage.xml
+        run: |
+          tox
+      - name: "Upload coverage report"
+        if: matrix.coverage && github.repository == 'artefactual/archivematica-storage-service'
+        uses: "codecov/codecov-action@v1"
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true
+          verbose: true
+          name: ${{ matrix.name }}
   integration:
     name: "Integration"
     runs-on: "ubuntu-18.04"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+# Validate this file:
+#   curl --data-binary @codecov.yml https://codecov.io/validate
+
+comment: off
+
+coverage:
+  precision: 2
+  round: down
+  range: "25...100"
+  status:
+    project:
+      default:
+        threshold: 25%
+        if_not_found: success
+    patch:
+      default:
+        threshold: 25%
+        if_not_found: success


### PR DESCRIPTION
This modifies the `test` CI workflow to generate a test coverage
report for the `py27` tox environment which is then uploaded and
processed in codecov.io.

The `codecov.yml` configuration is a copy from the Archivematica
repository without the path fixer.

Connected to https://github.com/archivematica/Issues/issues/1434