### PR TITLE
Add exception handling for cleanup routine

### DIFF
--- a/storage_service/common/tests/test_utils.py
+++ b/storage_service/common/tests/test_utils.py
@@ -451,12 +451,17 @@ def test_create_tar(
         ),
         # Ensure other directories are not removed.
         (
-            "/var/archivematica/sharedDirectory/www/offlineReplicas/test-file.txt",
-            "/var/archivematica/sharedDirectory/www/offlineReplicas/test-file.txt",
+            "/var/archivematica/sharedDirectory/www/offlineReplicas/test-file.tar",
+            "/var/archivematica/sharedDirectory/www/offlineReplicas/test-file.tar",
         ),
         (
             "/var/archivematica/sharedDirectory/www/offlineReplicas/test/package.tar.gz",
             "/var/archivematica/sharedDirectory/www/offlineReplicas/test/package.tar.gz",
+        ),
+        # Ensure directories terminate in slash, even if path contains dots.
+        (
+            "/var/archivematica/sharedDirectory/www/offlineReplicas/d8a4/d502/30b7/4902/b545/9c87/8242/f96c/uncompressed.test.1-d8a4d502-30b7-4902-b545-9c878242f96c",
+            "/var/archivematica/sharedDirectory/www/offlineReplicas/uncompressed.test.1-d8a4d502-30b7-4902-b545-9c878242f96c/",
         ),
     ],
 )

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -697,10 +697,10 @@ def strip_quad_dirs_from_path(dest_path):
             continue
         output_path = head
     output_path = os.path.join(output_path, package_name)
-    _, file_extension = os.path.splitext(output_path)
-    if not file_extension:
-        return os.path.join(output_path, "")
-    return output_path
+    for extension in PACKAGE_EXTENSIONS:
+        if output_path.endswith(extension):
+            return output_path
+    return os.path.join(output_path, "")
 
 
 def coerce_str(string):

--- a/storage_service/locations/models/replica_staging.py
+++ b/storage_service/locations/models/replica_staging.py
@@ -94,4 +94,11 @@ class OfflineReplicaStaging(models.Model):
         utils.removedirs(staging_quad_dirs, base=self.space.staging_path)
 
         # Cleanup empty directory created by space.create_local_directory.
-        os.rmdir(dest_path)
+        try:
+            os.rmdir(dest_path)
+        except OSError as err:
+            LOGGER.warning(
+                "Unable to cleanup expected temporary artefact {}: {}".format(
+                    dest_path, err
+                )
+            )


### PR DESCRIPTION
Connected to https://github.com/archivematica/Issues/issues/1461

`utils.strip_quad_dirs_from_path` previously returned a path string that did not terminate in a trailing slash if full stops (`.`) were present in the input file path. This PR fixes the issue, adds a test case for it, and adds exception handling so that Store AIP does not fail if an expected temporary artefact of the replication process can't be cleaned up.