### PR TITLE
Fix package checksums

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -2616,6 +2616,8 @@ class Package(models.Model):
                 premis_agents=premis_agents,
                 aip_subtype=aip_subtype,
             )
+            self.checksum = checksum
+            self.checksum_algorithm = Package.DEFAULT_CHECKSUM_ALGORITHM
 
         # 8. Store the AIP in the reingest_location.
         storage_effects = self._move_rein_updated_to_final_dest(

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -981,7 +981,7 @@ class Package(models.Model):
                 package=self,
             )
             checksum = None
-            if not v.already_generated_ptr_exists:
+            if self.package_type != Package.DIP and not v.already_generated_ptr_exists:
                 # If posix_move didn't raise, then get_local_path() should
                 # return not None
                 checksum = utils.generate_checksum(
@@ -1019,7 +1019,7 @@ class Package(models.Model):
             # ``self.get_local_path()`` won't work.
             local_aip_path = os.path.join(v.dest_space.staging_path, self.current_path)
             checksum = None
-            if not v.already_generated_ptr_exists:
+            if self.package_type != Package.DIP and not v.already_generated_ptr_exists:
                 checksum = utils.generate_checksum(
                     local_aip_path, Package.DEFAULT_CHECKSUM_ALGORITHM
                 ).hexdigest()


### PR DESCRIPTION
This fixes a couple of issues that were detected in the acceptance tests after https://github.com/artefactual/archivematica-storage-service/pull/639:

* At the end of a reingest the checksum of the existing package was not updated. Fixed in https://github.com/artefactual/archivematica-storage-service/commit/6727159358d5a140e5242551c627e96fe945895d
* DIPs match the criteria for calculating checksums of uncompressed AIPs: they are uncompressed and don't have pointer files. They're now ignored in https://github.com/artefactual/archivematica-storage-service/commit/94323176d2f9373481666b069ead56d8f920cd6a

Connected to https://github.com/archivematica/Issues/issues/1582