### PR TITLE
Move pyenv directory outside of home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,15 @@ ENV LC_ALL en_US.UTF-8
 
 RUN set -ex \
 	&& groupadd --gid ${GROUP_ID} --system archivematica \
-	&& useradd -m --uid ${USER_ID} --gid ${GROUP_ID} --create-home --home-dir /home/archivematica --system archivematica
+	&& useradd --uid ${USER_ID} --gid ${GROUP_ID} --home-dir /var/archivematica --system archivematica
+
+ENV PYENV_ROOT="/pyenv/data"
+ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 
 RUN set -ex \
 	&& internalDirs=' \
-		/db \
+		/pyenv \
+		/home/archivematica \
 		/src/storage_service/assets \
 		/src/storage_service/locations/fixtures \
 		/var/archivematica/storage_service \
@@ -71,9 +75,6 @@ RUN set -ex \
 	&& chown -R archivematica:archivematica $internalDirs
 
 USER archivematica
-
-ENV PYENV_ROOT="/home/archivematica/.pyenv"
-ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 
 RUN set -ex \
 	&& curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \


### PR DESCRIPTION
The Compose configuration mounts the `archivematica-sample-data` repository under `/home/archivematica/` so the default configuration of the Storage Service filesystem space works. A side effect of this is that any file created by other tools like `pyenv`, `pip` or `bash`  in the home directory of the `archivematica` user are accessible from the external `ss-location-data` volume.

This minimizes that problem by setting the home directory of the `archivematica` user and the `pyenv` root directory outside of the `/home` directory.

Connected to https://github.com/archivematica/Issues/issues/1613