### PR TITLE
Lock default locations creation on startup

### DIFF
--- a/storage_service/administration/models.py
+++ b/storage_service/administration/models.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import
 from django.db import models
+import six
 
 
+@six.python_2_unicode_compatible
 class Settings(models.Model):
     name = models.CharField(max_length=255, unique=True)
     value = models.TextField(null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return u"{}: {}".format(self.name, self.value)

--- a/storage_service/common/startup.py
+++ b/storage_service/common/startup.py
@@ -1,15 +1,64 @@
-import django.core.exceptions
 import errno
+import logging
 import os.path
+
+import django.core.exceptions
+from django.db import connection
+
 from locations import models as locations_models
 from locations.models.async_manager import start_async_manager
 from common import utils
-import logging
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def startup():
-    LOGGER = logging.getLogger(__name__)
     LOGGER.info("Running startup")
+
+    try:
+        with PopulateLock():
+            populate_default_locations()
+    except PopulateLockError:
+        LOGGER.warning("Another worker is initializing the database.")
+
+    start_async_manager()
+
+
+class PopulateLockError(Exception):
+    """MySQL lock is already held or an error occurred."""
+
+
+class PopulateLock(object):
+    """MySQL lock that gives up immediately on a held lock."""
+
+    def __init__(self):
+        self.name = "default_locations"
+        self.connection = connection
+        self.timeout = 0
+
+    def __enter__(self):
+        if self.connection.vendor == "mysql":
+            self.acquire()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.connection.vendor == "mysql":
+            self.release()
+
+    def acquire(self):
+        with self.connection.cursor() as cursor:
+            cursor.execute("SELECT GET_LOCK(%s, %s)", (self.name, self.timeout))
+            result = cursor.fetchone()[0]
+            if result != 1:
+                raise PopulateLockError("Error obtaining the lock or already acquried.")
+
+    def release(self):
+        with self.connection.cursor() as cursor:
+            cursor.execute("SELECT RELEASE_LOCK(%s)", (self.name,))
+
+
+def populate_default_locations():
+    """Create default local filesystem space and its locations."""
     try:
         space, space_created = locations_models.Space.objects.get_or_create(
             access_protocol=locations_models.Space.LOCAL_FILESYSTEM,
@@ -119,5 +168,3 @@ def startup():
         ):
             utils.set_setting(loc_info["default_setting"], [new_loc.uuid])
             LOGGER.info("Set %s as %s", new_loc, loc_info["default_setting"])
-
-    start_async_manager()


### PR DESCRIPTION
This adds a MySQL exclusive lock to the startup process which prevents
multiple gunicorn workers from creating different default locations at
once.

Co-authored-by: Jesús García Crespo <jesus@sevein.com>

Connected to https://github.com/archivematica/Issues/issues/1463