### PR TITLE
Minimize leftovers on disk for Write-Only Replica Staging

### DIFF
--- a/storage_service/locations/models/replica_staging.py
+++ b/storage_service/locations/models/replica_staging.py
@@ -59,8 +59,13 @@ class OfflineReplicaStaging(models.Model):
         self.space.create_local_directory(dest_path)
         if not package.is_packaged(src_path):
             return self._store_tar_replica(src_path, dest_path, package)
-        self.space.move_rsync(src_path, dest_path)
+        self.space.move_rsync(src_path, dest_path, try_mv_local=True)
         package.current_path = dest_path
+
+        staging_quad_dirs = os.path.relpath(
+            os.path.dirname(src_path), self.space.staging_path
+        )
+        utils.removedirs(staging_quad_dirs, base=self.space.staging_path)
 
     def _store_tar_replica(self, src_path, dest_path, package):
         """Create and store TAR replica."""

--- a/storage_service/locations/tests/test_package.py
+++ b/storage_service/locations/tests/test_package.py
@@ -755,7 +755,6 @@ class TestPackage(TestCase):
         assert os.path.exists(expected_replica_path)
         assert replica.current_path == expected_replica_path
 
-        # Ensure tar file and quad dirs in staging are cleaned up properly.
         assert staging_files_count_initial == recursive_file_count(staging_dir)
         assert staging_dirs_count_initial == recursive_dir_count(staging_dir)
 
@@ -775,6 +774,9 @@ class TestPackage(TestCase):
         aip.current_location.space.staging_path = space_dir
         aip.current_location.space.save()
 
+        staging_files_count_initial = recursive_file_count(staging_dir)
+        staging_dirs_count_initial = recursive_dir_count(staging_dir)
+
         aip.current_location.replicators.create(
             space=replica_space,
             relative_path=replication_dir,
@@ -791,6 +793,9 @@ class TestPackage(TestCase):
         expected_replica_path = os.path.join(replication_dir, "working_bag.7z")
         assert os.path.exists(expected_replica_path)
         assert replica.current_path == expected_replica_path
+
+        assert staging_files_count_initial == recursive_file_count(staging_dir)
+        assert staging_dirs_count_initial == recursive_dir_count(staging_dir)
 
     def test_deletion_and_creation_of_replicas_compressed(self):
         """Ensure that when it is requested a replica be created, then


### PR DESCRIPTION
Connected to https://github.com/archivematica/issues/issues/1440

These small tweaks will help not to leave leftover copies of the AIP around after replication.