### PR TITLE
Start watchdog thread explicitly

### DIFF
--- a/storage_service/common/startup.py
+++ b/storage_service/common/startup.py
@@ -2,6 +2,7 @@ import django.core.exceptions
 import errno
 import os.path
 from locations import models as locations_models
+from locations.models.async_manager import start_async_manager
 from common import utils
 import logging
 
@@ -118,3 +119,5 @@ def startup():
         ):
             utils.set_setting(loc_info["default_setting"], [new_loc.uuid])
             LOGGER.info("Set %s as %s", new_loc, loc_info["default_setting"])
+
+    start_async_manager()

--- a/storage_service/locations/models/async_manager.py
+++ b/storage_service/locations/models/async_manager.py
@@ -175,7 +175,8 @@ class AsyncManager(object):
         return async_task
 
 
-# Start our watchdog thread.
-AsyncManager.watchdog = threading.Thread(target=AsyncManager._watchdog)
-AsyncManager.watchdog.daemon = True
-AsyncManager.watchdog.start()
+def start_async_manager():
+    """Start our watchdog thread."""
+    AsyncManager.watchdog = threading.Thread(target=AsyncManager._watchdog)
+    AsyncManager.watchdog.daemon = True
+    AsyncManager.watchdog.start()


### PR DESCRIPTION
Until now, the watchdog thread was started as a side effect of loading
the Django models at startup time. This was inconvenient because the
thread would run (and sometimes fail) when running migrations or other
management commands, running tests, etc...

This commit changes moves the code into a function that is explicitly
executed from `common.startup` when the WSGI application launched.

Connects to https://github.com/archivematica/Issues/issues/1433.