### PR TITLE
Add GHA workflow to push docker images to registry

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -1,0 +1,25 @@
+name: "Push images to Docker Hub"
+on: workflow_dispatch
+jobs:
+  build:
+    name: "Builds images and push them to Docker Hub"
+    runs-on: "ubuntu-22.04"
+    steps:
+      - name: "Check out repository"
+        uses: "actions/checkout@v4"
+      - name: "Set up buildx"
+        uses: "docker/setup-buildx-action@v3"
+      - name: "Login to Docker Hub"
+        uses: docker/login-action@v3
+        with:
+          username: artefactual
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: "Build and Push Storage Service"
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          load: true
+          file: ./Dockerfile
+          target: "archivematica-storage-service"
+          tags: artefactual/archivematica-storage-service:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,6 @@ RUN set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		build-essential \
-		gcc \
 		gettext \
 		gnupg1 \
 		libffi-dev \


### PR DESCRIPTION
This PR creates a Github Action that builds and push docker images to Docker Hub. For now the trigger to this workflow will be manual and will be tagged only with `latest`.