### PR TITLE
Fix tests in Python 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ jobs:
             python-version: "2.7"
             toxenv: "py27"
             coverage: true
+          - name: "py36"
+            python-version: "3.6"
+            toxenv: "py36"
+            coverage: false
           - name: "py27-checkformigrations"
             python-version: "2.7"
             toxenv: "checkformigrations"

--- a/requirements/base-py3.txt
+++ b/requirements/base-py3.txt
@@ -38,7 +38,7 @@ jsonfield==2.0.1          # via -r base.in
 keystoneauth1==4.3.1      # via python-keystoneclient
 logutils==0.3.4.1         # via -r base.in
 lxml==4.6.3               # via -r base.in, metsrw, python-cas, sword2
-metsrw==0.3.16            # via -r base.in
+metsrw==0.3.17            # via -r base.in
 mozilla-django-oidc==1.2.4  # via -r base.in
 msgpack==1.0.2            # via oslo.serialization
 mysqlclient==1.4.6        # via agentarchives

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,7 +14,7 @@ importlib_resources~=1.4
 jsonfield==2.0.1
 logutils==0.3.4.1
 lxml~=4.6
-metsrw==0.3.16
+metsrw==0.3.17
 ndg-httpsclient==0.4.2
 pathlib2==2.3.5; python_version < '3.0'
 python-gnupg~=0.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,7 +45,7 @@ jsonfield==2.0.1          # via -r base.in
 keystoneauth1==4.0.1      # via python-keystoneclient
 logutils==0.3.4.1         # via -r base.in
 lxml==4.6.3               # via -r base.in, metsrw, python-cas
-metsrw==0.3.16            # via -r base.in
+metsrw==0.3.17            # via -r base.in
 monotonic==1.5            # via oslo.utils
 mozilla-django-oidc==1.2.4  # via -r base.in
 msgpack==1.0.2            # via oslo.serialization

--- a/requirements/local-py3.txt
+++ b/requirements/local-py3.txt
@@ -39,7 +39,7 @@ jsonfield==2.0.1          # via -r base-py3.txt
 keystoneauth1==4.3.1      # via -r base-py3.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base-py3.txt
 lxml==4.6.3               # via -r base-py3.txt, metsrw, python-cas, sword2
-metsrw==0.3.16            # via -r base-py3.txt
+metsrw==0.3.17            # via -r base-py3.txt
 mozilla-django-oidc==1.2.4  # via -r base-py3.txt
 msgpack==1.0.2            # via -r base-py3.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base-py3.txt, agentarchives

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -46,7 +46,7 @@ jsonfield==2.0.1          # via -r base.txt
 keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base.txt
 lxml==4.6.3               # via -r base.txt, metsrw, python-cas
-metsrw==0.3.16            # via -r base.txt
+metsrw==0.3.17            # via -r base.txt
 monotonic==1.5            # via -r base.txt, oslo.utils
 mozilla-django-oidc==1.2.4  # via -r base.txt
 msgpack==1.0.2            # via -r base.txt, oslo.serialization

--- a/requirements/production-py3.txt
+++ b/requirements/production-py3.txt
@@ -39,7 +39,7 @@ jsonfield==2.0.1          # via -r base-py3.txt
 keystoneauth1==4.3.1      # via -r base-py3.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base-py3.txt
 lxml==4.6.3               # via -r base-py3.txt, metsrw, python-cas, sword2
-metsrw==0.3.16            # via -r base-py3.txt
+metsrw==0.3.17            # via -r base-py3.txt
 mozilla-django-oidc==1.2.4  # via -r base-py3.txt
 msgpack==1.0.2            # via -r base-py3.txt, oslo.serialization
 mysqlclient==1.4.6        # via -r base-py3.txt, agentarchives

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -46,7 +46,7 @@ jsonfield==2.0.1          # via -r base.txt
 keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base.txt
 lxml==4.6.3               # via -r base.txt, metsrw, python-cas
-metsrw==0.3.16            # via -r base.txt
+metsrw==0.3.17            # via -r base.txt
 monotonic==1.5            # via -r base.txt, oslo.utils
 mozilla-django-oidc==1.2.4  # via -r base.txt
 msgpack==1.0.2            # via -r base.txt, oslo.serialization

--- a/requirements/test-py3.txt
+++ b/requirements/test-py3.txt
@@ -45,7 +45,7 @@ jsonfield==2.0.1          # via -r base-py3.txt
 keystoneauth1==4.3.1      # via -r base-py3.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base-py3.txt
 lxml==4.6.3               # via -r base-py3.txt, metsrw, python-cas, sword2
-metsrw==0.3.16            # via -r base-py3.txt
+metsrw==0.3.17            # via -r base-py3.txt
 mock==4.0.3               # via -r test-py3.in
 more-itertools==8.7.0     # via pytest
 mozilla-django-oidc==1.2.4  # via -r base-py3.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -54,7 +54,7 @@ jsonfield==2.0.1          # via -r base.txt
 keystoneauth1==4.0.1      # via -r base.txt, python-keystoneclient
 logutils==0.3.4.1         # via -r base.txt
 lxml==4.6.3               # via -r base.txt, metsrw, python-cas
-metsrw==0.3.16            # via -r base.txt
+metsrw==0.3.17            # via -r base.txt
 mock==3.0.5               # via -r test.in, pytest-mock, vcrpy
 monotonic==1.5            # via -r base.txt, oslo.utils
 more-itertools==5.0.0     # via pytest

--- a/storage_service/locations/models/dspace.py
+++ b/storage_service/locations/models/dspace.py
@@ -341,7 +341,7 @@ class DSpace(models.Model):
         for upload_path in upload_paths:
             LOGGER.info("Add file %s to %s", upload_path, entry_receipt.edit_media)
             # Add file to DSpace item
-            with open(upload_path, "r") as f:
+            with open(upload_path, "rb") as f:
                 content = f.read()  # sword2 iterates over this twice
 
             # Note: This has problems because httplib2 tries all requests using basic auth without any auth and retries after getting a 401. This breaks with files over 2097152 bytes.

--- a/storage_service/locations/tests/test_dspace_rest.py
+++ b/storage_service/locations/tests/test_dspace_rest.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from lxml import etree
 import pytest
 import requests
+import six
 
 import agentarchives
 from agentarchives import archivesspace
@@ -360,7 +361,10 @@ def test_move_from_storage_service(
     mocker.patch("subprocess.Popen", return_value=MockProcess(["fake-command"]))
     mocker.patch("lxml.etree.parse", return_value=etree.parse(package.fake_mets_file))
     mocker.patch("os.remove")
-    mocker.patch("__builtin__.open")
+    if six.PY3:
+        mocker.patch("builtins.open")
+    else:
+        mocker.patch("__builtin__.open")
     mocker.patch("os.listdir", return_value=[AIP_METS_FILENAME])
     mocker.patch("scandir.walk", return_value=[("", [], [AIP_METS_FILENAME])])
 

--- a/storage_service/locations/tests/test_space.py
+++ b/storage_service/locations/tests/test_space.py
@@ -7,6 +7,8 @@ import pytest
 from scandir import scandir
 import shutil
 
+import six
+
 from locations.models import Space
 from locations.models.space import path2browse_dict
 
@@ -264,7 +266,7 @@ def aipstore_compressed(tmpdir):
             aipstore_path, path[AIP_QUAD_PATH], path[COMPRESSED_PACKAGE_DIR]
         )
         with open(package_file, "wb") as package:
-            package.write(MAGIC)
+            package.write(six.ensure_binary(MAGIC))
         assert os.path.exists(package_file)
         assert os.path.isfile(package_file)
 
@@ -429,7 +431,7 @@ def aipstore_uncompressed(tmpdir):
         os.makedirs(path_to_write_to)
         some_file = os.path.join(aipstore_path, path, aip_name, some_file_name)
         with open(some_file, "wb") as _some_file:
-            _some_file.write(some_data)
+            _some_file.write(six.ensure_binary(some_data))
         assert os.path.exists(some_file)
 
     return aipstore


### PR DESCRIPTION
This fixes the tests in Python 3.6 and adds the `py36` toxenv to the `test` CI workflow.

Connected to https://github.com/archivematica/Issues/issues/878