### PR TITLE
Don't stage encrypted AIPs twice, refs #1112

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -255,7 +255,7 @@ class Package(models.Model):
     @property
     def is_compressed(self):
         """ Determines whether or not the package is a compressed file. """
-        full_path = self.fetch_local_path()
+        full_path = self.get_local_path() or self.fetch_local_path()
         if os.path.isdir(full_path):
             return False
         elif os.path.isfile(full_path):
@@ -309,7 +309,7 @@ class Package(models.Model):
         else:  # LOCKSS AU number specified, but not a LOCKSS package
             LOGGER.warning("Trying to download LOCKSS chunk for a non-LOCKSS package.")
             path = full_path
-        LOGGER.debug("Got download path {} for package {}".format(path, self.uuid))
+        LOGGER.debug("Got download path %s for package %s", path, self.uuid)
         return path
 
     def get_local_path(self):
@@ -363,7 +363,6 @@ class Package(models.Model):
             destination_space=ss_internal.space,
         )
 
-        self.current_location = ss_internal
         self.local_path_location = ss_internal
         self.local_path = int_path
         self.local_tempdirs.append(temp_dir)


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/1112

Update `self.current_location` to the temporary staging directory after
copying and decrypting the package.  This is necessary so subsequent
calls to `fetch_local_path()` check if the current (staging) Space is
encrypted (via `is_encrypted()`), not whether the AIPsStore Space
is encrypted.  If `fetch_local_path()` thinks the package is still
encrypted it will copy it to a new temp dir and decrypt it again.

Also:
- Copy encrypted AIPs directly from storage location to temporary
  staging directory and decrypt there
- Add a debug log message to `get_download_path()`