### PR TITLE
Add support for Content Security Policy headers

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -10,6 +10,9 @@
     - [Gunicorn-specific environment variables](#gunicorn-specific-environment-variables)
     - [LDAP-specific environment variables](#ldap-specific-environment-variables)
     - [CAS-specific environment variables](#cas-specific-environment-variables)
+    - [OIDC-specific environment variables](#oidc-specific-environment-variables)
+    - [AWS-specific environment variables](#aws-specific-environment-variables)
+    - [CSP-specific environment variables](#csp-specific-environment-variables)
   - [Logging configuration](#logging-configuration)
 
 ## Introduction
@@ -112,6 +115,11 @@ of these settings or provide values to mandatory fields.
 
 - **`SS_INSECURE_SKIP_VERIFY`**:
     - **Description:** skip the SSL certificate verification process. This setting should not be used in production environments.
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`SS_CSP_ENABLED`**:
+    - **Description:** **Experimental** support for [Control Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) headers.
     - **Type:** `boolean`
     - **Default:** `false`
 
@@ -491,6 +499,17 @@ These variables can be set to allow AWS authentication for S3 storage spaces as 
     - **Description:** Secret key associated with the access key
     - **Type:** `string`
     - **Default:** `''`
+
+### CSP-specific environment variables
+
+**CSP support is experimental, please share your feedback!**
+
+These variables specify the behaviour of the Content Security Policy (CSP) headers. Only applicable if `SS_CSP_ENABLED` is set.
+
+- **`CSP_SETTINGS_FILE`**:
+    - **Description:** Path to a Python module with overrides of the [`django-csp` policy settings](https://django-csp.readthedocs.io/en/latest/configuration.html#policy-settings). An `ImproperlyConfigured` exception will be raised if the Python module cannot be imported.
+    - **Type:** `string`
+    - **Default:** ``
 
 ## Logging configuration
 

--- a/requirements/base-py3.txt
+++ b/requirements/base-py3.txt
@@ -17,11 +17,12 @@ debtcollector==2.2.0      # via oslo.config, oslo.utils, python-keystoneclient
 defusedxml==0.5.0         # via -r base.in
 django-auth-ldap==1.3.0   # via -r base.in
 django-cas-ng==3.6.0      # via -r base.in
+django-csp==3.7.0         # via -r base.in
 django-extensions==1.7.9  # via -r base.in
 django-prometheus==1.0.15  # via -r base.in
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.in
 django-tastypie==0.14.3   # via -r base.in
-django==1.11.29           # via -r base.in, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
+django==1.11.29           # via -r base.in, django-auth-ldap, django-cas-ng, django-csp, jsonfield, mozilla-django-oidc
 future==0.18.2            # via metsrw
 gevent==1.3.6             # via -r base.in
 greenlet==1.1.0           # via gevent

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,6 +4,7 @@ boto3>=1.17.88,<1.18.0
 brotli==0.5.2  # Better compression library for WhiteNoise
 defusedxml==0.5.0
 Django>=1.11,<2
+django-csp==3.7.0
 django-extensions==1.7.9
 django-tastypie==0.14.3
 futures==3.3.0; python_version < '3.0'  # used by gunicorn's async workers

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,11 +20,12 @@ debtcollector==1.22.0     # via oslo.config, oslo.utils, python-keystoneclient
 defusedxml==0.5.0         # via -r base.in
 django-auth-ldap==1.3.0   # via -r base.in
 django-cas-ng==3.6.0      # via -r base.in
+django-csp==3.7.0         # via -r base.in
 django-extensions==1.7.9  # via -r base.in
 django-prometheus==1.0.15  # via -r base.in
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.in
 django-tastypie==0.14.3   # via -r base.in
-django==1.11.29           # via -r base.in, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
+django==1.11.29           # via -r base.in, django-auth-ldap, django-cas-ng, django-csp, jsonfield, mozilla-django-oidc
 enum34==1.1.10            # via cryptography, oslo.config
 funcsigs==1.0.2           # via debtcollector, oslo.utils
 future==0.18.2            # via metsrw

--- a/requirements/local-py3.txt
+++ b/requirements/local-py3.txt
@@ -18,11 +18,12 @@ defusedxml==0.5.0         # via -r base-py3.txt
 dj-database-url==0.4.2    # via -r local-py3.in
 django-auth-ldap==1.3.0   # via -r base-py3.txt
 django-cas-ng==3.6.0      # via -r base-py3.txt
+django-csp==3.7.0         # via -r base-py3.txt
 django-extensions==1.7.9  # via -r base-py3.txt
 django-prometheus==1.0.15  # via -r base-py3.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base-py3.txt
 django-tastypie==0.14.3   # via -r base-py3.txt
-django==1.11.29           # via -r base-py3.txt, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
+django==1.11.29           # via -r base-py3.txt, django-auth-ldap, django-cas-ng, django-csp, jsonfield, mozilla-django-oidc
 future==0.18.2            # via -r base-py3.txt, metsrw
 gevent==1.3.6             # via -r base-py3.txt
 greenlet==1.1.0           # via -r base-py3.txt, gevent

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -21,11 +21,12 @@ defusedxml==0.5.0         # via -r base.txt
 dj-database-url==0.4.2    # via -r local.in
 django-auth-ldap==1.3.0   # via -r base.txt
 django-cas-ng==3.6.0      # via -r base.txt
+django-csp==3.7.0         # via -r base.txt
 django-extensions==1.7.9  # via -r base.txt
 django-prometheus==1.0.15  # via -r base.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
 django-tastypie==0.14.3   # via -r base.txt
-django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
+django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, django-csp, jsonfield, mozilla-django-oidc
 enum34==1.1.10            # via -r base.txt, cryptography, oslo.config
 funcsigs==1.0.2           # via -r base.txt, debtcollector, oslo.utils
 future==0.18.2            # via -r base.txt, metsrw

--- a/requirements/production-py3.txt
+++ b/requirements/production-py3.txt
@@ -18,11 +18,12 @@ defusedxml==0.5.0         # via -r base-py3.txt
 dj-database-url==0.4.2    # via -r production-py3.in
 django-auth-ldap==1.3.0   # via -r base-py3.txt
 django-cas-ng==3.6.0      # via -r base-py3.txt
+django-csp==3.7.0         # via -r base-py3.txt
 django-extensions==1.7.9  # via -r base-py3.txt
 django-prometheus==1.0.15  # via -r base-py3.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base-py3.txt
 django-tastypie==0.14.3   # via -r base-py3.txt
-django==1.11.29           # via -r base-py3.txt, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
+django==1.11.29           # via -r base-py3.txt, django-auth-ldap, django-cas-ng, django-csp, jsonfield, mozilla-django-oidc
 future==0.18.2            # via -r base-py3.txt, metsrw
 gevent==1.3.6             # via -r base-py3.txt
 greenlet==1.1.0           # via -r base-py3.txt, gevent

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -21,11 +21,12 @@ defusedxml==0.5.0         # via -r base.txt
 dj-database-url==0.4.2    # via -r production.in
 django-auth-ldap==1.3.0   # via -r base.txt
 django-cas-ng==3.6.0      # via -r base.txt
+django-csp==3.7.0         # via -r base.txt
 django-extensions==1.7.9  # via -r base.txt
 django-prometheus==1.0.15  # via -r base.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
 django-tastypie==0.14.3   # via -r base.txt
-django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
+django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, django-csp, jsonfield, mozilla-django-oidc
 enum34==1.1.10            # via -r base.txt, cryptography, oslo.config
 funcsigs==1.0.2           # via -r base.txt, debtcollector, oslo.utils
 future==0.18.2            # via -r base.txt, metsrw

--- a/requirements/test-py3.txt
+++ b/requirements/test-py3.txt
@@ -23,11 +23,12 @@ defusedxml==0.5.0         # via -r base-py3.txt
 distlib==0.3.2            # via virtualenv
 django-auth-ldap==1.3.0   # via -r base-py3.txt
 django-cas-ng==3.6.0      # via -r base-py3.txt
+django-csp==3.7.0         # via -r base-py3.txt
 django-extensions==1.7.9  # via -r base-py3.txt
 django-prometheus==1.0.15  # via -r base-py3.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base-py3.txt
 django-tastypie==0.14.3   # via -r base-py3.txt
-django==1.11.29           # via -r base-py3.txt, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
+django==1.11.29           # via -r base-py3.txt, django-auth-ldap, django-cas-ng, django-csp, jsonfield, mozilla-django-oidc
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r base-py3.txt, metsrw
 gevent==1.3.6             # via -r base-py3.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,11 +27,12 @@ defusedxml==0.5.0         # via -r base.txt
 distlib==0.3.2            # via virtualenv
 django-auth-ldap==1.3.0   # via -r base.txt
 django-cas-ng==3.6.0      # via -r base.txt
+django-csp==3.7.0         # via -r base.txt
 django-extensions==1.7.9  # via -r base.txt
 django-prometheus==1.0.15  # via -r base.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
 django-tastypie==0.14.3   # via -r base.txt
-django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, jsonfield, mozilla-django-oidc
+django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, django-csp, jsonfield, mozilla-django-oidc
 enum34==1.1.10            # via -r base.txt, cryptography, oslo.config
 filelock==3.0.12          # via tox, virtualenv
 funcsigs==1.0.2           # via -r base.txt, debtcollector, mock, oslo.utils, pytest

--- a/storage_service/storage_service/settings/components/csp.py
+++ b/storage_service/storage_service/settings/components/csp.py
@@ -1,0 +1,7 @@
+CSP_DEFAULT_SRC = ["'none'"]
+CSP_SCRIPT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
+CSP_STYLE_SRC = ["'self'", "'unsafe-inline'"]
+CSP_IMG_SRC = ["'self'"]
+
+# for the create space form
+CSP_CONNECT_SRC = ["'self'"]


### PR DESCRIPTION
This adds a new `SS_CSP_ENABLED` Django setting that enables control
of content security policy headers through the `django-csp` package.

A small set of header policies are loaded from the
`settings.components.csp` module, but users can provide their own
overrides though a Python module set in the `CSP_SETTINGS_FILE` Django
setting.

Connected to https://github.com/archivematica/Issues/issues/1311