### PR TITLE
Track and delete temporary directories for remote packages in Storage Service internal location

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -1381,6 +1381,7 @@ class PackageResource(ModelResource):
         except StorageException:
             full_path, temp_dir = package.compress_package(utils.COMPRESSION_TAR)
         response = utils.download_file_stream(full_path, temp_dir)
+        package.clear_local_tempdirs()
         return response
 
     @_custom_endpoint(expected_methods=["get"])
@@ -1410,6 +1411,7 @@ class PackageResource(ModelResource):
         report_json, report_dict = bundle.obj.get_fixity_check_report_send_signals(
             force_local=force_local
         )
+        bundle.obj.clear_local_tempdirs()
         return http.HttpResponse(report_json, content_type="application/json")
 
     @_custom_endpoint(expected_methods=["put"])
@@ -1570,6 +1572,7 @@ class PackageResource(ModelResource):
         response = bundle.obj.start_reingest(pipeline, reingest_type, processing_config)
         status_code = response.get("status_code", 500)
 
+        bundle.obj.clear_local_tempdirs()
         return self.create_response(request, response, status=status_code)
 
     @_custom_endpoint(expected_methods=["post"])


### PR DESCRIPTION
Connected to https://github.com/archivematica/Issues/issues/431

This PR modifies the `Package` model to keep track of temporary directories created in the Storage Service's internal location for packages which are fetched remotely via `Package.fetch_local_path()`. It then adds a method to clear these local directories, and calls that method at the end of the package download, fixity check, and reingest API methods, just prior to serving the response.

Functionally this means that temporary directories containing a copy of remote packages are no longer left behind in the Storage Service after downloading, reingesting, or checking fixity for packages stored in remote locations such as S3. I initially tried an approach of deleting tempdirs closer to their time of creation but that quickly became a web of side effects, and settled on the approach in this PR.

Incidentally, this change also helps with https://github.com/archivematica/Issues/issues/1112 by clearing temporary directories previously left behind when downloading, reingesting, or fixity checking uncompressed AIPs in GPG-encrypted AIP storage locations. Compressed encrypted AIPs are still leaving behind copies of the compressed package (seemingly 1 copy when downloading, 2 when checking fixity). I think these are being created and not cleaned up by the GPG Space's [`move_to_storage_service`](https://github.com/artefactual/archivematica-storage-service/blob/63f74d3314e29bd34d2844567047ecd248a5471c/storage_service/locations/models/gpg.py#L90-L133) method but think that might be better addressed in a separate PR.