### PR TITLE
Make the code Python 3 compatible

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -22,10 +22,10 @@ from django.http import HttpResponseRedirect
 from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils.translation import ugettext as _
-from django.utils import six
 
 # Third party dependencies, alphabetical
 import bagit
+import six
 from tastypie.authentication import (
     BasicAuthentication,
     ApiKeyAuthentication,
@@ -474,9 +474,7 @@ class LocationResource(ModelResource):
         location = bundle.obj
         path = request.GET.get("path", "")
         path = self.decode_path(path)
-        location_path = location.full_path
-        if isinstance(location_path, six.text_type):
-            location_path = location_path.encode("utf8")
+        location_path = six.ensure_str(location.full_path)
         if not path.startswith(location_path):
             path = os.path.join(location_path, path)
 

--- a/storage_service/locations/api/v2.py
+++ b/storage_service/locations/api/v2.py
@@ -1,10 +1,14 @@
 from __future__ import absolute_import
 import base64
 
+import six
+from tastypie import fields
+
 import locations.api.resources as resources
 
-from tastypie import fields
-from six.moves import map
+
+def b64encode_string(data):
+    return base64.b64encode(six.ensure_binary(data)).decode("utf8")
 
 
 class PipelineResource(resources.PipelineResource):
@@ -15,8 +19,8 @@ class PipelineResource(resources.PipelineResource):
 class SpaceResource(resources.SpaceResource):
     def get_objects(self, space, path):
         objects = space.browse(path)
-        objects["entries"] = list(map(base64.b64encode, objects["entries"]))
-        objects["directories"] = list(map(base64.b64encode, objects["directories"]))
+        objects["entries"] = [b64encode_string(e) for e in objects["entries"]]
+        objects["directories"] = [b64encode_string(d) for d in objects["directories"]]
 
         return objects
 
@@ -27,15 +31,14 @@ class LocationResource(resources.LocationResource):
     pipeline = fields.ToManyField(PipelineResource, "pipeline")
 
     def decode_path(self, path):
-        return base64.b64decode(path)
+        return base64.b64decode(path).decode("utf8")
 
     def get_objects(self, space, path):
         objects = space.browse(path)
-        objects["entries"] = list(map(base64.b64encode, objects["entries"]))
-        objects["directories"] = list(map(base64.b64encode, objects["directories"]))
+        objects["entries"] = [b64encode_string(e) for e in objects["entries"]]
+        objects["directories"] = [b64encode_string(d) for d in objects["directories"]]
         objects["properties"] = {
-            base64.b64encode(k).decode("utf8"): v
-            for k, v in objects.get("properties", {}).items()
+            b64encode_string(k): v for k, v in objects.get("properties", {}).items()
         }
         return objects
 


### PR DESCRIPTION
This converts the `Dockerfile` into a multistage build and adds a
`PYTHON_VERSION` argument which allows the Storage Service to be run
from the development environment in Python 2.7 or Python 3.6.

A few encoding issues raised by the AMAUATs have also been fixed.

Connected to https://github.com/archivematica/Issues/issues/1452