### PR TITLE
Add Python 3.12 to GitHub test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           "3.9",
           "3.10",
           "3.11",
+          "3.12",
         ]
     steps:
       - name: "Check out repository"
@@ -70,6 +71,7 @@ jobs:
           "3.9",
           "3.10",
           "3.11",
+          "3.12",
         ]
     steps:
       - name: "Check out repository"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -325,7 +325,7 @@ stevedore==5.1.0
     #   keystoneauth1
     #   oslo-config
     #   python-keystoneclient
-sword2 @ git+https://github.com/swordapp/python-client-sword2.git@59db54c03e4498dd6b001ac4f3a4167aa2fb8987
+sword2 @ git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4
     # via -r requirements.txt
 tomli==2.0.1
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ python-gnupg
 python-keystoneclient
 python-swiftclient
 requests
-git+https://github.com/swordapp/python-client-sword2.git@59db54c03e4498dd6b001ac4f3a4167aa2fb8987#egg=sword2
+git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4#egg=sword2
 whitenoise
 agentarchives
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@962f6f9818683ef5f6432f091d22945e54b82592#egg=django-shibboleth-remoteuser

--- a/requirements.txt
+++ b/requirements.txt
@@ -201,7 +201,7 @@ stevedore==5.1.0
     #   keystoneauth1
     #   oslo-config
     #   python-keystoneclient
-sword2 @ git+https://github.com/swordapp/python-client-sword2.git@59db54c03e4498dd6b001ac4f3a4167aa2fb8987
+sword2 @ git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4
     # via -r requirements.in
 typing-extensions==4.9.0
     # via

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = linting, py{38,39,310,311}, migrations
+envlist = linting, py{38,39,310,311,312}, migrations
 skip_missing_interpreters = true
 
 [gh-actions]
@@ -9,6 +9,7 @@ python =
     3.9: py39, migrations
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv:linting]
 basepython = python3


### PR DESCRIPTION
According to the [release schedule for Ubuntu 24.04](https://discourse.ubuntu.com/t/noble-numbat-release-schedule/35649) Python 3.12 will be the default version.

This adds Python 3.12 to the matrix configuration of the GitHub `test` workflow and sets a compatible forked version of the `sword2` library. I plan to reduce the number of test jobs in a following pull request.