### PR TITLE
Fix Ldap Group Type and roles

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -331,6 +331,12 @@ These variables specify the behaviour of LDAP authentication. If `SS_LDAP_AUTHEN
     - **Type:** `string`
     - **Default:** `''`
 
+- **`AUTH_LDAP_GROUP_TYPE`**:
+    - **Description:** An LDAPGroupType instance describing the type of group returned by AUTH_LDAP_GROUP_SEARCH. See [available values](https://django-auth-ldap.readthedocs.io/en/latest/groups.html), e.g.
+    "PosixGroupType".
+    - **Type:** `string`
+    - **Default:** `ActiveDirectoryGroupType`
+
 - **`AUTH_LDAP_GROUP_SEARCH_BASE_DN`**:
     - **Description:** Base LDAP DN for group search, e.g. "ou=django,ou=groups,dc=example,dc=com".
     - **Type:** `string`

--- a/storage_service/common/signals.py
+++ b/storage_service/common/signals.py
@@ -111,13 +111,25 @@ def ldap_populate_user_profile(sender, user=None, ldap_user=None, **kwargs):
     if user.is_superuser:
         return
 
-    role = roles.USER_ROLE_READER
-    if settings.AUTH_LDAP_ADMIN_GROUP in ldap_user.group_names:
-        role = roles.USER_ROLE_ADMIN
-    elif settings.AUTH_LDAP_MANAGER_GROUP in ldap_user.group_names:
-        role = roles.USER_ROLE_MANAGER
-    elif settings.AUTH_LDAP_REVIEWER_GROUP in ldap_user.group_names:
-        role = roles.USER_ROLE_REVIEWER
+    role = roles.settings.DEFAULT_USER_ROLE
+
+    if hasattr(settings, "AUTH_LDAP_GROUP_SEARCH"):
+        LOGGER.debug(
+            "Using LDAP groups for user %s. LDAP Groups: %s",
+            user.username,
+            ldap_user.group_names,
+        )
+        if settings.AUTH_LDAP_ADMIN_GROUP in ldap_user.group_names:
+            role = roles.USER_ROLE_ADMIN
+        elif settings.AUTH_LDAP_MANAGER_GROUP in ldap_user.group_names:
+            role = roles.USER_ROLE_MANAGER
+        elif settings.AUTH_LDAP_REVIEWER_GROUP in ldap_user.group_names:
+            role = roles.USER_ROLE_REVIEWER
+    else:
+        LOGGER.debug(
+            "Not using LDAP groups because AUTH_LDAP_GROUP_SEARCH is not defined. Using SS_AUTH_DEFAULT_USER_ROLE: %s",
+            settings.DEFAULT_USER_ROLE,
+        )
 
     role = roles.promoted_role(role)
 

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -386,7 +386,15 @@ if LDAP_AUTHENTICATION:
         )
 
     # https://pythonhosted.org/django-auth-ldap/groups.html#types-of-groups
-    AUTH_LDAP_GROUP_TYPE = ldap_config.ActiveDirectoryGroupType()
+    if "AUTH_LDAP_GROUP_TYPE" in environ:
+        try:
+            AUTH_LDAP_GROUP_TYPE = getattr(
+                ldap_config, environ.get("AUTH_LDAP_GROUP_TYPE", "PosixGroupType")
+            )()
+        except AttributeError:
+            AUTH_LDAP_GROUP_TYPE = ldap_config.ActiveDirectoryGroupType()
+    else:
+        AUTH_LDAP_GROUP_TYPE = ldap_config.ActiveDirectoryGroupType()
 
     AUTH_LDAP_REQUIRE_GROUP = environ.get("AUTH_LDAP_REQUIRE_GROUP", None)
     AUTH_LDAP_DENY_GROUP = environ.get("AUTH_LDAP_DENY_GROUP", None)


### PR DESCRIPTION
After SS roles commit, it was needing the LDAP_GROUP_SEARCH settings (getting 500 error). This commit allows to use thed default role when LDAP_GROUP_SEARCH variables are not set.

Added the AUTH_LDAP_GROUP_TYPE variable, that was fixed to ActiveDirectoryGroupType (it is the default value now).

Connects to https://github.com/archivematica/Issues/issues/1629