### PR TITLE
Lint Markdown files

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,10 @@
+{
+  "default": true,
+  "MD010": {
+    "code_blocks": false
+  },
+  "MD013": {
+    "code_blocks": false,
+    "tables": false
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,20 @@ repos:
     - eslint-config-prettier@9.0.0
     - eslint-plugin-prettier@5.0.1
     - prettier@3.0.3
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.37.0
+  hooks:
+  - id: markdownlint
+    exclude: |
+      (?x)^(
+        ISSUE_TEMPLATE\.md
+      )
+- repo: https://github.com/thlorenz/doctoc
+  rev: v2.2.0
+  hooks:
+  - id: doctoc
+    files: |
+      (?x)^(
+        (CONTRIBUTING|SECURITY).*\.md|
+        install/README\.md
+      )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-dev (0.7.0)
-===========
+# Changelog
+
+## dev (0.7.0)
 
 * SWORD: download MODS XML files into a subdirectory (#7424)
 * SWORD: bugfixes (#7424)
@@ -8,5 +9,6 @@ dev (0.7.0)
 * Browse: Return additional properties, e.g. number of objects, size (#7853)
 * Fix scanning fixity for uncompressed packages (#7777)
 * Duracloud: Handle files over 1GB (#7761)
-* Space: fix deleting directories where parent node contains non-ASCII characters (#8285)
+* Space: fix deleting directories where parent node contains non-ASCII characters
+  (#8285)
 * Space._browse_local: fix default value of "properties" attribute (#8959)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at info@artefactual.com. The project team
+reported by contacting the project team at <info@artefactual.com>. The project team
 will review and investigate all complaints, and will respond in a way that it deems
 appropriate to the circumstances. The project team is obligated to maintain
 confidentiality with regard to the reporter of an incident.
@@ -67,8 +67,8 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,31 @@
 # Contributing
 
 Thank you for considering a contribution to Archivematica!
-This document outlines the change submission process for Archivematica, along with our standards for new code contributions.
-Following these guidelines helps us assess your changes faster and makes it easier for us to merge your submission!
+This document outlines the change submission process for Archivematica, along
+with our standards for new code contributions. Following these guidelines helps
+us assess your changes faster and makes it easier for us to merge your
+submission!
 
-There are many ways to contribute: writing tutorials or blog posts about your experience, improving the [documentation](https://github.com/artefactual/archivematica-storage-service-docs), submitting bug reports, answering questions on the [mailing list](https://groups.google.com/forum/#!forum/archivematica), or writing code which can be incorporated into Archivematica itself.
+There are many ways to contribute: writing tutorials or blog posts about your
+experience, improving the [documentation], submitting bug reports, answering
+questions on the [mailing list], or writing code which can be incorporated into
+Archivematica itself.
+
+## Table of contents
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
 
 - [Submitting bugs](#submitting-bugs)
 - [Submitting enhancement ideas](#submitting-enhancement-ideas)
 - [Submitting code changes](#submitting-code-changes)
+  - [Permalinks](#permalinks)
   - [Getting started](#getting-started)
   - [When to submit code for review?](#when-to-submit-code-for-review)
   - [Opening the pull request](#opening-the-pull-request)
   - [Discussion](#discussion)
   - [Cleaning up the commit history](#cleaning-up-the-commit-history)
+  - [Stalled pull requests](#stalled-pull-requests)
 - [Contributor's Agreement](#contributors-agreement)
   - [Why do I have to sign a Contributor's Agreement?](#why-do-i-have-to-sign-a-contributors-agreement)
   - [How do I send in an agreement?](#how-do-i-send-in-an-agreement)
@@ -28,42 +36,37 @@ There are many ways to contribute: writing tutorials or blog posts about your ex
 ## Submitting bugs
 
 If you find a security vulnerability, do NOT open an issue. Email
-info@artefactual.com instead.
+<info@artefactual.com> instead.
 
-Issues can be filed using GitHub Issues in the
-[Archivematica Issues repo](https://github.com/archivematica/Issues). It is
-recommended to file issues there rather than in any of the Archivematica-related
-code repositories. Artefactual staff also use GitHub issues for any work they do
-on the Archivematica project.
+Issues can be filed using GitHub Issues in the [Archivematica Issues repo].
+It is recommended to file issues there rather than in any of the
+Archivematica-related code repositories. Artefactual staff also use GitHub
+issues for any work they do on the Archivematica project.
 
-You can also post in our
-[user](https://groups.google.com/forum/#!forum/archivematica) mailing list.
-A post to the mailing list is always welcome, especially if you're unsure if
-it's a bug or a local problem!
+You can also post in our [user] mailing list. A post to the mailing list is
+always welcome, especially if you're unsure if it's a bug or a local problem!
 
 Useful questions to answer if you're having problems include:
 
-* What version of Archivematica and the Storage Service are you using?
-* How was Archivematica installed? Package install, Ansible, etc?
-* Was this a fresh install or an upgrade?
-* What did you do to cause this bug to happen?
-* What did you expect to happen?
-* What did you see instead?
-* Can you reproduce this reliably?
-* If a specific Job is failing, what output did it produce? This is available
+- What version of Archivematica and the Storage Service are you using?
+- How was Archivematica installed? Package install, Ansible, etc?
+- Was this a fresh install or an upgrade?
+- What did you do to cause this bug to happen?
+- What did you expect to happen?
+- What did you see instead?
+- Can you reproduce this reliably?
+- If a specific Job is failing, what output did it produce? This is available
   by clicking on the gear icon.
 
 ## Submitting enhancement ideas
 
 Similar to submitting bugs, you are welcome to submit ideas for enhancements or
-new features in the
-[Archivematica Issues repo](https://github.com/archivematica/Issues). This is
-also where Artefactual staff record upcoming enhancements when they have been
-sponsored for inclusion either by Artefactual Systems or by a client.
+new features in the [Archivematica Issues repo]. This is also where Artefactual
+staff record upcoming enhancements when they have been sponsored for inclusion
+either by Artefactual Systems or by a client.
 
-Please feel free also to use the
-[Issues repo wiki](https://github.com/archivematica/Issues/wiki) as a space for
-gathering and collaborating on ideas. If you are not already a member of the
+Please feel free also to use the [Issues repo wiki] as a space for gathering and
+collaborating on ideas. If you are not already a member of the
 Archivematica repo (required for editing the wiki), file an issue there with
 the title "Request membership."
 
@@ -76,7 +79,7 @@ outside contributors.
 Here's an outline of the contribution process:
 
 1. File an issue in the
-   [Archivematica Issues repo](https://github.com/archivematica/Issues).
+   [Archivematica Issues repo].
 2. Fork the Artefactual project on GitHub, and commit your changes to a branch
    in your fork.
 3. Open a pull request.
@@ -87,79 +90,147 @@ Here's an outline of the contribution process:
 8. Sign a Contributor's Agreement, if you haven't already.
 9. Your branch will be merged!
 
+### Permalinks
+
+Issues can be enhanced by using GitHub's permalink features for [files] and
+[code snippets].
+Permalinks allow users to look back over old issues and pull requests and see
+what the code looked like at a certain point in time. This can be useful where
+lines may now have been added or removed but the topic of the conversation may
+still be relevant or of interest to the reader.
+
 ### Getting started
 
 So you have something to contribute to an Artefactual project. Great!
 
-To install Archivematica, see our [development installation](https://wiki.archivematica.org/Getting_started#Installation) instructions.
+To install Archivematica, see our [development installation] instructions.
 
-Artefactual uses [GitHub](https://github.com/)'s pull request feature for code review.
-Every change being submitted to an Artefactual project should be submitted as a pull request to the appropriate repository.
-A branch being submitted for code review should contain commits covering a related section of code.
-Try not to bundle unrelated changes together in one branch; it makes review harder.
+Artefactual uses [GitHub]'s pull request feature for code review. Every change
+being submitted to an Artefactual project should be
+submitted as a pull request to the appropriate repository. A branch being
+submitted for code review should contain commits covering a related section of
+code. Try not to bundle unrelated changes together in one branch; it makes
+review harder.
 
-If you're not familiar with forking repositories and creating branches in GitHub, consult their [guide](https://help.github.com/articles/fork-a-repo).
+If you're not familiar with forking repositories and creating branches in
+GitHub, consult their [guide].
 
 ### When to submit code for review?
 
-Your code doesn't have to be ready yet to submit for code review!
-You should submit a branch for code review as soon as you want to get feedback on it.
-Sometimes, that means submitting a feature-complete branch, but sometimes that means submitting an early WIP in order to get feedback on direction.
-Don't be shy about submitting early.
+Your code doesn't have to be ready yet to submit for code review! You should
+submit a branch for code review as soon as you want to get feedback on it.
+Sometimes, that means submitting a feature-complete branch, but sometimes that
+means submitting an early WIP in order to get feedback on direction. Don't be
+shy about submitting early.
 
 ### Opening the pull request
 
-GitHub has an [excellent](https://help.github.com/articles/using-pull-requests) guide on using the pull request feature.
+GitHub has an [excellent] guide on using the pull request feature.
 
 ### Discussion
 
-Discussion on pull requests is usually a back and forth process.
-Don't feel like you have to make every change the reviewer suggests; the pull request is a great place to have in-depth conversation on the issue.
+Discussion on pull requests is usually a back and forth process. Don't feel
+like you have to make every change the reviewer suggests; the pull request is
+a great place to have in-depth conversation on the issue.
 
 Do make use of GitHub's line comment feature!
 
-![Line comment](http://i.imgur.com/FsWppGN.png)
+![Line comment]
 
-By viewing the "Files changed", you can leave a comment on any line of the diff.
-This is a great way to scope discussion to a particular part of a diff.
-Any discussion you have in a specific part of the diff will also be automatically hidden once a change is pushed that addresses it, which helps keep the pull request page clear and readable.
+By viewing the "Files changed", you can leave a comment on any line of the
+diff. This is a great way to scope discussion to a particular part of a diff.
+Any discussion you have in a specific part of the diff will also be
+automatically hidden once a change is pushed that addresses it, which helps
+keep the pull request page clear and readable.
 
-Anyone can participate in code review discussions.
-Feel free to jump in if you have something to contribute on another pull request, even if you're not the one who opened it.
+Anyone can participate in code review discussions. Feel free to jump in if you
+have something to contribute on another pull request, even if you're not the
+one who opened it.
+
+For more details about code review in particular, look at our
+[code review guidelines].
 
 ### Cleaning up the commit history
 
-Once code review is finished or nearly finished, and no further development is planned on the branch, the branch's commit history should be cleaned up.
-You can alter the commit history of a branch using git's powerful [interactive rebase feature](http://www.git-scm.com/book/en/Git-Tools-Rewriting-History).
+Once code review is finished or nearly finished, and no further development is
+planned on the branch, the branch's commit history should be cleaned up.
+You can alter the commit history of a branch using git's powerful
+[interactive rebase feature].
+
+### Stalled pull requests
+
+Pull requests that have been inactive for 60 days will be closed and properly
+tagged using the "stalled" label. At that point, we prefer to continue the
+discussion under the original GitHub issue that should be linked from the pull
+request.
 
 ## Contributor's Agreement
 
-In order for the Archivematica development team to accept any patches or code commits, contributors must first sign this [Contributor's Agreement](https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf).
-The Archivematica contributor's agreement is based almost verbatim on the [Apache Foundation](http://apache.org )'s individual [contributor license](http://www.apache.org/licenses/icla.txt).
+In order for the Archivematica development team to accept any patches or code
+commits, contributors must first sign this [Contributor's Agreement].
+The Archivematica contributor's agreement is based almost verbatim on the
+[Apache Foundation]'s individual [contributor license].
 
-If you have any questions or concerns about the Contributor's Agreement, please email us at agreement@artefactual.com to discuss them.
+If you have any questions or concerns about the Contributor's Agreement,
+please email us at <agreement@artefactual.com> to discuss them.
 
 ### Why do I have to sign a Contributor's Agreement?
 
-One of the key challenges for open source software is to support a collaborative development environment while protecting the rights of contributors and users over the long-term.
-Unifying Archivematica copyrights through contributor agreements is the best way to protect the availability and sustainability of Archivematica over the long-term as free and open-source software.
-In all cases, contributors who sign the Contributor's Agreement retain full rights to use their original contributions for any other purpose outside of Archivematica, while enabling Artefactual Systems, any successor organization which may eventually take over responsibility for Archivematica, and the wider Archivematica community to benefit from their collaboration and contributions in this open source project.
+One of the key challenges for open source software is to support a collaborative
+development environment while protecting the rights of contributors and users
+over the long-term.
+Unifying Archivematica copyrights through contributor agreements is the best way
+to protect the availability and sustainability of Archivematica over the
+long-term as free and open-source software.
+In all cases, contributors who sign the Contributor's Agreement retain full
+rights to use their original contributions for any other purpose outside of
+Archivematica, while enabling Artefactual Systems, any successor organization
+which may eventually take over responsibility for Archivematica, and the wider
+Archivematica community to benefit from their collaboration and contributions
+in this open source project.
 
-[Artefactual Systems](http://artefactual.com) has made the decision and has a proven track record of making our intellectual property available to the community at large.
-By standardizing contributions on these agreements the Archivematica intellectual property position does not become too complicated.
-This ensures our resources are devoted to making our project the best they can be, rather than fighting legal battles over contributions.
+[Artefactual Systems] has made the decision and has a proven track record of
+making our intellectual property available to the community at large.
+By standardizing contributions on these agreements the Archivematica
+intellectual property position does not become too complicated.
+This ensures our resources are devoted to making our project the best they can
+be, rather than fighting legal battles over contributions.
 
 ### How do I send in an agreement?
 
-Please read and sign the [contributor agreement](https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf) and email it to agreement@artefactual.com
-Alternatively, you may send an original signed agreement to:
+Please read and sign the [Contributor's Agreement] and email it to
+<agreement@artefactual.com>.
 
-    Artefactual Systems Inc.
-    201 - 301 Sixth Street
-    New Westminster BC  V3L 3A7
-    Canada
+Alternatively, you may send a printed, signed agreement to:
 
+```text
+Artefactual Systems Inc.
+201 - 301 Sixth Street
+New Westminster BC  V3L 3A7
+Canada
+```
 
 ## Contribution standards
 
-For more information on contribution guidelines and standards, see the CONTRIBUTING.md in the [Archivematica project](https://github.com/artefactual/archivematica).
+For more information on contribution guidelines and standards, see the
+CONTRIBUTING.md in the [Archivematica project].
+
+[documentation]: https://github.com/artefactual/archivematica-storage-service-docs/
+[mailing list]: https://groups.google.com/forum/#!forum/archivematica
+[Archivematica Issues repo]: https://github.com/archivematica/Issues
+[user]: https://groups.google.com/forum/#!forum/archivematica
+[Issues repo wiki]: https://github.com/archivematica/Issues/wiki
+[files]: https://help.github.com/articles/getting-permanent-links-to-files/
+[code snippets]: https://help.github.com/articles/creating-a-permanent-link-to-a-code-snippet/
+[development installation]: https://wiki.archivematica.org/Getting_started#Installation
+[GitHub]: https://github.com/
+[guide]: https://help.github.com/articles/fork-a-repo
+[excellent]: https://help.github.com/articles/using-pull-requests
+[Line comment]: http://i.imgur.com/FsWppGN.png
+[code review guidelines]: https://github.com/artefactual/archivematica/blob/qa/1.x/code_review.md
+[interactive rebase feature]: http://www.git-scm.com/book/en/Git-Tools-Rewriting-History
+[Contributor's Agreement]: https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf
+[Apache Foundation]: http://apache.org
+[contributor license]: http://www.apache.org/licenses/icla.txt
+[Artefactual Systems]: http://artefactual.com
+[Archivematica project]: https://github.com/artefactual/archivematica

--- a/README.md
+++ b/README.md
@@ -1,47 +1,76 @@
-[![GitHub CI](https://github.com/artefactual/archivematica-storage-service/actions/workflows/test.yml/badge.svg)](https://github.com/artefactual/archivematica-storage-service/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/artefactual/archivematica-storage-service/branch/qa/0.x/graph/badge.svg?token=z1VcHtK8iw)](https://codecov.io/gh/artefactual/archivematica-storage-service)
+# [Archivematica Storage Service]
 
-# [Archivematica Storage Service](https://www.archivematica.org/)
+By [Artefactual]
 
-By [Artefactual](https://www.artefactual.com/)
+[![GitHub CI]][Test workflow]
+[![codecov]][Archivematica Storage Service Codecov]
 
 The Archivematica Storage Service is part of the Archivematica project.
-Archivematica is a web- and standards-based, open-source application which allows your institution to preserve long-term access to trustworthy, authentic and reliable digital content.
-Our target users are archivists, librarians, and anyone working to preserve digital objects.
-The Storage Service is responsible for moving files to and from Archivematica for processing and long-term storage.
-For more information, please see the [Archivematica documentation](https://www.archivematica.org/en/docs/).
+Archivematica is a web- and standards-based, open-source application which
+allows your institution to preserve long-term access to trustworthy, authentic
+and reliable digital content. Our target users are archivists, librarians, and
+anyone working to preserve digital objects.
 
-You are free to copy, modify, and distribute the Archivematica Storage Service with attribution under the terms of the AGPL license.
-See the [LICENSE](LICENSE) file for details.
+The Storage Service is responsible for moving files to and from Archivematica
+for processing and long-term storage. For more information, please see the
+[Archivematica documentation].
 
+You are free to copy, modify, and distribute the Archivematica Storage Service
+with attribution under the terms of the AGPL license. See the [LICENSE] file for
+details.
 
 ## Installation
 
-* [Production installation](https://www.archivematica.org/docs/latest/admin-manual/installation-setup/installation/installation/#installation)
-* [Development installation](https://github.com/artefactual/archivematica/tree/qa/1.x/hack)
-
+* [Production installation]
+* [Development installation]
 
 ## Resources
 
-* [Website](https://www.archivematica.org/): User and administrator documentation
-* [Wiki](https://www.archivematica.org/wiki/Development): Developer facing documentation, requirements analysis and community resources
-* [Issues](https://github.com/archivematica/Issues): Git repository used for tracking Archivematica issues and feature/enhancement ideas
-* [User Google Group](https://groups.google.com/forum/#!forum/archivematica): Forum/mailing list for user questions (both technical and end-user)
-* [Paid support](https://www.artefactual.com/services/): Paid support, hosting, training, consulting and software development contracts from Artefactual
-
+* [Website][Archivematica Storage Service]: User and administrator documentation
+* [Wiki]: Developer facing documentation, requirements analysis and community
+  resources
+* [Issues]: Git repository used for tracking Archivematica issues and
+  feature/enhancement ideas
+* [User Google Group]: Forum/mailing list for user questions (both technical and
+  end-user)
+* [Paid support]: Paid support, hosting, training, consulting and software
+  development contracts from Artefactual
 
 ## Contributing
 
 Thank you for your interest!
-For more details, please see the [contributing guidelines](CONTRIBUTING.md)
-
+For more details, please see the [contributing guidelines]
 
 ## Related projects
 
 Archivematica consists of several projects working together, including:
 
-* [Archivematica](https://github.com/artefactual/archivematica): Main repository containing the user-facing dashboard, task manager MCPServer and clients scripts for the MCPClient
-* [Storage Service](https://github.com/artefactual/archivematica-storage-service): This repository! Responsible for moving files to Archivematica for processing, and from Archivematica into long-term storage
-* [Format Policy Registry](https://github.com/artefactual/archivematica/tree/qa/1.x/src/dashboard/src/fpr): Submodule shared between Archivematica and the Format Policy Registry (FPR) server that displays and updates FPR rules and commands
+* [Archivematica]: Main repository containing the user-facing dashboard, task
+  manager MCPServer and clients scripts for the MCPClient
+* [Storage Service]: This repository! Responsible for moving files to
+  Archivematica for processing, and from Archivematica into long-term storage
+* [Format Policy Registry]: Submodule shared between Archivematica and the
+  Format Policy Registry (FPR) server that displays and updates FPR rules and
+  commands
 
-For more projects in the Archivematica ecosystem, see the [getting started](https://wiki.archivematica.org/Getting_started#Projects) page.
+For more projects in the Archivematica ecosystem, see the [getting started] page.
+
+[Archivematica Storage Service]: https://www.archivematica.org/
+[Artefactual]: https://www.artefactual.com/
+[GitHub CI]: https://github.com/artefactual/archivematica-storage-service/actions/workflows/test.yml/badge.svg
+[Test workflow]: https://github.com/artefactual/archivematica-storage-service/actions/workflows/test.yml
+[codecov]: https://codecov.io/gh/artefactual/archivematica-storage-service/branch/qa/0.x/graph/badge.svg?token=z1VcHtK8iw
+[Archivematica Storage Service Codecov]: https://codecov.io/gh/artefactual/archivematica-storage-service
+[Archivematica documentation]: https://www.archivematica.org/en/docs/
+[LICENSE]: LICENSE
+[Production installation]: https://www.archivematica.org/docs/latest/admin-manual/installation-setup/installation/installation/#installation
+[Development installation]: https://github.com/artefactual/archivematica/tree/qa/1.x/hack
+[Wiki]: https://www.archivematica.org/wiki/Development
+[Issues]: https://github.com/archivematica/Issues
+[User Google Group]: https://groups.google.com/forum/#!forum/archivematica
+[Paid support]: https://www.artefactual.com/services/
+[contributing guidelines]: CONTRIBUTING.md
+[Archivematica]: https://github.com/artefactual/archivematica
+[Storage Service]: https://github.com/artefactual/archivematica-storage-service
+[Format Policy Registry]: https://github.com/artefactual/archivematica/tree/qa/1.x/src/dashboard/src/fpr
+[getting started]: https://wiki.archivematica.org/Getting_started#Projects

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,15 +1,20 @@
 # Security Policy
 
 This document outlines security procedures and general policies for the
-Archivematica project. See https://www.archivematica.org for more information
+Archivematica project. See <https://www.archivematica.org> for more information
 about Archivematica.
 
-**Contents**
+## Table of contents
 
-* [Reporting a security vulnerability](#reporting-a-security-vulnerability)
-* [Disclosure policy](#disclosure-policy)
-* [Supported versions](#supported-versions)
-* [Reporting general bugs](#reporting-general-bugs)
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Reporting a security vulnerability](#reporting-a-security-vulnerability)
+- [Disclosure policy](#disclosure-policy)
+- [Supported versions](#supported-versions)
+- [Reporting general bugs](#reporting-general-bugs)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Reporting a security vulnerability
 
@@ -22,18 +27,18 @@ post about the issue on the user forum.** It is critical to the safety of other
 users that security issues are reported in a secure manner. Instead, please
 email a report to:
 
-* [security@artefactual.com](mailto:security@artefactual.com)
+- [security@artefactual.com](mailto:security@artefactual.com)
 
 We will be better able to evaluate and respond to your report if it includes
 all the details needed for us to reproduce the issue locally. Please include
 the following information in your email:
 
-* The version of Archivematica you are using.
-* Basic information about your installation environment, including operating
+- The version of Archivematica you are using.
+- Basic information about your installation environment, including operating
   system and dependency versions.
-* Steps to reproduce the issue.
-* The resulting error or vulnerability.
-* If there are any error logs related to the issue, please include the
+- Steps to reproduce the issue.
+- The resulting error or vulnerability.
+- If there are any error logs related to the issue, please include the
   relevant parts as well.
 
 Your report will be acknowledged within 2 business days, and we’ll follow up
@@ -43,9 +48,9 @@ within 1 week.
 If you haven’t received a reply to your submission after 5 business days of
 the original report, there are a couple steps you can take:
 
-* Email the Archivematica Program Manager directly at
+- Email the Archivematica Program Manager directly at
   [sromkey@artefactual.com](mailto:sromkey@artefactual.com)
-* Email Artefactual's info address: [info@artefactual.com](info@artefactual.com)
+- Email Artefactual's info address: [info@artefactual.com](info@artefactual.com)
 
 Any information you share with the Archivematica development team as a part of
 this process will be kept confidential within the team. If we determine that the
@@ -63,9 +68,9 @@ When the Archivematica development team receives a security bug report, we will
 assign it to a primary handler. This person will coordinate the fix and release
 process, involving the following steps:
 
-* Confirm the problem and determine the affected versions.
-* Audit code to find any similar potential problems.
-* Prepare fixes for all releases still under maintenance. These fixes will be
+- Confirm the problem and determine the affected versions.
+- Audit code to find any similar potential problems.
+- Prepare fixes for all releases still under maintenance. These fixes will be
   released as fast as possible.
 
 Once new releases and/or security patches have been prepared, tested, and made

--- a/install/README.md
+++ b/install/README.md
@@ -2,18 +2,23 @@
 
 ## Table of contents
 
-- [Storage Service Configuration](#storage-service-configuration)
-  - [Table of contents](#table-of-contents)
-  - [Introduction](#introduction)
-  - [Environment variables](#environment-variables)
-    - [Application-specific environment variables](#application-specific-environment-variables)
-    - [Gunicorn-specific environment variables](#gunicorn-specific-environment-variables)
-    - [LDAP-specific environment variables](#ldap-specific-environment-variables)
-    - [CAS-specific environment variables](#cas-specific-environment-variables)
-    - [OIDC-specific environment variables](#oidc-specific-environment-variables)
-    - [AWS-specific environment variables](#aws-specific-environment-variables)
-    - [CSP-specific environment variables](#csp-specific-environment-variables)
-  - [Logging configuration](#logging-configuration)
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Environment variables](#environment-variables)
+  - [Application-specific environment variables](#application-specific-environment-variables)
+  - [Gunicorn-specific environment variables](#gunicorn-specific-environment-variables)
+  - [LDAP-specific environment variables](#ldap-specific-environment-variables)
+  - [CAS-specific environment variables](#cas-specific-environment-variables)
+  - [OIDC-specific environment variables](#oidc-specific-environment-variables)
+  - [AWS-specific environment variables](#aws-specific-environment-variables)
+  - [CSP-specific environment variables](#csp-specific-environment-variables)
+- [Logging configuration](#logging-configuration)
+  - [Overriding the logging configuration](#overriding-the-logging-configuration)
+  - [Increase or decrease the logging output](#increase-or-decrease-the-logging-output)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Introduction
 
@@ -54,486 +59,541 @@ of these settings or provide values to mandatory fields.
 ### Application-specific environment variables
 
 - **`DJANGO_SETTINGS_MODULE`**:
-    - **Description:** the [settings module](https://docs.djangoproject.com/en/1.8/ref/settings/#secret-key) used by Django. There are three modules available: [storage_service.settings.production](../storage_service/storage_service/settings/production.py), [storage_service.settings.local](../storage_service/storage_service/settings/local.py) and [storage_service.settings.test](../storage_service/storage_service/settings/test.py). Unless you are a developer you should only use the former.
-    - **Type:** `string`
-    - :red_circle: **Mandatory!**
+  - **Description:** the [settings module] used by Django. There are three
+    modules available: [storage_service.settings.production](../storage_service/storage_service/settings/production.py),
+    [storage_service.settings.local](../storage_service/storage_service/settings/local.py)
+    and [storage_service.settings.test](../storage_service/storage_service/settings/test.py).
+    Unless you are a developer you should only use the former.
+  - **Type:** `string`
+  - :red_circle: **Mandatory!**
 
 - **`DJANGO_ALLOWED_HOSTS`**:
-    - **Description:** comma-separated list of hosts or domain names that this Django site can serve. See the [official docs](https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts).
-    - **Type:** `string`
-    - :red_circle: **Mandatory!**
+  - **Description:** comma-separated list of hosts or domain names that this
+    Django site can serve. See the [official docs][ALLOWED_HOSTS].
+  - **Type:** `string`
+  - :red_circle: **Mandatory!**
 
 - **`TIME_ZONE`**:
-    - **Description:** application time zone. See [TIME_ZONE](https://docs.djangoproject.com/en/1.8/ref/settings/#time-zone) for more details.
-    - **Type:** `string`
-    - **Default:** `"America/Los_Angeles"`
+  - **Description:** application time zone. See [TIME_ZONE] for more details.
+  - **Type:** `string`
+  - **Default:** `"America/Los_Angeles"`
 
 - **`SECRET_KEY`**:
-    - **Description:** a secret key used for cryptographic signing. See [SECRET_KEY](https://docs.djangoproject.com/en/1.8/ref/settings/#secret-key) for more details.
-    - **Type:** `string`
-    - :red_circle: **Mandatory!**
+  - **Description:** a secret key used for cryptographic signing. See [SECRET_KEY]
+    for more details.
+  - **Type:** `string`
+  - :red_circle: **Mandatory!**
 
 - **`SS_AUTH_PASSWORD_MINIMUM_LENGTH`**:
-    - **Description:** sets minimum length for user passwords.
-    - **Type:** `integer`
-    - **Default:** `8`
+  - **Description:** sets minimum length for user passwords.
+  - **Type:** `integer`
+  - **Default:** `8`
 
 - **`SS_AUTH_PASSWORD_DISABLE_COMMON_VALIDATION`**:
-    - **Description:** disables password validation that prevents users from using passwords that occur in a list of common passwords.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** disables password validation that prevents users from using
+    passwords that occur in a list of common passwords.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`SS_AUTH_PASSWORD_DISABLE_USER_ATTRIBUTE_SIMILARITY_VALIDATION`**:
-    - **Description:** disables password validation that prevents users from using passwords that are too similar to their username and other user attributes.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** disables password validation that prevents users from using
+    passwords that are too similar to their username and other user attributes.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`SS_AUTH_PASSWORD_DISABLE_COMPLEXITY_VALIDATION`**:
-    - **Description:** disables password validation that checks that passwords contain at least three of: lower-case characters, upper-case characters, numbers, special characters.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** disables password validation that checks that passwords
+    contain at least three of: lower-case characters, upper-case characters,
+    numbers, special characters.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`SS_AUTH_DEFAULT_USER_ROLE`**:
-    - **Description:** user role that must be assigned to authenticated users that would be readers otherwise based on the results given by the authentication backend. Valid options are "manager", "reviewer" and "reader" (or empty string).
-    - **Type:** `string`
-    - **Default:** `"reader"`
+  - **Description:** user role that must be assigned to authenticated users that
+    would be readers otherwise based on the results given by the authentication
+    backend. Valid options are "manager", "reviewer" and "reader"
+    (or empty string).
+  - **Type:** `string`
+  - **Default:** `"reader"`
 
 - **`SS_SHIBBOLETH_AUTHENTICATION`**:
-    - **Description:** enables the Shibboleth authentication system. Other settings related to Shibboleth cannot be defined via environment variables at the moment, please edit [storage_service.settings.base](../storage_service/storage_service/settings/base.py) manually.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** enables the Shibboleth authentication system. Other
+    settings related to Shibboleth cannot be defined via environment variables
+    at the moment, please edit [storage_service.settings.base](../storage_service/storage_service/settings/base.py)
+    manually.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`SS_CAS_AUTHENTICATION`**:
-    - **Description:** enables the CAS (Central Authentication Service) authentication system.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** enables the CAS (Central Authentication Service)
+    authentication system.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`SS_BAG_VALIDATION_NO_PROCESSES`**:
-    - **Description:** number of concurrent processes used by BagIt. If Gunicorn is being used to serve the Storage Service and its worker class is set to `gevent`, then BagIt validation must use 1 process. Otherwise, calls to `validate` will hang because of the incompatibility between gevent and multiprocessing (BagIt) concurrency strategies. See [#708](https://github.com/artefactual/archivematica/issues/708).
-    - **Type:** `int`
-    - **Default:** `1`
+  - **Description:** number of concurrent processes used by BagIt. If Gunicorn
+    is being used to serve the Storage Service and its worker class is set to
+    `gevent`, then BagIt validation must use 1 process. Otherwise, calls to
+    `validate` will hang because of the incompatibility between gevent and
+    multiprocessing (BagIt) concurrency strategies. See [#708].
+  - **Type:** `int`
+  - **Default:** `1`
 
 - **`SS_GNUPG_HOME_PATH`**:
-    - **Description:** path of the GnuPG home directory. If this environment string is not defined Storage Service will use its internal location directory.
-    - **Type:** `string`
-    - **Default:** `None`
+  - **Description:** path of the GnuPG home directory. If this environment
+    string is not defined Storage Service will use its internal location directory.
+  - **Type:** `string`
+  - **Default:** `None`
 
 - **`SS_INSECURE_SKIP_VERIFY`**:
-    - **Description:** skip the SSL certificate verification process. This setting should not be used in production environments.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** skip the SSL certificate verification process. This setting
+    should not be used in production environments.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`SS_CSP_ENABLED`**:
-    - **Description:** **Experimental** support for [Control Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) headers.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** **Experimental** support for [Control Security Policy]
+    headers.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`SS_PROMETHEUS_ENABLED`**:
-    - **Description:** enable metrics export for collection by Prometheus.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** enable metrics export for collection by Prometheus.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`SS_AUDIT_LOG_MIDDLEWARE`**:
-    - **Description:** enable X-Username header with authenticated HTTP responses.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** enable X-Username header with authenticated HTTP responses.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`SS_S3_TIMEOUTS`**:
-    - **Description:** read and connect timeouts for S3 matching your implementation's recommended defaults.
-    - **Type:** `integer`
-    - **Default:** `900`
+  - **Description:** read and connect timeouts for S3 matching your
+    implementation's recommended defaults.
+  - **Type:** `integer`
+  - **Default:** `900`
 
-The configuration of the database is also declared via environment variables. Storage Service looks up the `SS_DB_URL` environment string. If defined, its value is expected to follow the form described in the [dj-database-url docs](https://github.com/kennethreitz/dj-database-url#url-schema), e.g.: `mysql://username:password@192.168.1.20:3306/storage_service`. If undefined, Storage Service defaults to the `django.db.backends.sqlite3` [engine](https://docs.djangoproject.com/en/1.8/ref/settings/#engine) and expects the following environment variables to be defined:
+The configuration of the database is also declared via environment variables.
+Storage Service looks up the `SS_DB_URL` environment string. If defined, its
+value is expected to follow the form described in the [dj-database-url docs],
+e.g.: `mysql://username:password@192.168.1.20:3306/storage_service`. If
+undefined, Storage Service defaults to the `django.db.backends.sqlite3`[engine]
+and expects the following environment variables to be defined:
 
 - **`SS_DB_NAME`**:
-    - **Description:** see [the official description](https://docs.djangoproject.com/en/1.8/ref/settings/#name).
-    - **Type:** `string`
+  - **Description:** see [the official description][DB_NAME].
+  - **Type:** `string`
 
 - **`SS_DB_PASSWORD`**:
-    - **Description:**  see [the official description](https://docs.djangoproject.com/en/1.8/ref/settings/#password).
-    - **Type:** `string`
+  - **Description:**  see [the official description][DB_PASSWORD].
+  - **Type:** `string`
 
 - **`SS_DB_HOST`**:
-    - **Description:**  see [the official description](https://docs.djangoproject.com/en/1.8/ref/settings/#host).
-    - **Type:** `string`
+  - **Description:**  see [the official description][DB_HOST].
+  - **Type:** `string`
 
 There are a limited number of email settings that can be populated via
 environment variables - we are hoping to improve this soon (see
-[#813](https://github.com/artefactual/archivematica/pull/813)). We have some
+[#813]). We have some
 settings hard-coded (see [storage_service.settings.production](../storage_service/storage_service/settings/production.py)).
 This is the current list of strings supported:
 
 - **`EMAIL_BACKEND`**:
-    - **Description:** https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
-    - **Type:** `string`
-    - **Default:** `django.core.mail.backends.smtp.EmailBackend`
+  - **Description:** <https://docs.djangoproject.com/en/dev/ref/settings/#email-backend>
+  - **Type:** `string`
+  - **Default:** `django.core.mail.backends.smtp.EmailBackend`
 
 - **`EMAIL_HOST`**
-    - **Description:** https://docs.djangoproject.com/en/dev/ref/settings/#email-host
-    - **Type:** `string`
-    - **Default:** `smtp.gmail.com`
+  - **Description:** <https://docs.djangoproject.com/en/dev/ref/settings/#email-host>
+  - **Type:** `string`
+  - **Default:** `smtp.gmail.com`
 
 - **`EMAIL_HOST_PASSWORD`**
-    - **Description:** https://docs.djangoproject.com/en/dev/ref/settings/#email-host-password
-    - **Type:** `string`
-    - **Default:** (empty string)
+  - **Description:** <https://docs.djangoproject.com/en/dev/ref/settings/#email-host-password>
+  - **Type:** `string`
+  - **Default:** (empty string)
 
 - **`EMAIL_HOST_USER`**
-    - **Description:** https://docs.djangoproject.com/en/dev/ref/settings/#email-host-user
-    - **Type:** `string`
-    - **Default:** `your_email@example.com`
+  - **Description:** <https://docs.djangoproject.com/en/dev/ref/settings/#email-host-user>
+  - **Type:** `string`
+  - **Default:** `your_email@example.com`
 
 - **`EMAIL_PORT`**
-    - **Description:** https://docs.djangoproject.com/en/dev/ref/settings/#email-port
-    - **Type:** `int`
-    - **Default:** `587`
+  - **Description:** <https://docs.djangoproject.com/en/dev/ref/settings/#email-port>
+  - **Type:** `int`
+  - **Default:** `587`
 
 - **`EMAIL_SUBJECT_PREFIX`**
-    - **Description:** https://docs.djangoproject.com/en/dev/ref/settings/#email-subject-prefix
-    - **Type:** `string`
-    - **Default:** `[Archivematica Storage Service] `
+  - **Description:** <https://docs.djangoproject.com/en/dev/ref/settings/#email-subject-prefix>
+  - **Type:** `string`
+  - **Default:** `[Archivematica Storage Service]`
 
 - **`DEFAULT_FROM_EMAIL`**
-    - **Description:** https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
-    - **Type:** `string`
-    - **Default:** `webmaster@localhost`
+  - **Description:** <https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email>
+  - **Type:** `string`
+  - **Default:** `webmaster@localhost`
 
 - **`EMAIL_USE_TLS`**
-    - **Description:** https://docs.djangoproject.com/en/dev/ref/settings/#email-use-tls
-    - **Type:** `boolean`
-    - **Default:** `true`
+  - **Description:** <https://docs.djangoproject.com/en/dev/ref/settings/#email-use-tls>
+  - **Type:** `boolean`
+  - **Default:** `true`
 
 ### Gunicorn-specific environment variables
 
 - **`SS_GUNICORN_USER`**:
-    - **Description:** OS user for gunicorn worker processes to run as. See [USER](http://docs.gunicorn.org/en/stable/settings.html#user).
-    - **Type:** `integer` (user id) or `string` (user name)
-    - **Default:** `archivematica`
+  - **Description:** OS user for gunicorn worker processes to run as. See [USER].
+  - **Type:** `integer` (user id) or `string` (user name)
+  - **Default:** `archivematica`
 
 - **`SS_GUNICORN_GROUP`**:
-    - **Description:** OS group for gunicorn worker processes to run as. See [GROUP](http://docs.gunicorn.org/en/styable/settings.html#group).
-    - **Type:** `integer` (group id) or `string` (group name)
-    - **Default:** `archivematica`
+  - **Description:** OS group for gunicorn worker processes to run as. See [GROUP].
+  - **Type:** `integer` (group id) or `string` (group name)
+  - **Default:** `archivematica`
 
 - **`SS_GUNICORN_BIND`**:
-    - **Description:** the socket for gunicorn to bind to. See [BIND](http://docs.gunicorn.org/en/stable/settings.html#bind).
-    - **Type:** `string` (host name or ip with port number)
-    - **Default:** `127.0.0.1:8001`
+  - **Description:** the socket for gunicorn to bind to. See [BIND].
+  - **Type:** `string` (host name or ip with port number)
+  - **Default:** `127.0.0.1:8001`
 
 - **`SS_GUNICORN_WORKERS`**:
-    - **Description:** number of gunicorn worker processes to run. See [WORKERS](http://docs.gunicorn.org/en/stable/settings.html#workers). If `SS_GUNICORN_WORKER_CLASS` is set to `gevent`, then `SS_BAG_VALIDATION_NO_PROCESSES` **must** be set to `1`. Otherwise reingest will fail at bagit validate. See [#708](https://github.com/artefactual/archivematica/issues/708).
-    - **Type:** `integer`
-    - **Default:** `1`
+  - **Description:** number of gunicorn worker processes to run. See [WORKERS].
+    If `SS_GUNICORN_WORKER_CLASS` is set to `gevent`, then `SS_BAG_VALIDATION_NO_PROCESSES`
+    **must** be set to `1`. Otherwise reingest will fail at bagit validate. See
+    [#708].
+  - **Type:** `integer`
+  - **Default:** `1`
 
 - **`SS_GUNICORN_WORKER_CLASS`**:
-    - **Description:** the type of worker processes to run. See [WORKER-CLASS](http://docs.gunicorn.org/en/stable/settings.html#worker-class).
-    - **Type:** `string`
-    - **Default:** `gevent`
+  - **Description:** the type of worker processes to run. See [WORKER-CLASS].
+  - **Type:** `string`
+  - **Default:** `gevent`
 
 - **`SS_GUNICORN_TIMEOUT`**:
-    - **Description:** worker process timeout. See [TIMEOUT](http://docs.gunicorn.org/en/stable/settings.html#timeout).
-    - **Type:** `integer` (seconds)
-    - **Default:** `172800`
+  - **Description:** worker process timeout. See [TIMEOUT].
+  - **Type:** `integer` (seconds)
+  - **Default:** `172800`
 
 - **`SS_GUNICORN_RELOAD`**:
-    - **Description:** restart workers when code changes. See [RELOAD](http://docs.gunicorn.org/en/stable/settings.html#reload).
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** restart workers when code changes. See [RELOAD].
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`SS_GUNICORN_RELOAD_ENGINE`**:
-    - **Description:** method of performing reload. See [RELOAD-ENGINE](http://docs.gunicorn.org/en/stable/settings.html#reload-engine).
-    - **Type:** `string`
-    - **Default:** `auto`
+  - **Description:** method of performing reload. See [RELOAD-ENGINE].
+  - **Type:** `string`
+  - **Default:** `auto`
 
 - **`SS_GUNICORN_CHDIR`**:
-    - **Description:** directory to load apps from. See [CHDIR](http://docs.gunicorn.org/en/stable/settings.html#chdir).
-    - **Type:** `string`
-    - **Default:** `/usr/lib/archivematica/storage-service`
+  - **Description:** directory to load apps from. See [CHDIR].
+  - **Type:** `string`
+  - **Default:** `/usr/lib/archivematica/storage-service`
 
 - **`SS_GUNICORN_ACCESSLOG`**:
-    - **Description:** location to write access log to. See [ACCESSLOG](http://docs.gunicorn.org/en/stable/settings.html#accesslog).
-    - **Type:** `string`
-    - **Default:** `/dev/null`
+  - **Description:** location to write access log to. See [ACCESSLOG].
+  - **Type:** `string`
+  - **Default:** `/dev/null`
 
 - **`SS_GUNICORN_ERRORLOG`**:
-    - **Description:** location to write error log to. See [ERRORLOG](http://docs.gunicorn.org/en/stable/settings.html#errorlog).
-    - **Type:** `string`
-    - **Default:** `-`
+  - **Description:** location to write error log to. See [ERRORLOG].
+  - **Type:** `string`
+  - **Default:** `-`
 
 - **`SS_GUNICORN_LOGLEVEL`**:
-    - **Description:** the granularity of Error log outputs. See [LOGLEVEL](http://docs.gunicorn.org/en/stable/settings.html#loglevel).
-    - **Type:** `string`
-    - **Default:** `INFO`
+  - **Description:** the granularity of Error log outputs. See [LOGLEVEL].
+  - **Type:** `string`
+  - **Default:** `INFO`
 
 - **`SS_GUNICORN_PROC_NAME`**:
-    - **Description:** name for this instance of gunicorn. See [PROC-NAME](http://docs.gunicorn.org/en/stable/settings.html#proc-name).
-    - **Type:** `string`
-    - **Default:** `archivematica-storage-service`
+  - **Description:** name for this instance of gunicorn. See [PROC-NAME].
+  - **Type:** `string`
+  - **Default:** `archivematica-storage-service`
 
 ### LDAP-specific environment variables
 
-These variables specify the behaviour of LDAP authentication. If `SS_LDAP_AUTHENTICATION` is false, none of the other ones are used.
+These variables specify the behaviour of LDAP authentication. If
+`SS_LDAP_AUTHENTICATION` is false, none of the other ones are used.
 
 - **`SS_LDAP_AUTHENTICATION`**:
-    - **Description:** Enables user authentication via LDAP.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** Enables user authentication via LDAP.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`AUTH_LDAP_SERVER_URI`**:
-    - **Description:** Address of the LDAP server to authenticate against.
-    - **Type:** `string`
-    - **Default:** `ldap://localhost`
+  - **Description:** Address of the LDAP server to authenticate against.
+  - **Type:** `string`
+  - **Default:** `ldap://localhost`
 
 - **`AUTH_LDAP_BIND_DN`**:
-    - **Description:** LDAP "bind DN"; the object to authenticate against the LDAP server with, in order
-    to lookup users, e.g. "cn=admin,dc=example,dc=com".  Empty string for anonymous.
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** LDAP "bind DN"; the object to authenticate against the LDAP
+    server with, in order to lookup users, e.g. "cn=admin,dc=example,dc=com".
+    Empty string for anonymous.
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_BIND_PASSWORD`**:
-    - **Description:** Password for the LDAP bind DN.
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Password for the LDAP bind DN.
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_USER_SEARCH_BASE_DN`**:
-    - **Description:** Base LDAP DN for user search, e.g. "ou=users,dc=example,dc=com".
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Base LDAP DN for user search, e.g. "ou=users,dc=example,dc=com".
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_USER_SEARCH_BASE_FILTERSTR`**:
-    - **Description:** Filter for identifying LDAP user objects, e.g. "(uid=%(user)s)". The `%(user)s`
-    portion of the string will be replaced by the username. This variable is only used if
-    `AUTH_LDAP_USER_SEARCH_BASE_DN` is not empty.
-    - **Type:** `string`
-    - **Default:** `(uid=%(user)s)`
+  - **Description:** Filter for identifying LDAP user objects, e.g. "(uid=%(user)s)".
+    The `%(user)s` portion of the string will be replaced by the username. This
+    variable is only used if `AUTH_LDAP_USER_SEARCH_BASE_DN` is not empty.
+  - **Type:** `string`
+  - **Default:** `(uid=%(user)s)`
 
 - **`AUTH_LDAP_USER_DN_TEMPLATE`**:
-    - **Description:** Template for LDAP user search, e.g. "uid=%(user)s,ou=users,dc=example,dc=com".
+  - **Description:** Template for LDAP user search, e.g. "uid=%(user)s,ou=users,dc=example,dc=com".
     Not applicable if `AUTH_LDAP_USER_SEARCH_BASE_DN` is set.
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_GROUP_IS_ACTIVE`**:
-    - **Description:** Template for LDAP group used to set the Django user `is_active` flag, e.g.
-    "cn=active,ou=django,ou=groups,dc=example,dc=com".
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Template for LDAP group used to set the Django user
+    `is_active` flag, e.g. "cn=active,ou=django,ou=groups,dc=example,dc=com".
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_GROUP_IS_STAFF`**:
-    - **Description:** Template for LDAP group used to set the Django user `is_staff` flag, e.g.
-    "cn=staff,ou=django,ou=groups,dc=example,dc=com".
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Template for LDAP group used to set the Django user
+    `is_staff` flag, e.g. "cn=staff,ou=django,ou=groups,dc=example,dc=com".
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_GROUP_IS_SUPERUSER`**:
-    - **Description:** Template for LDAP group used to set the Django user `is_superuser` flag, e.g.
-    "cn=admins,ou=django,ou=groups,dc=example,dc=com".
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Template for LDAP group used to set the Django user
+    `is_superuser` flag, e.g. "cn=admins,ou=django,ou=groups,dc=example,dc=com".
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_GROUP_TYPE`**:
-    - **Description:** An LDAPGroupType instance describing the type of group returned by AUTH_LDAP_GROUP_SEARCH. See [available values](https://django-auth-ldap.readthedocs.io/en/latest/groups.html), e.g.
+  - **Description:** An LDAPGroupType instance describing the type of group
+    returned by AUTH_LDAP_GROUP_SEARCH. See [available values], e.g.
     "PosixGroupType".
-    - **Type:** `string`
-    - **Default:** `ActiveDirectoryGroupType`
+  - **Type:** `string`
+  - **Default:** `ActiveDirectoryGroupType`
 
 - **`AUTH_LDAP_GROUP_SEARCH_BASE_DN`**:
-    - **Description:** Base LDAP DN for group search, e.g. "ou=django,ou=groups,dc=example,dc=com".
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Base LDAP DN for group search, e.g. "ou=django,ou=groups,dc=example,dc=com".
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_GROUP_SEARCH_FILTERSTR`**:
-    - **Description:** Filter for identifying LDAP group objects, e.g. "(objectClass=groupOfNames)".
-    This variable is only used if `AUTH_LDAP_GROUP_SEARCH_BASE_DN` is not empty.
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Filter for identifying LDAP group objects, e.g.
+    "(objectClass=groupOfNames)". This variable is only used if
+    `AUTH_LDAP_GROUP_SEARCH_BASE_DN` is not empty.
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_REQUIRE_GROUP`**:
-    - **Description:** Filter for a group that LDAP users must belong to in order to authenticate, e.g.
-    "cn=enabled,ou=django,ou=groups,dc=example,dc=com"
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Filter for a group that LDAP users must belong to in order
+    to authenticate, e.g. "cn=enabled,ou=django,ou=groups,dc=example,dc=com"
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_DENY_GROUP`**:
-    - **Description:** Filter for a group that LDAP users must _not_ belong to in order to authenticate,
-    e.g. "cn=disabled,ou=django,ou=groups,dc=example,dc=com"
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Filter for a group that LDAP users must _not_ belong to in
+    order to authenticate, e.g. "cn=disabled,ou=django,ou=groups,dc=example,dc=com".
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_FIND_GROUP_PERMS`**:
-    - **Description:** If we should use LDAP group membership to calculate group permissions.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** If we should use LDAP group membership to calculate group permissions.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`AUTH_LDAP_CACHE_GROUPS`**:
-    - **Description:** If we should cache groups to minimize LDAP traffic.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** If we should cache groups to minimize LDAP traffic.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`AUTH_LDAP_GROUP_CACHE_TIMEOUT`**:
-    - **Description:** How long we should cache LDAP groups for (in seconds). Only applies if
+  - **Description:** How long we should cache LDAP groups for (in seconds). Only
+    applies if
     `AUTH_LDAP_CACHE_GROUPS` is true.
-    - **Type:** `integer`
-    - **Default:** `3600`
+  - **Type:** `integer`
+  - **Default:** `3600`
 
 - **`AUTH_LDAP_START_TLS`**:
-    - **Description:** Determines if we update to a secure LDAP connection using StartTLS after connecting.
-    - **Type:** `boolean`
-    - **Default:** `true`
+  - **Description:** Determines if we update to a secure LDAP connection using
+    StartTLS after connecting.
+  - **Type:** `boolean`
+  - **Default:** `true`
 
 - **`AUTH_LDAP_PROTOCOL_VERSION`**:
-    - **Description:** If set, forces LDAP protocol version 3.
-    - **Type:** `integer`
-    - **Default:** `''`
+  - **Description:** If set, forces LDAP protocol version 3.
+  - **Type:** `integer`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_TLS_CACERTFILE`**:
-    - **Description:** Path to a custom LDAP certificate authority file.
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Path to a custom LDAP certificate authority file.
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_TLS_CERTFILE`**:
-    - **Description:** Path to a custom LDAP certificate file.
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Path to a custom LDAP certificate file.
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_TLS_KEYFILE`**:
-    - **Description:** Path to a custom LDAP key file (matching the cert given in `AUTH_LDAP_TLS_CERTFILE`).
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Path to a custom LDAP key file (matching the cert given in `AUTH_LDAP_TLS_CERTFILE`).
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_TLS_REQUIRE_CERT`**:
-    - **Description:** How strict to be regarding TLS cerfiticate verification. Allowed values are "never",
-    "allow", "try", "demand", or "hard". Corresponds to the TLSVerifyClient OpenLDAP setting.
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** How strict to be regarding TLS cerfiticate verification.
+    Allowed values are "never", "allow", "try", "demand", or "hard". Corresponds
+    to the TLSVerifyClient OpenLDAP setting.
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AUTH_LDAP_ADMIN_GROUP`**:
-    - **Description:** Members of this LDAP group authenticate as administrators.
-    - **Type:** `string`
-    - **Default:** `'Administrators'`
+  - **Description:** Members of this LDAP group authenticate as administrators.
+  - **Type:** `string`
+  - **Default:** `'Administrators'`
 
 - **`AUTH_LDAP_MANAGER_GROUP`**: Members of this LDAP group authenticate as managers.
-    - **Type:** `string`
-    - **Default:** `'Managers'`
+  - **Type:** `string`
+  - **Default:** `'Managers'`
 
 - **`AUTH_LDAP_REVIEWER_GROUP`**: Members of this LDAP group authenticate as reviewers.
-    - **Type:** `string`
-    - **Default:** `'Reviewers'`
+  - **Type:** `string`
+  - **Default:** `'Reviewers'`
 
 ### CAS-specific environment variables
 
-These variables specify the behaviour of CAS authentication. If `SS_CAS_AUTHENTICATION` is false, none of the other ones are used.
+These variables specify the behaviour of CAS authentication. If
+`SS_CAS_AUTHENTICATION` is false, none of the other ones are used.
 
 - **`AUTH_CAS_SERVER_URL`**:
-    - **Description:** Address of the CAS server to authenticate against. Defaults to CAS demo server.
-    - **Type:** `string`
-    - **Default:** `https://django-cas-ng-demo-server.herokuapp.com/cas/`
+  - **Description:** Address of the CAS server to authenticate against. Defaults
+    to CAS demo server.
+  - **Type:** `string`
+  - **Default:** `https://django-cas-ng-demo-server.herokuapp.com/cas/`
 
 - **`AUTH_CAS_PROTOCOL_VERSION`**:
-    - **Description:** Version of CAS protocol to use. Allowed values are "1", "2", "3", or "CAS_2_SAML_1_0".
-    - **Type:** `string`
-    - **Default:** `3`
+  - **Description:** Version of CAS protocol to use. Allowed values are "1",
+    "2", "3", or "CAS_2_SAML_1_0".
+  - **Type:** `string`
+  - **Default:** `3`
 
 - **`AUTH_CAS_CHECK_ADMIN_ATTRIBUTES`**:
-    - **Description:** Determines if we check user attributes returned by CAS server to determine if user is an administrator.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** Determines if we check user attributes returned by CAS
+    server to determine if user is an administrator.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`AUTH_CAS_ADMIN_ATTRIBUTE`**:
-    - **Description:** Name of attribute to check for administrator status, if `CAS_CHECK_ADMIN_ATTRIBUTES` is True.
-    - **Type:** `string`
-    - **Default:** `None`
+  - **Description:** Name of attribute to check for administrator status, if
+    `CAS_CHECK_ADMIN_ATTRIBUTES` is True.
+  - **Type:** `string`
+  - **Default:** `None`
 
 - **`AUTH_CAS_ADMIN_ATTRIBUTE_VALUE`**:
-    - **Description:** Value in `CAS_ADMIN_ATTRIBUTE` that indicates user is an administrator, if `CAS_CHECK_ADMIN_ATTRIBUTES` is True.
-    - **Type:** `string`
-    - **Default:** `None`
+  - **Description:** Value in `CAS_ADMIN_ATTRIBUTE` that indicates user is an
+    administrator, if `CAS_CHECK_ADMIN_ATTRIBUTES` is True.
+  - **Type:** `string`
+  - **Default:** `None`
 
 - **`AUTH_CAS_AUTOCONFIGURE_EMAIL`**:
-    - **Description:** Determines if we auto-configure an email address for new users by following the rule username@domain.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** Determines if we auto-configure an email address for new
+    users by following the rule username@domain.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`AUTH_CAS_EMAIL_DOMAIN`**:
-    - **Description:** Domain to use for auto-configured email addresses, if `AUTH_CAS_AUTOCONFIGURE_EMAIL` is True.
-    - **Type:** `string`
-    - **Default:** `None`
+  - **Description:** Domain to use for auto-configured email addresses, if
+    `AUTH_CAS_AUTOCONFIGURE_EMAIL` is True.
+  - **Type:** `string`
+  - **Default:** `None`
 
 ### OIDC-specific environment variables
 
 **OIDC support is experimental, please share your feedback!**
 
-These variables specify the behaviour of OpenID Connect (OIDC) authentication. If `SS_OIDC_AUTHENTICATION` is false, none of the other ones are used.
+These variables specify the behaviour of OpenID Connect (OIDC) authentication.
+If `SS_OIDC_AUTHENTICATION` is false, none of the other ones are used.
 
 - **`SS_OIDC_AUTHENTICATION`**:
-    - **Description:** Enables user authentication via OIDC.
-    - **Type:** `boolean`
-    - **Default:** `false`
+  - **Description:** Enables user authentication via OIDC.
+  - **Type:** `boolean`
+  - **Default:** `false`
 
 - **`OIDC_RP_CLIENT_ID`**:
-    - **Description:** OIDC client ID
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** OIDC client ID
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`OIDC_RP_CLIENT_SECRET`**:
-    - **Description:** OIDC client secret
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** OIDC client secret
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AZURE_TENANT_ID`**:
-    - **Description:** Azure Active Directory Tenant ID - if this is provided, the endpoint URLs will be automatically generated from this.
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Azure Active Directory Tenant ID - if this is provided, the
+    endpoint URLs will be automatically generated from this.
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`OIDC_OP_AUTHORIZATION_ENDPOINT`**:
-    - **Description:** URL of OIDC provider authorization endpoint
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** URL of OIDC provider authorization endpoint
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`OIDC_OP_TOKEN_ENDPOINT`**:
-    - **Description:** URL of OIDC provider token endpoint
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** URL of OIDC provider token endpoint
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`OIDC_OP_USER_ENDPOINT`**:
-    - **Description:** URL of OIDC provider userinfo endpoint
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** URL of OIDC provider userinfo endpoint
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`OIDC_OP_JWKS_ENDPOINT`**:
-    - **Description:** URL of OIDC provider JWKS endpoint
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** URL of OIDC provider JWKS endpoint
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`OIDC_RP_SIGN_ALGO`**:
-    - **Description:** Algorithm used by the ID provider to sign ID tokens
-    - **Type:** `string`
-    - **Default:** `HS256`
+  - **Description:** Algorithm used by the ID provider to sign ID tokens
+  - **Type:** `string`
+  - **Default:** `HS256`
 
 ### AWS-specific environment variables
 
-These variables can be set to allow AWS authentication for S3 storage spaces as an alternative to providing these details via the user interface. See [AWS CLI Environment Variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) for details.
+These variables can be set to allow AWS authentication for S3 storage spaces as
+an alternative to providing these details via the user interface. See
+[AWS CLI Environment Variables] for details.
 
 - **`AWS_ACCESS_KEY_ID`**:
-    - **Description:** Access key for AWS authentication
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Access key for AWS authentication
+  - **Type:** `string`
+  - **Default:** `''`
 
 - **`AWS_SECRET_ACCESS_KEY`**:
-    - **Description:** Secret key associated with the access key
-    - **Type:** `string`
-    - **Default:** `''`
+  - **Description:** Secret key associated with the access key
+  - **Type:** `string`
+  - **Default:** `''`
 
 ### CSP-specific environment variables
 
 **CSP support is experimental, please share your feedback!**
 
-These variables specify the behaviour of the Content Security Policy (CSP) headers. Only applicable if `SS_CSP_ENABLED` is set.
+These variables specify the behaviour of the Content Security Policy (CSP)
+headers. Only applicable if `SS_CSP_ENABLED` is set.
 
 - **`CSP_SETTINGS_FILE`**:
-    - **Description:** Path to a Python module with overrides of the [`django-csp` policy settings](https://django-csp.readthedocs.io/en/latest/configuration.html#policy-settings). An `ImproperlyConfigured` exception will be raised if the Python module cannot be imported.
-    - **Type:** `string`
-    - **Default:** ``
+  - **Description:** Path to a Python module with overrides of the
+    [django-csp policy settings]. An `ImproperlyConfigured` exception will be
+    raised if the Python module cannot be imported.
+  - **Type:** `string`
+  - **Default:** ``
 
 ## Logging configuration
 
@@ -567,11 +627,11 @@ Archivematica uses Python's standard approach to logging. There is a hierarchy
 of logging levels, at each level, more or less output can be configured. The
 values run from DEBUG (verbose) to CRITICAL (less verbose) as follows:
 
-* DEBUG.
-* INFO.
-* WARNING.
-* ERROR.
-* CRITICAL.
+- DEBUG.
+- INFO.
+- WARNING.
+- ERROR.
+- CRITICAL.
 
 The [Python documentation][python-docs] provides greater explanation.
 
@@ -611,3 +671,31 @@ services.
 [boto3]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/boto3.html#boto3.set_stream
 [django-config]: https://github.com/artefactual/archivematica-storage-service/blob/1adaea28b8853308b8220c493d836eb9d50eb975/storage_service/storage_service/settings/base.py
 [gh-issues]: https://github.com/archivematica/issues
+[settings module]: https://docs.djangoproject.com/en/1.8/ref/settings/#settings
+[SECRET_KEY]: https://docs.djangoproject.com/en/1.8/ref/settings/#secret-key
+[ALLOWED_HOSTS]: https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts
+[TIME_ZONE]: https://docs.djangoproject.com/en/1.8/ref/settings/#time-zone
+[#708]: https://github.com/artefactual/archivematica/issues/708
+[Control Security Policy]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+[dj-database-url docs]: https://github.com/kennethreitz/dj-database-url#url-schema
+[engine]: https://docs.djangoproject.com/en/1.8/ref/settings/#engine
+[DB_NAME]: https://docs.djangoproject.com/en/1.8/ref/settings/#name
+[DB_PASSWORD]: https://docs.djangoproject.com/en/1.8/ref/settings/#password
+[DB_HOST]: https://docs.djangoproject.com/en/1.8/ref/settings/#host
+[#813]: https://github.com/artefactual/archivematica/pull/813
+[USER]: http://docs.gunicorn.org/en/stable/settings.html#user
+[GROUP]: http://docs.gunicorn.org/en/styable/settings.html#group
+[BIND]: http://docs.gunicorn.org/en/stable/settings.html#bind
+[WORKERS]: http://docs.gunicorn.org/en/stable/settings.html#workers
+[WORKER-CLASS]: http://docs.gunicorn.org/en/stable/settings.html#worker-class
+[TIMEOUT]: http://docs.gunicorn.org/en/stable/settings.html#timeout
+[RELOAD]: http://docs.gunicorn.org/en/stable/settings.html#reload
+[RELOAD-ENGINE]: http://docs.gunicorn.org/en/stable/settings.html#reload-engine
+[CHDIR]: http://docs.gunicorn.org/en/stable/settings.html#chdir
+[ACCESSLOG]: http://docs.gunicorn.org/en/stable/settings.html#accesslog
+[ERRORLOG]: http://docs.gunicorn.org/en/stable/settings.html#errorlog
+[LOGLEVEL]: http://docs.gunicorn.org/en/stable/settings.html#loglevel
+[PROC-NAME]: http://docs.gunicorn.org/en/stable/settings.html#proc-name
+[available values]: https://django-auth-ldap.readthedocs.io/en/latest/groups.html
+[AWS CLI Environment Variables]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+[django-csp policy settings]: https://django-csp.readthedocs.io/en/latest/configuration.html#policy-settings


### PR DESCRIPTION
This adds `markdownlint` and `doctoc` to `pre-commit` for linting the main markdown files in the repository.

I restructured some of the content, mostly headers and links, but tried not to alter its meaning. I identified a few issues like Django reference links pointing to 1.8 and so on, but I plan to address those in a separate pull request.