### PR TITLE
Use os.makedirs to build tree in extract_file

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -1633,13 +1633,13 @@ class Package(models.Model):
                 # copy only one file out of aip
                 head, tail = os.path.split(full_path)
                 src = os.path.join(head, relative_path)
-                os.mkdir(os.path.join(extract_path, basename))
+                os.makedirs(os.path.dirname(output_path))
+                LOGGER.info("Copying from: %s to %s", src, output_path)
                 shutil.copy(src, output_path)
             else:
                 src = full_path
+                LOGGER.info("Copying from: %s to %s", full_path, output_path)
                 shutil.copytree(full_path, output_path)
-
-            LOGGER.info("Copying from: %s to %s", src, output_path)
 
         if not relative_path:
             self.local_path_location = ss_internal

--- a/storage_service/locations/tests/test_package.py
+++ b/storage_service/locations/tests/test_package.py
@@ -448,6 +448,18 @@ class TestPackage(TestCase):
         assert output_path == os.path.join(self.tmp_dir, basedir, "manifest-md5.txt")
         assert os.path.isfile(output_path)
 
+    def test_extract_file_nested_file_from_uncompressed_aip(self):
+        """ It should return a single file from an uncompressed aip (with nested path) """
+        package = models.Package.objects.get(
+            uuid="0d4e739b-bf60-4b87-bc20-67a379b28cea"
+        )
+        basedir = package.get_base_directory()
+        output_path, extract_path = package.extract_file(
+            relative_path="working_bag/data/test.txt", extract_path=self.tmp_dir
+        )
+        assert output_path == os.path.join(self.tmp_dir, basedir, "data/test.txt")
+        assert os.path.isfile(output_path)
+
     def test_extract_file_file_from_compressed_aip(self):
         """ It should return a single file from a 7zip compressed aip """
         package = models.Package.objects.get(


### PR DESCRIPTION
Since baaede6b3, `is_compressed` returns `True` when expected. This forces
`extract_file_request` to call `extract_file` to retrieve the file. This method
was failing because `os.mkdir` is not able to create directories recursively.
This commit uses `os.makedirs` instead.

I've tested with encrypted and non-encrypted AIPs (compressed and uncompressed).

Connects to https://github.com/archivematica/Issues/issues/1112.