### PR TITLE
Update common to use pathlib instead of os.path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,8 @@ repos:
       (?x)^(
         storage_service/storage_service/settings/.*\.py |
         storage_service/common/gpgutils.py |
-        storage_service/common/startup.py
+        storage_service/common/startup.py |
+        storage_service/common/management/commands/populate_aip_checksums.py
       )
 - repo: https://github.com/pre-commit/mirrors-eslint
   rev: v8.56.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,8 @@ repos:
     files: |
       (?x)^(
         storage_service/storage_service/settings/.*\.py |
-        storage_service/common/gpgutils.py
+        storage_service/common/gpgutils.py |
+        storage_service/common/startup.py
       )
 - repo: https://github.com/pre-commit/mirrors-eslint
   rev: v8.56.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,8 @@ repos:
     - flake8-use-pathlib==0.3.0
     files: |
       (?x)^(
-        storage_service/storage_service/settings/(base).py
+        storage_service/storage_service/settings/.*\.py |
+        storage_service/common/gpgutils.py
       )
 - repo: https://github.com/pre-commit/mirrors-eslint
   rev: v8.56.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,8 @@ repos:
         storage_service/storage_service/settings/.*\.py |
         storage_service/common/gpgutils.py |
         storage_service/common/startup.py |
-        storage_service/common/management/commands/populate_aip_checksums.py
+        storage_service/common/management/commands/populate_aip_checksums.py |
+        storage_service/common/management/commands/import_aip.py
       )
 - repo: https://github.com/pre-commit/mirrors-eslint
   rev: v8.56.0

--- a/storage_service/common/gpgutils.py
+++ b/storage_service/common/gpgutils.py
@@ -216,7 +216,7 @@ def gpg_decrypt_file(path, decr_path):
     """Use GPG to decrypt the file at ``path`` and save the decrypted file to
     ``decr_path``.
     """
-    with open(path, "rb") as stream:
+    with Path(path).open("rb") as stream:
         return gpg().decrypt_file(stream, output=decr_path)
 
 
@@ -227,7 +227,7 @@ def gpg_encrypt_file(path, recipient_fingerprint):
     result <gnupg.Crypt> object are returned.
     """
     encr_path = path + ".gpg"
-    with open(path, "rb") as stream:
+    with Path(path).open("rb") as stream:
         result = gpg().encrypt_file(
             stream,
             [recipient_fingerprint],

--- a/storage_service/common/management/commands/import_aip.py
+++ b/storage_service/common/management/commands/import_aip.py
@@ -174,7 +174,7 @@ def fail(string):
 
 
 def is_compressed(aip_path):
-    return os.path.isfile(aip_path)
+    return Path(aip_path).is_file()
 
 
 def tree(path):
@@ -220,7 +220,7 @@ def _decompress_7z(aip_path, temp_dir):
 
 
 def confirm_aip_exists(aip_path):
-    if not os.path.exists(aip_path):
+    if not Path(aip_path).exists():
         raise ImportAIPException(f"There is nothing at {aip_path}")
 
 
@@ -385,7 +385,7 @@ def compress(aip_model_inst, compression_algorithm):
         details,
     ) = aip_model_inst.compress_package(compression_algorithm, detailed_output=True)
     compressed_aip_fname = Path(compressed_aip_path).name
-    aip_current_dir = os.path.dirname(aip_model_inst.current_path)
+    aip_current_dir = Path(aip_model_inst.current_path).parent
     shutil.rmtree(aip_model_inst.full_path)
     new_current_path = Path(aip_current_dir) / compressed_aip_fname
     new_full_path = Path(aip_model_inst.current_location.full_path) / new_current_path

--- a/storage_service/common/management/commands/import_aip.py
+++ b/storage_service/common/management/commands/import_aip.py
@@ -181,7 +181,7 @@ def tree(path):
     for root, _, files in os.walk(path):
         level = root.replace(path, "").count(os.sep)
         indent = " " * 4 * (level)
-        print(header(f"{indent}{os.path.basename(root)}/"))
+        print(header(f"{indent}{Path(root).name}/"))
         subindent = " " * 4 * (level + 1)
         for f in files:
             print(okgreen(f"{subindent}{f}"))
@@ -245,7 +245,7 @@ def get_aip_mets_path(aip_path):
 
 
 def get_aip_uuid(aip_mets_path):
-    return uuid.UUID(os.path.basename(aip_mets_path)[5:41])
+    return uuid.UUID(Path(aip_mets_path).name[5:41])
 
 
 def get_aip_storage_locations(aip_storage_location_uuid):
@@ -384,7 +384,7 @@ def compress(aip_model_inst, compression_algorithm):
         compressed_aip_parent_path,
         details,
     ) = aip_model_inst.compress_package(compression_algorithm, detailed_output=True)
-    compressed_aip_fname = os.path.basename(compressed_aip_path)
+    compressed_aip_fname = Path(compressed_aip_path).name
     aip_current_dir = os.path.dirname(aip_model_inst.current_path)
     shutil.rmtree(aip_model_inst.full_path)
     new_current_path = Path(aip_current_dir) / compressed_aip_fname
@@ -430,7 +430,7 @@ def import_aip(
         size=utils.recalculate_size(aip_path),
         origin_pipeline=get_pipeline(adoptive_pipeline_uuid),
         current_location=local_as_location,
-        current_path=os.path.basename(os.path.normpath(aip_path)),
+        current_path=Path(aip_path).name,
     )
     copy_aip_to_aip_storage_location(
         aip_model_inst, aip_path, local_as_location, unix_owner

--- a/storage_service/common/management/commands/populate_aip_checksums.py
+++ b/storage_service/common/management/commands/populate_aip_checksums.py
@@ -13,7 +13,7 @@ have the Package.checksum and Package.checksum_algorithm fields populated.
 Execution example:
 ./manage.py populate_aip_checksums
 """
-from pathlib import Path
+import pathlib
 
 from common import utils
 from common.management.commands import StorageServiceCommand
@@ -54,7 +54,7 @@ class Command(StorageServiceCommand):
         compressed_aips = []
         uncompressed_aips = []
         for aip in aips:
-            if Path(aip.current_path).suffix in utils.PACKAGE_EXTENSIONS:
+            if pathlib.Path(aip.current_path).suffix in utils.PACKAGE_EXTENSIONS:
                 compressed_aips.append(aip)
             else:
                 uncompressed_aips.append(aip)

--- a/storage_service/common/management/commands/populate_aip_checksums.py
+++ b/storage_service/common/management/commands/populate_aip_checksums.py
@@ -13,7 +13,7 @@ have the Package.checksum and Package.checksum_algorithm fields populated.
 Execution example:
 ./manage.py populate_aip_checksums
 """
-import os
+from pathlib import Path
 
 from common import utils
 from common.management.commands import StorageServiceCommand
@@ -54,7 +54,7 @@ class Command(StorageServiceCommand):
         compressed_aips = []
         uncompressed_aips = []
         for aip in aips:
-            if os.path.splitext(aip.current_path)[1] in utils.PACKAGE_EXTENSIONS:
+            if Path(aip.current_path).suffix in utils.PACKAGE_EXTENSIONS:
                 compressed_aips.append(aip)
             else:
                 uncompressed_aips.append(aip)

--- a/storage_service/common/startup.py
+++ b/storage_service/common/startup.py
@@ -1,6 +1,7 @@
 import errno
 import logging
 import os.path
+from pathlib import Path
 
 import django.core.exceptions
 from common import utils
@@ -58,15 +59,14 @@ class PopulateLock:
 
 def populate_default_locations():
     """Create default local filesystem space and its locations."""
+
+    BASE_PATH = Path("var") / "archivematica"
+
     try:
         space, space_created = locations_models.Space.objects.get_or_create(
             access_protocol=locations_models.Space.LOCAL_FILESYSTEM,
             path=os.sep,
-            defaults={
-                "staging_path": os.path.join(
-                    os.sep, "var", "archivematica", "storage_service"
-                )
-            },
+            defaults={"staging_path": os.sep / BASE_PATH / "storage_service"},
         )
         if space_created:
             locations_models.LocalFilesystem.objects.create(space=space)
@@ -84,45 +84,36 @@ def populate_default_locations():
         },
         {
             "purpose": locations_models.Location.AIP_STORAGE,
-            "relative_path": os.path.join(
-                "var", "archivematica", "sharedDirectory", "www", "AIPsStore"
-            ),
+            "relative_path": BASE_PATH / "sharedDirectory" / "www" / "AIPsStore",
             "description": "Store AIP in standard Archivematica Directory",
             "default_setting": "default_aip_storage",
         },
         {
             "purpose": locations_models.Location.DIP_STORAGE,
-            "relative_path": os.path.join(
-                "var", "archivematica", "sharedDirectory", "www", "DIPsStore"
-            ),
+            "relative_path": BASE_PATH / "sharedDirectory" / "www" / "DIPsStore",
             "description": "Store DIP in standard Archivematica Directory",
             "default_setting": "default_dip_storage",
         },
         {
             "purpose": locations_models.Location.BACKLOG,
-            "relative_path": os.path.join(
-                "var",
-                "archivematica",
-                "sharedDirectory",
-                "www",
-                "AIPsStore",
-                "transferBacklog",
-            ),
+            "relative_path": BASE_PATH
+            / "sharedDirectory"
+            / "www"
+            / "AIPsStore"
+            / "transferBacklog",
             "description": "Default transfer backlog",
             "default_setting": "default_backlog",
         },
         {
             "purpose": locations_models.Location.STORAGE_SERVICE_INTERNAL,
-            "relative_path": os.path.join("var", "archivematica", "storage_service"),
+            "relative_path": BASE_PATH / "storage_service",
             "description": "For storage service internal usage.",
             "default_setting": None,
             "create_dirs": True,
         },
         {
             "purpose": locations_models.Location.AIP_RECOVERY,
-            "relative_path": os.path.join(
-                "var", "archivematica", "storage_service", "recover"
-            ),
+            "relative_path": BASE_PATH / "storage_service" / "recover",
             "description": "Default AIP recovery",
             "default_setting": "default_recovery",
             "create_dirs": True,

--- a/storage_service/common/startup.py
+++ b/storage_service/common/startup.py
@@ -1,7 +1,7 @@
 import errno
 import logging
 import os
-from pathlib import Path
+import pathlib
 
 import django.core.exceptions
 from common import utils
@@ -60,7 +60,7 @@ class PopulateLock:
 def populate_default_locations():
     """Create default local filesystem space and its locations."""
 
-    BASE_PATH = Path("var") / "archivematica"
+    BASE_PATH = pathlib.Path("var") / "archivematica"
 
     try:
         space, space_created = locations_models.Space.objects.get_or_create(
@@ -140,10 +140,10 @@ def populate_default_locations():
         if created and loc_info.get("create_dirs"):
             LOGGER.info("Creating %s Location %s", loc_info["purpose"], new_loc)
             try:
-                Path(new_loc.full_path).mkdir()
+                pathlib.Path(new_loc.full_path).mkdir()
                 # Hack for extra recovery dir
                 if loc_info["purpose"] == locations_models.Location.AIP_RECOVERY:
-                    Path(new_loc.full_path).joinpath("backup").mkdir()
+                    pathlib.Path(new_loc.full_path).joinpath("backup").mkdir()
             except OSError as e:
                 if e.errno != errno.EEXIST:
                     LOGGER.error(

--- a/storage_service/common/startup.py
+++ b/storage_service/common/startup.py
@@ -1,6 +1,6 @@
 import errno
 import logging
-import os.path
+import os
 from pathlib import Path
 
 import django.core.exceptions
@@ -140,10 +140,10 @@ def populate_default_locations():
         if created and loc_info.get("create_dirs"):
             LOGGER.info("Creating %s Location %s", loc_info["purpose"], new_loc)
             try:
-                os.mkdir(new_loc.full_path)
+                Path(new_loc.full_path).mkdir()
                 # Hack for extra recovery dir
                 if loc_info["purpose"] == locations_models.Location.AIP_RECOVERY:
-                    os.mkdir(os.path.join(new_loc.full_path, "backup"))
+                    Path(new_loc.full_path).joinpath("backup").mkdir()
             except OSError as e:
                 if e.errno != errno.EEXIST:
                     LOGGER.error(

--- a/storage_service/common/startup.py
+++ b/storage_service/common/startup.py
@@ -140,10 +140,11 @@ def populate_default_locations():
         if created and loc_info.get("create_dirs"):
             LOGGER.info("Creating %s Location %s", loc_info["purpose"], new_loc)
             try:
-                pathlib.Path(new_loc.full_path).mkdir()
+                new_loc_full_path = pathlib.Path(new_loc.full_path)
+                new_loc_full_path.mkdir()
                 # Hack for extra recovery dir
                 if loc_info["purpose"] == locations_models.Location.AIP_RECOVERY:
-                    pathlib.Path(new_loc.full_path).joinpath("backup").mkdir()
+                    (new_loc_full_path / "backup").mkdir()
             except OSError as e:
                 if e.errno != errno.EEXIST:
                     LOGGER.error(


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/1622

Remarks:
- There is no direct equivalent function like [`os.path.commonprefix`](https://github.com/artefactual/archivematica-storage-service/blob/a8aefbc84b605fad340e383c3a9f353caadc1e8b/storage_service/common/management/commands/import_aip.py#L209).
- [`os.path.join(source, "")`](https://github.com/artefactual/archivematica-storage-service/blob/a8aefbc84b605fad340e383c3a9f353caadc1e8b/storage_service/common/management/commands/import_aip.py#L315) has the behaviour an empty last part will result in a path that ends with a separator.  I have opted for [this equivalence](https://stackoverflow.com/questions/47572165/whats-the-best-way-to-add-a-trailing-slash-to-a-pathlib-directory).
- flake8-use-pathlib does not find [some changes](https://github.com/artefactual/archivematica-storage-service/blob/a8aefbc84b605fad340e383c3a9f353caadc1e8b/storage_service/common/management/commands/import_aip.py#L184). They have also changed. 
