### PR TITLE
Cleanup quad dirs left in staging directory

### DIFF
--- a/storage_service/locations/models/replica_staging.py
+++ b/storage_service/locations/models/replica_staging.py
@@ -64,13 +64,20 @@ class OfflineReplicaStaging(models.Model):
         package.current_path = tar_dest_path
         self.space.move_rsync(tar_src_path, tar_dest_path)
 
-        # Cleanup tar in staging directory
+        staging_quad_dirs = os.path.relpath(
+            os.path.dirname(tar_src_path), self.space.staging_path
+        )
+
+        # Cleanup tar in staging directory.
         try:
             os.remove(tar_src_path)
         except OSError as err:
             LOGGER.warning(
                 "Unable to delete staged replica {}: {}".format(tar_src_path, err)
             )
+
+        # Cleanup quaddirs in staging directory.
+        utils.removedirs(staging_quad_dirs, base=self.space.staging_path)
 
         # Cleanup empty directory created by space.create_local_directory.
         os.rmdir(dest_path)

--- a/storage_service/locations/tests/test_package.py
+++ b/storage_service/locations/tests/test_package.py
@@ -35,6 +35,11 @@ def recursive_file_count(target_dir):
     return sum([len(files) for _, _, files in os.walk(target_dir)])
 
 
+def recursive_dir_count(target_dir):
+    """Return count of dirs in directory based on recursive walk."""
+    return sum([len(dirs) for _, dirs, _ in os.walk(target_dir)])
+
+
 class TestPackage(TestCase):
 
     fixtures = ["base.json", "package.json", "arkivum.json", "callback.json"]
@@ -731,6 +736,7 @@ class TestPackage(TestCase):
         aip.current_location.space.save()
 
         staging_files_count_initial = recursive_file_count(staging_dir)
+        staging_dirs_count_initial = recursive_dir_count(staging_dir)
 
         aip.current_location.replicators.create(
             space=replica_space,
@@ -750,8 +756,9 @@ class TestPackage(TestCase):
         )
         assert os.path.exists(expected_replica_path)
 
-        # Ensure that tar file in staging is cleaned up properly.
+        # Ensure tar file and quad dirs in staging are cleaned up properly.
         assert staging_files_count_initial == recursive_file_count(staging_dir)
+        assert staging_dirs_count_initial == recursive_dir_count(staging_dir)
 
     def test_replicate_aip_offline_staging_compressed(self):
         """Ensure that a replica is created and stored correctly as-is."""


### PR DESCRIPTION
Connected to https://github.com/archivematica/issues/issues/1440

The initial implementation of the `OfflineReplicaStaging` Space left behind empty quad dirs in the Space's staging directory. This commit fixes the issue and adds an assertion to the test for replicating uncompressed packages in the new Space to ensure that the empty quad dirs are cleaned up properly.