### PR TITLE
Send mimetype when uploading object to s3 and DuraCloud

### DIFF
--- a/storage_service/common/tests/test_utils.py
+++ b/storage_service/common/tests/test_utils.py
@@ -468,3 +468,9 @@ def test_create_tar(
 )
 def test_strip_quad_dirs_from_path(input_path, expected_path):
     assert utils.strip_quad_dirs_from_path(input_path) == expected_path
+
+def test_get_mimetype():
+    assert utils.get_mimetype('video.mp4') == 'video/mp4'
+    assert utils.get_mimetype('C:\Windows\Path\windowsfile.xml') == 'application/xml'
+    assert utils.get_mimetype('/var/lib/file.txt') == 'text/plain'
+    assert utils.get_mimetype('undetermined') == None

--- a/storage_service/common/tests/test_utils.py
+++ b/storage_service/common/tests/test_utils.py
@@ -473,4 +473,4 @@ def test_get_mimetype():
     assert utils.get_mimetype('video.mp4') == 'video/mp4'
     assert utils.get_mimetype('C:\Windows\Path\windowsfile.xml') == 'application/xml'
     assert utils.get_mimetype('/var/lib/file.txt') == 'text/plain'
-    assert utils.get_mimetype('undetermined') == None
+    assert utils.get_mimetype('undetermined') is None

--- a/storage_service/common/tests/test_utils.py
+++ b/storage_service/common/tests/test_utils.py
@@ -469,8 +469,9 @@ def test_create_tar(
 def test_strip_quad_dirs_from_path(input_path, expected_path):
     assert utils.strip_quad_dirs_from_path(input_path) == expected_path
 
+
 def test_get_mimetype():
-    assert utils.get_mimetype('video.mp4') == 'video/mp4'
-    assert utils.get_mimetype('C:\Windows\Path\windowsfile.xml') == 'application/xml'
-    assert utils.get_mimetype('/var/lib/file.txt') == 'text/plain'
-    assert utils.get_mimetype('undetermined') is None
+    assert utils.get_mimetype("video.mp4") == "video/mp4"
+    assert utils.get_mimetype("C:\\Windows\\Path\\windowsfile.xml") == "application/xml"
+    assert utils.get_mimetype("/var/lib/file.txt") == "text/plain"
+    assert utils.get_mimetype("undetermined") is None

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -174,8 +174,7 @@ def download_file_stream(filepath, temp_dir=None):
     # Open file in binary mode
     response = http.FileResponse(open(filepath, "rb"))
 
-    mimetype = mimetypes.guess_type(filename)[0]
-    response["Content-type"] = mimetype
+    response["Content-type"] = get_mimetype(filename)
     response["Content-Disposition"] = 'attachment; filename="' + filename + '"'
     response["Content-Length"] = os.path.getsize(filepath)
 
@@ -744,3 +743,9 @@ def package_is_file(path):
         if path.endswith(ext):
             return True
     return False
+
+def get_mimetype(path):
+    """Returns a file's mimetype based on its extension.
+    Returns None if unable to determine the mimetype.
+    """
+    return mimetypes.guess_type(path)[0]

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -744,6 +744,7 @@ def package_is_file(path):
             return True
     return False
 
+
 def get_mimetype(path):
     """Returns a file's mimetype based on its extension.
     Returns None if unable to determine the mimetype.

--- a/storage_service/locations/models/duracloud.py
+++ b/storage_service/locations/models/duracloud.py
@@ -440,7 +440,10 @@ class Duracloud(models.Model):
                     ).decode("utf8")
                 )
             # Upload .dura-manifest
-            self._upload_chunk(manifest_url, manifest_path, checksum.hexdigest())
+            manifest_checksum = utils.generate_checksum(manifest_path)
+            self._upload_chunk(
+                manifest_url, manifest_path, manifest_checksum.hexdigest()
+            )
             os.remove(manifest_path)
             # TODO what if .dura-manifest over chunksize?
         else:

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -244,18 +244,25 @@ class S3(models.Model):
                     entry = os.path.join(path, basename)
                     dest = entry.replace(src_path, dest_path, 1)
 
-                    with open(entry, "rb") as data:
-                        bucket.upload_fileobj(data, dest)
+                    self.upload_object(bucket, dest, entry)
 
         elif os.path.isfile(src_path):
             # strip leading slash on dest_path
             dest_path = dest_path.lstrip("/")
 
-            with open(src_path, "rb") as data:
-                bucket.upload_fileobj(data, dest_path)
+            self.upload_object(bucket, dest_path, src_path)
 
         else:
             raise StorageException(
                 _("%(path)s is neither a file nor a directory, may not exist")
                 % {"path": src_path}
             )
+
+    def upload_object(self, bucket, path, data):
+        extra_args = {}
+        mtype = utils.get_mimetype(path)
+        if mtype:
+            extra_args["ContentType"] = mtype
+
+        with open(data, "rb") as d:
+            bucket.upload_fileobj(d, path, ExtraArgs=extra_args)


### PR DESCRIPTION
And sends the locally calculated checksum when uploading to DuraCloud.

Creates a new util method for returning mimetype, so we don't repeat code.

I noticed that `dspace.py` also uses `mimetypes`. It could re-use the `get_mimetype` method introduced here, but I wanted to confirm something with the maintainers first.

In `dspace.py` there is this line:

```
"Content-Type": str(mimetypes.guess_type(upload_path)),
```

which effectively means the Content-Type header being sent to dspace is `('video/mp4', None)`. Is that intentional? I would have thought only `video/mp4` is necessary.

Connected to https://github.com/archivematica/Issues/issues/1550