### PR TITLE
Remove Django warnings

### DIFF
--- a/storage_service/administration/apps.py
+++ b/storage_service/administration/apps.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 
 
 class AdministrationAppConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
     name = "administration"
 
     def ready(self):

--- a/storage_service/common/apps.py
+++ b/storage_service/common/apps.py
@@ -8,6 +8,7 @@ version_info = Info("version", "Archivematica Storage Service version info")
 
 
 class CommonAppConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
     name = "common"
 
     def ready(self):

--- a/storage_service/locations/apps.py
+++ b/storage_service/locations/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class LocationsAppConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
+    name = "locations"

--- a/storage_service/locations/apps.py
+++ b/storage_service/locations/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class LocationsAppConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
     name = "locations"
+
+    def ready(self):
+        import locations.signals  # noqa: F401

--- a/storage_service/locations/models/__init__.py
+++ b/storage_service/locations/models/__init__.py
@@ -1,11 +1,4 @@
 # flake8: noqa
-# Note that while the signals are not actually used here,
-# they should be imported here to make sure that they
-# are imported very early on globally. This ensures that
-# the signals themselves are registered early.
-from .. import signals
-
-
 # Required by other files
 class StorageException(Exception):
     """Exceptions specific to the service."""


### PR DESCRIPTION
Remove Django 3.2 warnings created during "make bootstrap" in development environment.

Reference: https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DEFAULT_AUTO_FIELD