### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: "Check out repository"
         uses: "actions/checkout@v4"
       - name: "Set up Python ${{ matrix.python-version }}"
-        uses: "actions/setup-python@v4"
+        uses: "actions/setup-python@v5"
         with:
           python-version: "${{ matrix.python-version }}"
           cache: "pip"
@@ -50,7 +50,7 @@ jobs:
           tox
       - name: "Upload coverage report"
         if: github.repository == 'artefactual/archivematica-storage-service'
-        uses: "codecov/codecov-action@v3"
+        uses: "codecov/codecov-action@v4"
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
@@ -92,7 +92,7 @@ jobs:
       - name: "Check out repository"
         uses: "actions/checkout@v4"
       - name: "Set up Python 3.9"
-        uses: "actions/setup-python@v4"
+        uses: "actions/setup-python@v5"
         with:
           python-version: "3.9"
       - name: "Install tox"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,30 +24,30 @@ repos:
   - id: django-upgrade
     args: [--target-version, "4.2"]
 - repo: https://github.com/psf/black
-  rev: "23.10.1"
+  rev: "23.12.1"
   hooks:
   - id: black
     args: [--safe, --quiet]
 - repo: https://github.com/pycqa/flake8
-  rev: "6.1.0"
+  rev: "7.0.0"
   hooks:
   - id: flake8
     additional_dependencies:
     - flake8-bugbear==23.9.16
     - flake8-comprehensions==3.14.0
 - repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v8.52.0
+  rev: v8.56.0
   hooks:
   - id: eslint
     files: ^storage_service/static/js/(project|.*directory_picker|file-explorer).js
     args: [--fix]
     additional_dependencies:
-    - eslint@8.52.0
-    - eslint-config-prettier@9.0.0
-    - eslint-plugin-prettier@5.0.1
+    - eslint@8.56.0
+    - eslint-config-prettier@9.1.0
+    - eslint-plugin-prettier@5.1.3
     - prettier@3.0.3
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.37.0
+  rev: v0.39.0
   hooks:
   - id: markdownlint
     exclude: |

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "mysql"
 
   minio:
-    image: "minio/minio:RELEASE.2023-08-16T20-17-30Z"
+    image: "minio/minio:RELEASE.2024-01-31T20-20-33Z"
     command: "server /data"
     environment:
       MINIO_ACCESS_KEY: "minio"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,9 +12,9 @@ asgiref==3.7.2
     #   django
 bagit==1.8.1
     # via -r requirements.txt
-boto3==1.34.21
+boto3==1.34.33
     # via -r requirements.txt
-botocore==1.34.21
+botocore==1.34.33
     # via
     #   -r requirements.txt
     #   boto3
@@ -43,11 +43,11 @@ click==8.1.7
     # via pip-tools
 colorama==0.4.6
     # via tox
-coverage[toml]==7.4.0
+coverage[toml]==7.4.1
     # via
     #   -r requirements-dev.in
     #   pytest-cov
-cryptography==41.0.7
+cryptography==42.0.2
     # via
     #   -r requirements.txt
     #   josepy
@@ -140,7 +140,7 @@ lxml==5.1.0
     #   metsrw
     #   python-cas
     #   sword2
-metsrw==0.5.0
+metsrw==0.5.1
     # via -r requirements.txt
 mozilla-django-oidc==4.0.0
     # via -r requirements.txt
@@ -205,11 +205,11 @@ pbr==6.0.0
     #   stevedore
 pip-tools==7.3.0
     # via -r requirements-dev.in
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via
     #   tox
     #   virtualenv
-pluggy==1.3.0
+pluggy==1.4.0
     # via
     #   pytest
     #   tox
@@ -230,7 +230,7 @@ pycparser==2.21
     # via
     #   -r requirements.txt
     #   cffi
-pyopenssl==23.3.0
+pyopenssl==24.0.0
     # via
     #   -r requirements.txt
     #   josepy
@@ -243,7 +243,7 @@ pyproject-api==1.6.1
     # via tox
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.4
+pytest==8.0.0
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -252,7 +252,7 @@ pytest==7.4.4
     #   pytest-randomly
 pytest-cov==4.1.0
     # via -r requirements-dev.in
-pytest-django==4.7.0
+pytest-django==4.8.0
     # via -r requirements-dev.in
 pytest-mock==3.12.0
     # via -r requirements-dev.in
@@ -281,7 +281,7 @@ python-mimeparse==1.6.0
     #   django-tastypie
 python-swiftclient==4.4.0
     # via -r requirements.txt
-pytz==2023.3.post1
+pytz==2023.4
     # via
     #   -r requirements.txt
     #   oslo-serialization

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@ asgiref==3.7.2
     # via django
 bagit==1.8.1
     # via -r requirements.in
-boto3==1.34.21
+boto3==1.34.33
     # via -r requirements.in
-botocore==1.34.21
+botocore==1.34.33
     # via
     #   boto3
     #   s3transfer
@@ -24,7 +24,7 @@ cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
-cryptography==41.0.7
+cryptography==42.0.2
     # via
     #   josepy
     #   mozilla-django-oidc
@@ -89,7 +89,7 @@ lxml==5.1.0
     #   metsrw
     #   python-cas
     #   sword2
-metsrw==0.5.0
+metsrw==0.5.1
     # via -r requirements.in
 mozilla-django-oidc==4.0.0
     # via -r requirements.in
@@ -143,7 +143,7 @@ pyasn1-modules==0.3.0
     # via python-ldap
 pycparser==2.21
     # via cffi
-pyopenssl==23.3.0
+pyopenssl==24.0.0
     # via josepy
 pyparsing==3.1.1
     # via
@@ -167,7 +167,7 @@ python-mimeparse==1.6.0
     # via django-tastypie
 python-swiftclient==4.4.0
     # via -r requirements.in
-pytz==2023.3.post1
+pytz==2023.4
     # via
     #   oslo-serialization
     #   oslo-utils


### PR DESCRIPTION
This upgrades the Python requirements, `pre-commit` hooks and GitHub action versions.

The only exception is the `pre-commit` hook for `black` which in its latest version has introduced an incompatibility with the `reorder-python-imports` hook.