### PR TITLE
Add OfflineReplicaStaging Space

### DIFF
--- a/storage_service/common/tests/test_utils.py
+++ b/storage_service/common/tests/test_utils.py
@@ -1,5 +1,10 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from collections import namedtuple
+import os
+import shutil
+import subprocess
+import tarfile
 
 from six import StringIO
 import mock
@@ -17,6 +22,9 @@ PROG_VERS_TAR = "tar"
 # Specifically string types for the tuple we create.
 COMPRESS_ORDER_ONE = "1"
 COMPRESS_ORDER_TWO = "2"
+
+ExTarCase = namedtuple("ExTarCase", "path isdir raises expected")
+CrTarCase = namedtuple("CrTarCase", "path isfile istar raises expected extension")
 
 
 @pytest.mark.parametrize(
@@ -290,3 +298,136 @@ def test_package_is_file(package_path, is_file):
     see in the storage service.
     """
     assert utils.package_is_file(package_path) == is_file
+
+
+@pytest.mark.parametrize(
+    "path, will_be_dir, sp_raises, expected",
+    [
+        ExTarCase(path="/a/b/c", isdir=True, raises=False, expected="success"),
+        ExTarCase(path="/a/b/d", isdir=False, raises=True, expected="fail"),
+        ExTarCase(path="/a/b/c", isdir=True, raises=True, expected="fail"),
+    ],
+)
+def test_extract_tar(mocker, path, will_be_dir, sp_raises, expected):
+    if sp_raises:
+        mocker.patch.object(subprocess, "check_output", side_effect=OSError("gotcha!"))
+    else:
+        mocker.patch.object(subprocess, "check_output")
+    mocker.patch.object(os, "rename")
+    mocker.patch.object(os, "remove")
+    if will_be_dir:
+        mocker.patch.object(os.path, "isdir", return_value=True)
+    else:
+        mocker.patch.object(os.path, "isdir", return_value=False)
+    tarpath_ext = "{}.tar".format(path)
+    dirname = os.path.dirname(tarpath_ext)
+    if expected == "success":
+        ret = utils.extract_tar(path)
+        assert ret is None
+        os.remove.assert_called_once_with(tarpath_ext)
+    else:
+        with pytest.raises(utils.TARException) as excinfo:
+            ret = utils.extract_tar(path)
+        assert "Failed to extract {}: gotcha!".format(path) == str(excinfo.value)
+        os.rename.assert_any_call(tarpath_ext, path)
+        assert not os.remove.called
+    os.rename.assert_any_call(path, tarpath_ext)
+    subprocess.check_output.assert_called_once_with(
+        ["tar", "-xf", tarpath_ext, "-C", dirname]
+    )
+
+
+@pytest.mark.parametrize(
+    "path, will_be_file, will_be_tar, sp_raises, expected, extension",
+    [
+        CrTarCase(
+            path="/a/b/c",
+            isfile=True,
+            istar=True,
+            raises=False,
+            expected="success",
+            extension=False,
+        ),
+        CrTarCase(
+            path="/a/b/c/",
+            isfile=True,
+            istar=True,
+            raises=False,
+            expected="success",
+            extension=False,
+        ),
+        CrTarCase(
+            path="/a/b/c",
+            isfile=True,
+            istar=False,
+            raises=False,
+            expected="fail",
+            extension=False,
+        ),
+        CrTarCase(
+            path="/a/b/c",
+            isfile=False,
+            istar=True,
+            raises=False,
+            expected="fail",
+            extension=False,
+        ),
+        CrTarCase(
+            path="/a/b/c",
+            isfile=False,
+            istar=False,
+            raises=True,
+            expected="fail",
+            extension=False,
+        ),
+        CrTarCase(
+            path="/a/b/c",
+            isfile=True,
+            istar=True,
+            raises=False,
+            expected="success",
+            extension=True,
+        ),
+        CrTarCase(
+            path="/a/b/c/",
+            isfile=True,
+            istar=True,
+            raises=False,
+            expected="success",
+            extension=True,
+        ),
+    ],
+)
+def test_create_tar(
+    mocker, path, will_be_file, will_be_tar, sp_raises, expected, extension
+):
+    if sp_raises:
+        mocker.patch.object(subprocess, "check_output", side_effect=OSError("gotcha!"))
+    else:
+        mocker.patch.object(subprocess, "check_output")
+    mocker.patch.object(os.path, "isfile", return_value=will_be_file)
+    mocker.patch.object(tarfile, "is_tarfile", return_value=will_be_tar)
+    mocker.patch.object(os, "rename")
+    mocker.patch.object(shutil, "rmtree")
+    fixed_path = path.rstrip("/")
+    tarpath = "{}.tar".format(fixed_path)
+    if expected == "success":
+        ret = utils.create_tar(path)
+        shutil.rmtree.assert_called_once_with(fixed_path)
+        os.rename.assert_called_once_with(tarpath, fixed_path)
+        tarfile.is_tarfile.assert_any_call(fixed_path)
+        assert ret is None
+    else:
+        with pytest.raises(utils.TARException) as excinfo:
+            ret = utils.create_tar(path, extension=extension)
+        assert "Failed to create a tarfile at {} for dir at {}".format(
+            tarpath, fixed_path
+        ) == str(excinfo.value)
+        assert not shutil.rmtree.called
+        assert not os.rename.called
+    if not sp_raises:
+        os.path.isfile.assert_called_once_with(tarpath)
+        if will_be_file:
+            tarfile.is_tarfile.assert_any_call(tarpath)
+        if extension:
+            tarpath.endswith(utils.TAR_EXTENSION)

--- a/storage_service/locations/constants.py
+++ b/storage_service/locations/constants.py
@@ -74,6 +74,11 @@ PROTOCOL = {
         "form": forms.NFSForm,
         "fields": ["manually_mounted", "remote_name", "remote_path", "version"],
     },
+    models.Space.OFFLINE_REPLICA_STAGING: {
+        "model": models.OfflineReplicaStaging,
+        "form": forms.OfflineReplicaStagingForm,
+        "fields": [],
+    },
     models.Space.PIPELINE_LOCAL_FS: {
         "model": models.PipelineLocalFS,
         "form": forms.PipelineLocalFSForm,

--- a/storage_service/locations/fixtures/replica_staging.json
+++ b/storage_service/locations/fixtures/replica_staging.json
@@ -1,0 +1,54 @@
+[
+{
+    "pk": 1,
+    "model": "locations.offlinereplicastaging",
+    "fields": {
+        "space": "eb4348c7-5ec9-432d-b451-93214860aae2"
+    }
+},
+{
+    "pk": 2,
+    "model": "locations.space",
+    "fields": {
+        "last_verified": null,
+        "used": 0,
+        "verified": false,
+        "uuid": "eb4348c7-5ec9-432d-b451-93214860aae2",
+        "access_protocol": "REPLICA",
+        "staging_path": "/var/archivematica/storage_service/",
+        "path": "/archivematica",
+        "size": null
+    }
+},
+{
+    "pk": 8,
+    "model": "locations.location",
+    "fields": {
+        "used": 0,
+        "description": "offline replica staging",
+        "space": "eb4348c7-5ec9-432d-b451-93214860aae2",
+        "enabled": true,
+        "quota": null,
+        "relative_path": "offlinestaging",
+        "purpose": "RP",
+        "uuid": "ac3dc2d0-8422-4067-bb25-dd3cc1c54c2c"
+    }
+},
+{
+    "pk": 1,
+    "model": "locations.package",
+    "fields": {
+        "uuid": "216a6d25-d705-4d00-86c3-02f51c66a0c0",
+        "description": null,
+        "origin_pipeline": null,
+        "current_location": "ac3dc2d0-8422-4067-bb25-dd3cc1c54c2c",
+        "current_path": "locations/fixtures/small_compressed_bag.zip",
+        "pointer_file_location": "",
+        "pointer_file_path": "",
+        "size": 0,
+        "package_type": "AIP",
+        "status": "Uploaded",
+        "misc_attributes": {}
+    }
+}
+]

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -249,6 +249,12 @@ class S3Form(forms.ModelForm):
         )
 
 
+class OfflineReplicaStagingForm(forms.ModelForm):
+    class Meta:
+        model = models.OfflineReplicaStaging
+        fields = ()
+
+
 class LocationForm(forms.ModelForm):
     default = forms.BooleanField(
         required=False, label=_("Set as global default location for its purpose")

--- a/storage_service/locations/migrations/0028_offline_replica_space.py
+++ b/storage_service/locations/migrations/0028_offline_replica_space.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+"""Migration to add an Offline Replica Staging Space to the Storage Service."""
+
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    """Entry point for OfflineReplicaStaging Space migration."""
+
+    dependencies = [("locations", "0027_update_default_transfer_source_description")]
+    operations = [
+        migrations.CreateModel(
+            name="OfflineReplicaStaging",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Write-Only Replica Staging on Local Filesystem",
+            },
+        ),
+        migrations.AlterField(
+            model_name="space",
+            name="access_protocol",
+            field=models.CharField(
+                choices=[
+                    (b"ARKIVUM", "Arkivum"),
+                    (b"DV", "Dataverse"),
+                    (b"DC", "DuraCloud"),
+                    (b"DSPACE", "DSpace via SWORD2 API"),
+                    (b"DSPC_RST", "DSpace via REST API"),
+                    (b"FEDORA", "FEDORA via SWORD2"),
+                    (b"GPG", "GPG encryption on Local Filesystem"),
+                    (b"FS", "Local Filesystem"),
+                    (b"LOM", "LOCKSS-o-matic"),
+                    (b"NFS", "NFS"),
+                    (b"REPLICA", "Write-Only Replica Staging on Local Filesystem"),
+                    (b"PIPE_FS", "Pipeline Local Filesystem"),
+                    (b"SWIFT", "Swift"),
+                    (b"S3", "S3"),
+                ],
+                help_text="How the space can be accessed.",
+                max_length=8,
+                verbose_name="Access protocol",
+            ),
+        ),
+        migrations.AddField(
+            model_name="offlinereplicastaging",
+            name="space",
+            field=models.OneToOneField(
+                on_delete=django.db.models.deletion.CASCADE,
+                to="locations.Space",
+                to_field="uuid",
+            ),
+        ),
+    ]

--- a/storage_service/locations/models/__init__.py
+++ b/storage_service/locations/models/__init__.py
@@ -40,5 +40,6 @@ from .local_filesystem import LocalFilesystem
 from .lockssomatic import Lockssomatic
 from .nfs import NFS
 from .pipeline_local import PipelineLocalFS
+from .replica_staging import OfflineReplicaStaging
 from .swift import Swift
 from .s3 import S3

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -242,6 +242,16 @@ class Package(models.Model):
         is_file = os.path.isfile(local_path)
         return space_is_encr and is_file
 
+    def is_packaged(self, local_path):
+        """Determines whether or not the package at ``local_path`` is
+        packaged.
+        """
+        space_is_packaged = getattr(
+            self.current_location.space.get_child_space(), "packaged_space", False
+        )
+        is_file = os.path.isfile(local_path)
+        return space_is_packaged and is_file
+
     @property
     def is_compressed(self):
         """ Determines whether or not the package is a compressed file. """
@@ -328,9 +338,15 @@ class Package(models.Model):
 
         :returns: Local path to this package.
         """
+
         local_path = self.get_local_path()
-        if local_path and not self.is_encrypted(local_path):
+        if (
+            local_path
+            and not self.is_encrypted(local_path)
+            and not self.is_packaged(local_path)
+        ):
             return local_path
+
         # Not locally accessible, so copy to SS internal temp dir
         ss_internal = Location.active.get(purpose=Location.STORAGE_SERVICE_INTERNAL)
         temp_dir = tempfile.mkdtemp(dir=ss_internal.full_path)

--- a/storage_service/locations/models/replica_staging.py
+++ b/storage_service/locations/models/replica_staging.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import logging
+import os
+
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from common import utils
+
+from .location import Location
+
+LOGGER = logging.getLogger(__name__)
+
+
+class OfflineReplicaStaging(models.Model):
+    """Space for storing packages for write-only offline replication.
+
+    Uncompressed packages in this Space will be packaged as a tarball
+    prior to storing.
+    """
+
+    packaged_space = True
+
+    space = models.OneToOneField("Space", to_field="uuid", on_delete=models.CASCADE)
+
+    class Meta:
+        verbose_name = _("Write-Only Replica Staging on Local Filesystem")
+        app_label = _("locations")
+
+    ALLOWED_LOCATION_PURPOSE = [Location.REPLICATOR]
+
+    def browse(self, path):
+        raise NotImplementedError(
+            _("Write-Only Offline Staging does not implement browse")
+        )
+
+    def delete_path(self, delete_path):
+        raise NotImplementedError(
+            _("Write-Only Offline Staging does not implement deletion")
+        )
+
+    def move_to_storage_service(self, src_path, dest_path, dest_space):
+        """ Moves src_path to dest_space.staging_path/dest_path. """
+        raise NotImplementedError(
+            _("Write-Only Offline Staging does not implement fetching packages")
+        )
+
+    def move_from_storage_service(self, src_path, dest_path, package=None):
+        """ Moves self.staging_path/src_path to dest_path."""
+        self.space.create_local_directory(dest_path)
+        if not package.is_packaged(src_path):
+            return self._store_tar_replica(src_path, dest_path, package)
+        self.space.move_rsync(src_path, dest_path)
+
+    def _store_tar_replica(self, src_path, dest_path, package):
+        """Create and store TAR replica."""
+        tar_src_path = src_path.rstrip("/") + utils.TAR_EXTENSION
+        tar_dest_path = dest_path.rstrip("/") + utils.TAR_EXTENSION
+        try:
+            utils.create_tar(src_path, extension=True)
+        except utils.TARException:
+            raise
+        package.current_path = tar_dest_path
+        self.space.move_rsync(tar_src_path, tar_dest_path)
+
+        # Cleanup empty directory created by space.create_local_directory.
+        os.rmdir(dest_path)

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -143,6 +143,7 @@ class Space(models.Model):
     LOCAL_FILESYSTEM = "FS"
     LOM = "LOM"
     NFS = "NFS"
+    OFFLINE_REPLICA_STAGING = "REPLICA"
     PIPELINE_LOCAL_FS = "PIPE_FS"
     SWIFT = "SWIFT"
     GPG = "GPG"
@@ -161,6 +162,7 @@ class Space(models.Model):
         (LOCAL_FILESYSTEM, _("Local Filesystem")),
         (LOM, _("LOCKSS-o-matic")),
         (NFS, _("NFS")),
+        (OFFLINE_REPLICA_STAGING, _("Write-Only Replica Staging on Local Filesystem")),
         (PIPELINE_LOCAL_FS, _("Pipeline Local Filesystem")),
         (SWIFT, _("Swift")),
         (S3, _("S3")),

--- a/storage_service/locations/tests/test_package.py
+++ b/storage_service/locations/tests/test_package.py
@@ -709,6 +709,74 @@ class TestPackage(TestCase):
         ]
         self._test_bagit_structure(replica, replication_dir)
 
+    def test_replicate_aip_offline_staging_uncompressed(self):
+        """Ensure that a replica is created and stored correctly as a tarball."""
+        space_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="space")
+        replication_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="replication")
+        staging_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="offline")
+        replica_space = models.Space.objects.create(
+            access_protocol=models.Space.OFFLINE_REPLICA_STAGING,
+            path="/",
+            staging_path=staging_dir,
+        )
+        models.OfflineReplicaStaging.objects.create(space=replica_space)
+
+        aip = models.Package.objects.get(uuid="0d4e739b-bf60-4b87-bc20-67a379b28cea")
+        aip.current_location.space.staging_path = space_dir
+        aip.current_location.space.save()
+
+        aip.current_location.replicators.create(
+            space=replica_space,
+            relative_path=replication_dir,
+            purpose=models.Location.REPLICATOR,
+        )
+
+        assert aip.replicas.count() == 0
+
+        aip.create_replicas()
+        replica = aip.replicas.first()
+
+        assert aip.replicas.count() == 1
+        assert replica is not None
+        expected_replica_path = os.path.join(
+            replication_dir, utils.uuid_to_path(replica.uuid), "working_bag.tar"
+        )
+        assert os.path.exists(expected_replica_path)
+
+    def test_replicate_aip_offline_staging_compressed(self):
+        """Ensure that a replica is created and stored correctly as-is."""
+        space_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="space")
+        replication_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="replication")
+        staging_dir = tempfile.mkdtemp(dir=self.tmp_dir, prefix="offline")
+        replica_space = models.Space.objects.create(
+            access_protocol=models.Space.OFFLINE_REPLICA_STAGING,
+            path="/",
+            staging_path=staging_dir,
+        )
+        models.OfflineReplicaStaging.objects.create(space=replica_space)
+
+        aip = models.Package.objects.get(uuid="88deec53-c7dc-4828-865c-7356386e9399")
+        aip.current_location.space.staging_path = space_dir
+        aip.current_location.space.save()
+
+        aip.current_location.replicators.create(
+            space=replica_space,
+            relative_path=replication_dir,
+            purpose=models.Location.REPLICATOR,
+        )
+
+        assert aip.replicas.count() == 0
+
+        aip.create_replicas()
+        replica = aip.replicas.first()
+
+        assert aip.replicas.count() == 1
+        assert replica is not None
+        expected_replica_path = os.path.join(
+            replication_dir, utils.uuid_to_path(replica.uuid), "working_bag.7z"
+        )
+        assert os.path.exists(expected_replica_path)
+
     def test_deletion_and_creation_of_replicas_compressed(self):
         """Ensure that when it is requested a replica be created, then
         existing replicas are checked for and deleted if necessary, e.g.

--- a/storage_service/locations/tests/test_replica_staging.py
+++ b/storage_service/locations/tests/test_replica_staging.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+import os
+import tempfile
+
+from django.test import TestCase
+
+from . import TempDirMixin
+from locations import models
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+FIXTURES_DIR = os.path.abspath(os.path.join(THIS_DIR, "..", "fixtures"))
+
+
+class TestOfflineReplicaStaging(TempDirMixin, TestCase):
+
+    fixtures = ["base.json", "replica_staging.json"]
+
+    def setUp(self):
+        super(TestOfflineReplicaStaging, self).setUp()
+        self.replica = models.Package.objects.get(id=1)
+        self.replica.current_location.space.staging_path = str(self.tmpdir)
+        self.replica.current_location.space.save()
+
+        space = models.Space.objects.get(id=1)
+        space.path = str(self.tmpdir)
+        space.save()
+
+        location = models.Location.objects.get(id=5)
+        ss_internal_dir = tempfile.mkdtemp(dir=str(self.tmpdir), prefix="int")
+        ss_int_relpath = os.path.relpath(ss_internal_dir, str(self.tmpdir))
+        location.relative_path = ss_int_relpath
+        location.save()
+
+    def test_delete(self):
+        """Test that package in Space isn't deleted."""
+        success, err = self.replica.delete_from_storage()
+        assert success is False
+        assert isinstance(err, NotImplementedError)
+
+    def test_check_fixity(self):
+        """Test that fixity check raises NotImplementedError."""
+        with self.assertRaises(NotImplementedError):
+            self.replica.check_fixity()
+
+    def test_browse(self):
+        """Test that browse raises NotImplementedError."""
+        with self.assertRaises(NotImplementedError):
+            self.replica.current_location.space.browse("/test/path")
+
+    def test_move_to_storage_service(self):
+        """Test that move_to_storage_service raises NotImplementedError."""
+        with self.assertRaises(NotImplementedError):
+            self.replica.current_location.space.move_to_storage_service(
+                "/test/path", "/dev/null", self.replica.current_location.space
+            )


### PR DESCRIPTION
Connected to https://github.com/archivematica/issues/issues/1440

This PR adds a new `OfflineReplicaStaging` Space, which is a write-only Space used solely for replicas. Packages are stored to a directory on the local filesystem to facilitate pickup by offline storage devices such as tape robots. Uncompressed packages are packaged as a tarball prior to storage.

Because this is a write-only space intended for staging to external storage systems, it is not possible by design to download, delete, or check fixity for replicas stored in this Space.