### PR TITLE
delete source path after moving

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -489,6 +489,8 @@ class Package(models.Model):
         source_path = os.path.join(
             self.current_location.relative_path, self.current_path
         )
+        #get full path of origin for delete_path
+        source_delete_path = self.full_path
 
         destination_path = os.path.join(to_location.relative_path, self.current_path)
 
@@ -517,6 +519,8 @@ class Package(models.Model):
             destination_space.post_move_from_storage_service(
                 destination_path, destination_path
             )
+            #After everything is moved, delete the path at origin
+            origin_space.delete_path(source_delete_path)
 
         # If we get here everything went well, update with new location
         self.current_location = to_location


### PR DESCRIPTION
Piggybacking off of #632, even if the pointer file is successfully recreated, I don't think 'move' is working fully as intended because it doesn't delete the original package in the source after the move. Though, I'm not sure if that was the intent to leave the original there. In the SS api, it uses the term 'relocate' so I'm assuming that the intent is to remove the original files in the source. This uses 'delete_path' to do so.