### PR TITLE
Decode git hash in version view

### DIFF
--- a/storage_service/administration/tests/test_views.py
+++ b/storage_service/administration/tests/test_views.py
@@ -1,0 +1,21 @@
+import subprocess
+
+import pytest
+from administration.views import get_git_commit
+
+
+@pytest.mark.parametrize(
+    "check_output,expected_result",
+    [
+        (
+            b"d9c93f388a770287cf6337d4f9bcbbe60c25fdb8\n",
+            "d9c93f388a770287cf6337d4f9bcbbe60c25fdb8",
+        ),
+        (subprocess.CalledProcessError(128, "git", "error"), None),
+    ],
+    ids=["success", "error"],
+)
+def test_get_git_commit(check_output, expected_result, mocker):
+    mocker.patch("subprocess.check_output", side_effect=[check_output])
+
+    assert get_git_commit() == expected_result

--- a/storage_service/administration/views.py
+++ b/storage_service/administration/views.py
@@ -59,7 +59,8 @@ def configuration(request):
 
 def get_git_commit():
     try:
-        return subprocess.check_output(["git", "rev-parse", "HEAD"])
+        result = subprocess.check_output(["git", "rev-parse", "HEAD"])
+        return result.decode().strip()
     except (OSError, subprocess.CalledProcessError):
         return None
 


### PR DESCRIPTION
The git hash of the version view currently looks like this:

![Screenshot 2023-11-27 at 10-28-43 Archivematica Storage Service](https://github.com/artefactual/archivematica-storage-service/assets/560781/75e748e4-6ded-4feb-b557-4fbcad417da4)

This PR decodes it correctly.