### PR TITLE
Resolve symbolic link paths in browse API endpoints

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -73,9 +73,9 @@ LOGGER = logging.getLogger(__name__)
 def _is_relative_path(path1, path2):
     """Ensure path2 is relative to path1"""
     try:
-        Path(path2).resolve().relative_to(path1)
+        Path(path2).resolve().relative_to(Path(path1).resolve())
         return True
-    except ValueError:
+    except (ValueError, RuntimeError):
         return False
 
 


### PR DESCRIPTION
In order to restrict access to files and directories outside the designated storage locations, https://github.com/artefactual/archivematica-storage-service/pull/617 introduced the `_is_relative_path` helper (based on [`Pathlib.resolve`](https://docs.python.org/3.6/library/pathlib.html#pathlib.Path.resolve)) to convert the `path` parameter in the [`/api/v2/space/<UUID>/browse/`](https://wiki.archivematica.org/Storage_Service_API#Browse_space_path) and [`/api/v2/location/<UUID>/browse/`](https://wiki.archivematica.org/Storage_Service_API#Browse_location_path) API calls into an absolute path before determining if it is relative to the space/location path.

The problem is that `Pathlib.resolve` resolves symbolic links automatically and if the involved paths are symbolic links pointing to outside directories, the helper only resolves the `path` parameter but keeps the space/location path in its original form which results in a path mismatch. This PR fixes it by resolving both.

Connected to https://github.com/archivematica/Issues/issues/1515