### PR TITLE
Make javascript catalog view login exempt

### DIFF
--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -243,7 +243,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 # ######## LOGIN REQUIRED MIDDLEWARE CONFIGURATION
 LOGIN_URL = "/login/"
 LOGIN_REDIRECT_URL = "/"
-LOGIN_EXEMPT_URLS = (r"^api/", r"^admin/", r"^Shibboleth.sso/", r"^login/")
+LOGIN_EXEMPT_URLS = (r"^api/", r"^admin/", r"^Shibboleth.sso/", r"^login/", r"^jsi18n/")
 # ######## END LOGIN REQUIRED MIDDLEWARE CONFIGURATION
 
 


### PR DESCRIPTION
The `common.middleware.LoginRequiredMiddleware` class requires
authentication for accessing the javascript catalog view at `/jsi18n`
which produces a JS `Uncaught SyntaxError` in the login form when its
`<script>` tag receives HTML instead of JS.

This fixes it by adding the javascript catalog path to the list of
login exempt URLs.

Connected to https://github.com/archivematica/Issues/issues/1317