### PR TITLE
Fix Shibboleth URL patterns

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -80,7 +80,7 @@ django-csp==3.7
     # via -r requirements.txt
 django-prometheus==2.3.1
     # via -r requirements.txt
-django-shibboleth-remoteuser @ git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@962f6f9818683ef5f6432f091d22945e54b82592
+django-shibboleth-remoteuser @ git+https://github.com/artefactual-labs/django-shibboleth-remoteuser.git@f08a7864d6130416c352981ccf318fff0fd5be58
     # via -r requirements.txt
 django-tastypie==0.14.6
     # via -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ requests
 git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4#egg=sword2
 whitenoise
 agentarchives
-git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@962f6f9818683ef5f6432f091d22945e54b82592#egg=django-shibboleth-remoteuser
+git+https://github.com/artefactual-labs/django-shibboleth-remoteuser.git@f08a7864d6130416c352981ccf318fff0fd5be58#egg=django-shibboleth-remoteuser
 prometheus_client
 django-prometheus
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ django-csp==3.7
     # via -r requirements.in
 django-prometheus==2.3.1
     # via -r requirements.in
-django-shibboleth-remoteuser @ git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@962f6f9818683ef5f6432f091d22945e54b82592
+django-shibboleth-remoteuser @ git+https://github.com/artefactual-labs/django-shibboleth-remoteuser.git@f08a7864d6130416c352981ccf318fff0fd5be58
     # via -r requirements.in
 django-tastypie==0.14.6
     # via -r requirements.in

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -47,15 +47,7 @@ else:
     ]
 
 if "shibboleth" in settings.INSTALLED_APPS:
-    # Simulate a shibboleth urls module (so our custom Shibboleth logout view
-    # matches the same namespaced URL name as the standard logout view from
-    # the shibboleth lib)
-    class ShibbolethURLs:
-        urlpatterns = [
-            path("logout/", views.CustomShibbolethLogoutView.as_view(), name="logout")
-        ]
-
-    urlpatterns += [path("shib/", include(ShibbolethURLs, namespace="shibboleth"))]
+    urlpatterns += [path("shib/", include("shibboleth.urls"))]
 
 
 if settings.PROMETHEUS_ENABLED:


### PR DESCRIPTION
This sets a forked version of the `django-shibboleth-remoteuser` library compatible with Django 3.2 and above and removes the custom Shibboleth logout view which is not necessary after the middleware removed the `LOGOUT_SESSION_KEY`.

Connected to https://github.com/archivematica/Issues/issues/1667