### PR TITLE
Add chunk download retry when expected size is not met

### DIFF
--- a/storage_service/locations/models/duracloud.py
+++ b/storage_service/locations/models/duracloud.py
@@ -277,7 +277,7 @@ class Duracloud(models.Model):
                 LOGGER.error(
                     "[RETRY=%(retry)d] File %(path)s does not match expected size of %(expected_size)s bytes, but was actually %(actual_size)s bytes"
                     % {
-                        "retry": retry,
+                        "retry": retry + 1,
                         "path": download_path,
                         "expected_size": expected_size,
                         "actual_size": os.path.getsize(download_path),


### PR DESCRIPTION
This is a rebase of https://github.com/artefactual/archivematica-storage-service/pull/650 on top of the latest `qa/0.x` branch which addresses the linting errors and updates and adds tests for the new download retry logic.

Connected to https://github.com/archivematica/Issues/issues/1607