### PR TITLE
Use tempfile library for temp file creation in package.py

### DIFF
--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -1714,16 +1714,16 @@ class Package(models.Model):
             rc = p.returncode
             LOGGER.debug("Compress package RC: %s", rc)
 
-            script_path = f"/tmp/{str(uuid4())}"
-            file_ = os.open(script_path, os.O_WRONLY | os.O_CREAT, 0o770)
-            os.write(file_, tool_info_command.encode("utf-8"))
-            os.close(file_)
-            tic_cmd = [script_path]
-            p = subprocess.Popen(
-                tic_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
-            )
-            tic_stdout, tic_stderr = p.communicate()
-            os.remove(script_path)
+            with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmpfile:
+                os.chmod(tmpfile.name, 0o770)
+                tmpfile.write(tool_info_command.encode("utf-8"))
+                tmpfile.close()
+                tic_cmd = [tmpfile.name]
+                p = subprocess.Popen(
+                    tic_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+                )
+                tic_stdout, tic_stderr = p.communicate()
+                os.unlink(tmpfile.name)
             LOGGER.debug("Tool info stdout")
             LOGGER.debug(tool_info_command)
             LOGGER.debug(tic_stdout)

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -1714,9 +1714,11 @@ class Package(models.Model):
             rc = p.returncode
             LOGGER.debug("Compress package RC: %s", rc)
 
-            with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmpfile:
+            with tempfile.NamedTemporaryFile(
+                encoding="utf-8", mode="wt", delete=False
+            ) as tmpfile:
                 os.chmod(tmpfile.name, 0o770)
-                tmpfile.write(tool_info_command.encode("utf-8"))
+                tmpfile.write(tool_info_command)
                 tmpfile.close()
                 tic_cmd = [tmpfile.name]
                 p = subprocess.Popen(


### PR DESCRIPTION
Fixes use of hardcoded temp directory.
This is part of the fix for issue https://github.com/archivematica/Issues/issues/1425

Reviewed in SS 0.21.1 Am 1.15.1
- Transfer with compression
- Full Reingest

Custom temporary directory can be set in the storages service environment file. Example:
- `TMPDIR=/path/to/dir`