### PR TITLE
Fix codecov-action configuration in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,8 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   integration:
     name: "Integration ${{ matrix.ubuntu-version }} with ${{ matrix.python-version }}"
     runs-on: "ubuntu-22.04"


### PR DESCRIPTION
> Tokenless uploading is unsupported.

The `v4.0.0` release of the `codecov/codecov-action` made a [breaking change](https://github.com/codecov/codecov-action/releases/tag/v4.0.0).

This PR follows their [document](https://docs.codecov.com/docs/adding-the-codecov-token#github-actions) on how to update the GitHub workflow.