### PR TITLE
Avoid config reset in pipeline edit form

### DIFF
--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -53,7 +53,7 @@ class DisableableSelectWidget(forms.Select):
 class PipelineForm(forms.ModelForm):
     create_default_locations = forms.BooleanField(
         required=False,
-        initial=True,
+        initial=False,
         label=_("Default Locations:"),
         help_text=_("Enabled if default locations should be created for this pipeline"),
     )

--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -538,7 +538,10 @@ def pipeline_edit(request, uuid=None):
     else:
         action = _("Create Pipeline")
         pipeline = None
-        initial = {"enabled": not utils.get_setting("pipelines_disabled")}
+        initial = {
+            "create_default_locations": True,
+            "enabled": not utils.get_setting("pipelines_disabled"),
+        }
 
     if request.method == "POST":
         form = forms.PipelineForm(request.POST, instance=pipeline, initial=initial)
@@ -549,7 +552,15 @@ def pipeline_edit(request, uuid=None):
             return redirect("locations:pipeline_list")
     else:
         form = forms.PipelineForm(instance=pipeline, initial=initial)
-    return render(request, "locations/pipeline_form.html", locals())
+    return render(
+        request,
+        "locations/pipeline_form.html",
+        {
+            "action": action,
+            "form": form,
+            "pipeline": pipeline,
+        },
+    )
 
 
 def pipeline_list(request):


### PR DESCRIPTION
When a pipeline is being edited, "create_default_locations" defaults to
True. This is often misleading because it forces the pipeline to
re-create the default locations.

This commit changes the pipeline view so the checkbox appears enabled by
default when creating a new pipeline but not when editing an existing
one.

Connects to https://github.com/archivematica/Issues/issues/1107.