### PR TITLE
Fix Space.delete_path logging

### DIFF
--- a/storage_service/common/tests/test_command_import_aip.py
+++ b/storage_service/common/tests/test_command_import_aip.py
@@ -41,6 +41,7 @@ def test_import_aip_command_creates_uncompressed_package(
 ):
     mocker.patch("os.chown")
     mocker.patch("pwd.getpwnam")
+    mocker.patch("logging.config")
     call_command(
         "import_aip",
         "--decompress-source",
@@ -73,6 +74,7 @@ def test_import_aip_command_creates_compressed_package(
 ):
     mocker.patch("os.chown")
     mocker.patch("pwd.getpwnam")
+    mocker.patch("logging.config")
     call_command(
         "import_aip",
         "--decompress-source",

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -809,7 +809,9 @@ class Space(models.Model):
         Deletes `delete_path` in this space, assuming it is locally accessible.
         """
         if not os.path.exists(delete_path):
-            LOGGER.debug("Attempted to delete '%s' but path does not exist")
+            LOGGER.debug(
+                "Attempted to delete '%s' but path does not exist", delete_path
+            )
             return
         self._del_package(delete_path)
         self._delete_quad_dir_structure(delete_path)


### PR DESCRIPTION
Extracted from https://github.com/artefactual/archivematica-storage-service/pull/628

This also avoids resetting the root logger configuration in the `test_command_import_aip` tests which breaks usage of the `caplog` fixture in other tests. See https://github.com/pytest-dev/pytest/discussions/11011