### PR TITLE
Cleanup tar replica left in staging directory

### DIFF
--- a/storage_service/locations/models/replica_staging.py
+++ b/storage_service/locations/models/replica_staging.py
@@ -64,5 +64,13 @@ class OfflineReplicaStaging(models.Model):
         package.current_path = tar_dest_path
         self.space.move_rsync(tar_src_path, tar_dest_path)
 
+        # Cleanup tar in staging directory
+        try:
+            os.remove(tar_src_path)
+        except OSError as err:
+            LOGGER.warning(
+                "Unable to delete staged replica {}: {}".format(tar_src_path, err)
+            )
+
         # Cleanup empty directory created by space.create_local_directory.
         os.rmdir(dest_path)

--- a/storage_service/locations/tests/test_package.py
+++ b/storage_service/locations/tests/test_package.py
@@ -30,6 +30,11 @@ FIXTURES_DIR = os.path.abspath(os.path.join(THIS_DIR, "..", "fixtures", ""))
 TOTAL_FIXTURE_PACKAGES = 15
 
 
+def recursive_file_count(target_dir):
+    """Return count of files in directory based on recursive walk."""
+    return sum([len(files) for _, _, files in os.walk(target_dir)])
+
+
 class TestPackage(TestCase):
 
     fixtures = ["base.json", "package.json", "arkivum.json", "callback.json"]
@@ -725,6 +730,8 @@ class TestPackage(TestCase):
         aip.current_location.space.staging_path = space_dir
         aip.current_location.space.save()
 
+        staging_files_count_initial = recursive_file_count(staging_dir)
+
         aip.current_location.replicators.create(
             space=replica_space,
             relative_path=replication_dir,
@@ -742,6 +749,9 @@ class TestPackage(TestCase):
             replication_dir, utils.uuid_to_path(replica.uuid), "working_bag.tar"
         )
         assert os.path.exists(expected_replica_path)
+
+        # Ensure that tar file in staging is cleaned up properly.
+        assert staging_files_count_initial == recursive_file_count(staging_dir)
 
     def test_replicate_aip_offline_staging_compressed(self):
         """Ensure that a replica is created and stored correctly as-is."""


### PR DESCRIPTION
Connected to https://github.com/archivematica/issues/issues/1440

The initial implementation of the `OfflineReplicaStaging` Space left an extra copy of the tar replica in the Space's staging directory, which was causing disk space issues. This commit fixes the issue and adds an assertion to the test for replicating uncompressed packages in the new Space to ensure that extra copies of the new tar replica aren't left behind in staging.