### PR TITLE
Return staging_path when getting space via API

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -248,6 +248,7 @@ class SpaceResource(ModelResource):
             "used",
             "uuid",
             "verified",
+            "staging_path",
         ]
         list_allowed_methods = ["get", "post"]
         detail_allowed_methods = ["get"]
@@ -260,6 +261,7 @@ class SpaceResource(ModelResource):
             "used": ALL,
             "uuid": ALL,
             "verified": ALL,
+            "staging_path": ALL,
         }
 
     def prepend_urls(self):


### PR DESCRIPTION
staging_path is a common field for all storage types, but the field was
absent from the JSON returned via the API.

Resolves https://github.com/archivematica/Issues/issues/1528