### PR TITLE
Update get-pip script URL to use Python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN set -ex \
 	&& chown -R archivematica:archivematica $internalDirs
 
 RUN set -ex \
-	&& curl -s https://bootstrap.pypa.io/get-pip.py | python3.6 \
+	&& curl -s https://bootstrap.pypa.io/pip/3.6/get-pip.py | python3.6 \
 	&& update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 COPY requirements/ /src/requirements/


### PR DESCRIPTION
Connected to https://github.com/archivematica/Issues/issues/1532