### PR TITLE
Use osdeps to install mime types package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,20 +8,12 @@ on:
       - "stable/**"
 jobs:
   test:
-    name: "Test ${{ matrix.name }}"
+    name: "Test Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-20.04"
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: "py36"
-            python-version: "3.6"
-            toxenv: "py36"
-            coverage: true
-          - name: "migrations"
-            python-version: "3.6"
-            toxenv: "migrations"
-            coverage: false
+        python-version: ["3.6"]
     steps:
       - name: "Check out repository"
         uses: "actions/checkout@v3"
@@ -29,6 +21,9 @@ jobs:
         uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
+          cache: "pip"
+          cache-dependency-path: |
+            **/requirements/test.txt
       - name: "Install OS packages"
         run: |
           sudo apt-get --quiet update
@@ -53,7 +48,7 @@ jobs:
       - name: "Install tox"
         run: |
           python -m pip install --upgrade pip
-          pip install tox
+          pip install tox tox-gh-actions
       - name: "Run tox"
         if: "! matrix.coverage"
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,12 @@ jobs:
           name: ${{ matrix.name }}
           flags: ${{ matrix.name }}
   integration:
-    name: "Integration"
+    name: "Integration ${{ matrix.ubuntu-version }}"
     runs-on: "ubuntu-22.04"
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu-version: ["20.04", "22.04"]
     steps:
       - name: "Check out repository"
         uses: "actions/checkout@v3"
@@ -89,6 +93,8 @@ jobs:
         shell: "bash"
         working-directory: "integration"
         env:
+          UBUNTU_VERSION: ${{ matrix.ubuntu-version }}
+          PYTHON_VERSION: "3.6"
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
           PYTEST_ADDOPTS: -vv

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,16 +39,7 @@ RUN set -ex \
 		unzip \
 		xz-utils tk-dev \
 		zlib1g-dev \
-		media-types \
 	&& rm -rf /var/lib/apt/lists/*
-
-# Install rclone
-RUN set -ex \
-	&& cd $(mktemp -d) \
- 	&& curl -OfsS "https://downloads.rclone.org/rclone-current-linux-amd64.zip" \
- 	&& unzip "rclone-*-linux-amd64.zip" \
- 	&& mv rclone-*-linux-amd64/rclone /usr/bin/ \
- 	&& chmod a+x /usr/bin/rclone
 
 # Set the locale
 RUN locale-gen en_US.UTF-8
@@ -91,8 +82,13 @@ RUN set -ex \
 
 COPY ./ /src/
 
-# Allow Django's compilemessages to write *.mo files to the messages subdirectories.
 USER root
+# Install Ubuntu release specific packages.
+RUN set -ex \
+	&& apt-get update \
+	&& /src/osdeps.py Ubuntu-22 1 | grep -v -E "python3.6-dev" | xargs apt-get install -y --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
+# Allow Django's compilemessages to write *.mo files to the messages subdirectories.
 RUN set -ex \
 	&& find /src/storage_service/locale -type d -name 'LC_MESSAGES' -exec chown archivematica:archivematica '{}' \;
 USER archivematica

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 ARG TARGET=archivematica-storage-service
+ARG UBUNTU_VERSION=22.04
 
-FROM ubuntu:22.04 AS base
+FROM ubuntu:${UBUNTU_VERSION} AS base
 
+ARG UBUNTU_VERSION=22.04
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 ARG PYTHON_VERSION=3.6
@@ -86,7 +88,7 @@ USER root
 # Install Ubuntu release specific packages.
 RUN set -ex \
 	&& apt-get update \
-	&& /src/osdeps.py Ubuntu-22 1 | grep -v -E "python3.6-dev" | xargs apt-get install -y --no-install-recommends \
+	&& /src/osdeps.py Ubuntu-${UBUNTU_VERSION} 1 | grep -v -E "python3.6-dev" | xargs apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 # Allow Django's compilemessages to write *.mo files to the messages subdirectories.
 RUN set -ex \

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     build:
       context: "../"
       dockerfile: "Dockerfile"
+      args:
+        UBUNTU_VERSION: ${UBUNTU_VERSION:-22.04}
+        PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
     entrypoint: ""
     working_dir: "/src"
     command: ["pytest", "storage_service", "integration"]

--- a/osdeps.py
+++ b/osdeps.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+osdeps retrieves the list of packages needed for a given distro
+across the different Archivematica components.
+
+Usage: ./osdeps.py [distro] [stage]
+
+  distro   (required) Distro name, e.g. "Ubuntu-18"
+  stage    (requried) Stage number, e.g. "1", "2", ...
+
+Typically, we'll use stage "1". However, some distros require packages to be
+installed in multiple groups.
+
+In combination with apt, users can do something like the following in order to
+automatically install the osdeps dependencies:
+
+    ./osdeps.py Ubuntu-18 1 | xargs apt-get install
+"""
+import json
+import sys
+from pathlib import Path
+
+OSDEPS_DIRS = ("osdeps",)
+
+try:
+    distro = sys.argv[1]
+except IndexError:
+    sys.exit('Missing argument: distro, e.g. "Ubuntu-18"')
+
+try:
+    stage = int(sys.argv[2])
+except (IndexError, ValueError):
+    sys.exit('Missing argument: stage, e.g. "1"')
+
+src_dir = Path(__file__).parent
+
+packages = set()
+
+if distro.endswith(".04"):
+    distro = distro[: -len(".04")]
+
+for osdeps_dir in OSDEPS_DIRS:
+    osdeps = src_dir / osdeps_dir / f"{distro}.json"
+    if not osdeps.is_file():
+        sys.exit(f"{str(osdeps)} not found")
+    try:
+        document = json.loads(osdeps.read_bytes())
+    except json.decoder.JSONDecodeError as err:
+        sys.exit(f"Error reading {str(osdeps)}: {err}")
+    key = "osdeps_packages" if stage == 1 else f"osdeps_packages_{stage}"
+    if key not in document:
+        continue
+    packages.update([item["name"] for item in document[key]])
+
+if not packages:
+    sys.exit("No packages needed.")
+
+print("\n".join(packages))

--- a/osdeps/Ubuntu-20.json
+++ b/osdeps/Ubuntu-20.json
@@ -84,6 +84,10 @@
     {
       "name": "rclone",
       "state": "latest"
+    },
+    {
+      "name": "mime-support",
+      "state": "latest"
     }
   ],
   "osdeps_repos": [

--- a/osdeps/Ubuntu-22.json
+++ b/osdeps/Ubuntu-22.json
@@ -84,6 +84,10 @@
     {
       "name": "rclone",
       "state": "latest"
+    },
+    {
+      "name": "media-types",
+      "state": "latest"
     }
   ],
   "osdeps_repos": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
 skipsdist = True
-minversion = 2.7.0
 envlist = linting, py36, migrations
 skip_missing_interpreters = true
+
+[gh-actions]
+python =
+    3.6: py36, migrations
 
 [testenv:linting]
 basepython = python3
@@ -13,7 +16,7 @@ setenv =
 
 [testenv]
 skip_install = true
-deps = -rrequirements/test.txt
+deps = -r {toxinidir}/requirements/test.txt
 commands =
     py.test {posargs}
 setenv =
@@ -21,11 +24,11 @@ setenv =
     PYTHONPATH = ./storage_service
     DJANGO_SETTINGS_MODULE = storage_service.settings.test
     DJANGO_SECRET_KEY = 1234
-    BOTO_CONFIG=/dev/null
+    BOTO_CONFIG = /dev/null
 
 [testenv:migrations]
 basepython = python3
-deps = -rrequirements/test.txt
+deps = -r {toxinidir}/requirements/test.txt
 commands = django-admin makemigrations --check --dry-run
 
 [flake8]


### PR DESCRIPTION
https://github.com/artefactual/archivematica-storage-service/pull/658 added the `media-types` package to the development environment to run the [mime type tests](https://github.com/artefactual/archivematica-storage-service/blob/747bd89e34ffc3bd2218176fce812779b48af2fa/storage_service/common/tests/test_utils.py#L537-L541).

This reuses the `osdeps.py` script from Archivematica to install the package from the `Ubuntu-22.json` file instead.

It also updates the CI workflow to run the integration test in  Ubuntu 20.04.

Connected to https://github.com/archivematica/Issues/issues/1612