### PR TITLE
Remove download/delete links for offline replicas

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -274,6 +274,43 @@ class Package(models.Model):
             raise StorageException(message)
 
     @property
+    def is_downloadable(self):
+        """Determines whether or not package is downloadable."""
+        space_is_offline_replica = (
+            self.current_location.space.access_protocol == Space.OFFLINE_REPLICA_STAGING
+        )
+        return self.status != self.DELETED and not space_is_offline_replica
+
+    @property
+    def is_deletable(self):
+        """Determines whether or not package is deletable."""
+        space_is_offline_replica = (
+            self.current_location.space.access_protocol == Space.OFFLINE_REPLICA_STAGING
+        )
+        return (
+            self.package_type in self.PACKAGE_TYPE_CAN_DELETE
+            and self.status != self.DELETED
+            and not space_is_offline_replica
+        )
+
+    @property
+    def is_directly_deletable(self):
+        """Determines whether or not package is directly deletable."""
+        return (
+            self.package_type in self.PACKAGE_TYPE_CAN_DELETE_DIRECTLY
+            and self.status != self.DELETED
+        )
+
+    @property
+    def is_reingestable(self):
+        """Determines whether or not package can be reingested."""
+        return (
+            self.package_type in self.PACKAGE_TYPE_CAN_REINGEST
+            and self.status != self.DELETED
+            and not self.replicated_package
+        )
+
+    @property
     def latest_fixity_check_datetime(self):
         latest_check = self._latest_fixity_check()
         return latest_check.datetime_reported if latest_check is not None else None

--- a/storage_service/templates/snippets/package_row.html
+++ b/storage_service/templates/snippets/package_row.html
@@ -9,7 +9,7 @@
           {% endif %}
         </td>
         <td>
-          {% if package.status != package.DELETED and package.current_location.space.access_protocol != "REPLICA" %}
+          {% if package.is_downloadable %}
             <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">{{ package.full_path }}</a>
           {% else %}
             <span>{{ package.full_path }}</span>
@@ -38,26 +38,27 @@
         </td>
         <td>
           {% if package.pointer_file_location %}
-            <a href="{% url 'pointer_file_request' 'v2' 'file' package.uuid %}">{% trans "Pointer File" %}</a> |
+            <a href="{% url 'pointer_file_request' 'v2' 'file' package.uuid %}">{% trans "Pointer File" %}</a>
           {% endif %}
-          {% if package.status != package.DELETED and package.current_location.space.access_protocol != "REPLICA" %}
-            <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">{% trans "Download" %}</a> |
+          {% if package.is_downloadable %}
+            {% if package.pointer_file_location %}| {% endif %}
+            <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">{% trans "Download" %}</a>
           {% endif %}
 
           <!-- Replicas should not be re-ingestible -->
-          {% if package.package_type in 'AIP AIC' and not package.replicated_package %}
-            <a href="{% url 'locations:aip_reingest' package.uuid %}?next={{ redirect_path }}">{% trans "Re-ingest" %}</a> |
+          {% if package.is_reingestable %}
+            | <a href="{% url 'locations:aip_reingest' package.uuid %}?next={{ redirect_path }}">{% trans "Re-ingest" %}</a>
           {% endif %}
 
-          {% if package.package_type in package.PACKAGE_TYPE_CAN_DELETE and package.current_location.space.access_protocol != "REPLICA" %}
-          <a href="#" class="request-delete"
-             data-package-type="{{ package.package_type }}"
-             data-package-uuid="{{ package.uuid }}"
-             data-package-pipeline="{{ package.origin_pipeline.uuid }}"
-             >{% trans "Request Deletion" %}</a>
+          {% if package.is_deletable %}
+            | <a href="#" class="request-delete"
+               data-package-type="{{ package.package_type }}"
+               data-package-uuid="{{ package.uuid }}"
+               data-package-pipeline="{{ package.origin_pipeline.uuid }}"
+               >{% trans "Request Deletion" %}</a>
           {% endif %}
 
-          {% if package.package_type in package.PACKAGE_TYPE_CAN_DELETE_DIRECTLY and package.status != package.DELETED %}
+          {% if package.is_directly_deletable %}
             <form method="POST" class="submit-confirm" action="{% url 'locations:package_delete' package.uuid %}">
               {% csrf_token %}
               <button class="link" type="submit">{% trans "Delete" %}</button>

--- a/storage_service/templates/snippets/package_row.html
+++ b/storage_service/templates/snippets/package_row.html
@@ -9,7 +9,7 @@
           {% endif %}
         </td>
         <td>
-          {% if package.status != package.DELETED %}
+          {% if package.status != package.DELETED and package.current_location.space.access_protocol != "REPLICA" %}
             <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">{{ package.full_path }}</a>
           {% else %}
             <span>{{ package.full_path }}</span>
@@ -40,7 +40,7 @@
           {% if package.pointer_file_location %}
             <a href="{% url 'pointer_file_request' 'v2' 'file' package.uuid %}">{% trans "Pointer File" %}</a> |
           {% endif %}
-          {% if package.status != package.DELETED %}
+          {% if package.status != package.DELETED and package.current_location.space.access_protocol != "REPLICA" %}
             <a href="{% url 'download_request' 'v2' 'file' package.uuid %}">{% trans "Download" %}</a> |
           {% endif %}
 
@@ -49,7 +49,7 @@
             <a href="{% url 'locations:aip_reingest' package.uuid %}?next={{ redirect_path }}">{% trans "Re-ingest" %}</a> |
           {% endif %}
 
-          {% if package.package_type in package.PACKAGE_TYPE_CAN_DELETE %}
+          {% if package.package_type in package.PACKAGE_TYPE_CAN_DELETE and package.current_location.space.access_protocol != "REPLICA" %}
           <a href="#" class="request-delete"
              data-package-type="{{ package.package_type }}"
              data-package-uuid="{{ package.uuid }}"


### PR DESCRIPTION
Connected to https://github.com/archivematica/Issues/issues/1440

This PR removes action (download and delete) links from the Packages table for replicas stored in an `OfflineReplicaStaging` Space, based on feedback from internal QA.

Example row for a replica with this commit:

![image](https://user-images.githubusercontent.com/6758804/117332563-004ee600-ae66-11eb-9025-23691d460606.png)
