### PR TITLE
Remove UUID regex from urls

### DIFF
--- a/storage_service/administration/urls.py
+++ b/storage_service/administration/urls.py
@@ -1,6 +1,5 @@
 from administration import views
 from django.urls import path
-from django.urls import re_path
 
 app_name = "administration"
 urlpatterns = [
@@ -10,17 +9,15 @@ urlpatterns = [
     path("version/", views.version_view, name="version"),
     path("users/", views.user_list, name="user_list"),
     path("users/create/", views.user_create, name="user_create"),
-    re_path(r"^users/(?P<id>[-\w]+)/edit/$", views.user_edit, name="user_edit"),
-    re_path(r"^users/(?P<id>[-\w]+)/$", views.user_detail, name="user_detail"),
+    path("users/<int:id>/edit/", views.user_edit, name="user_edit"),
+    path("users/<int:id>/", views.user_detail, name="user_detail"),
     path("language/", views.change_language, name="change_language"),
     path("keys/", views.key_list, name="key_list"),
-    re_path(
-        r"^keys/(?P<key_fingerprint>[\w]+)/detail$", views.key_detail, name="key_detail"
-    ),
+    path("keys/<str:key_fingerprint>/detail/", views.key_detail, name="key_detail"),
     path("keys/create/", views.key_create, name="key_create"),
     path("keys/import/", views.key_import, name="key_import"),
-    re_path(
-        r"^keys/(?P<key_fingerprint>[\w]+)/delete/$",
+    path(
+        "keys/<str:key_fingerprint>/delete/",
         views.key_delete,
         name="key_delete",
     ),

--- a/storage_service/locations/urls.py
+++ b/storage_service/locations/urls.py
@@ -1,26 +1,23 @@
 from django.urls import path
-from django.urls import re_path
 from locations import views
-
-UUID = r"\w{8}-\w{4}-\w{4}-\w{4}-\w{12}"
 
 app_name = "locations"
 urlpatterns = [
     # Sorted by alphabetized categories
     # Locations
     path("locations/", views.location_list, name="location_list"),
-    re_path(
-        r"^locations/(?P<location_uuid>" + UUID + ")/$",
+    path(
+        "locations/<uuid:location_uuid>",
         views.location_detail,
         name="location_detail",
     ),
-    re_path(
-        r"^locations/(?P<location_uuid>" + UUID + ")/delete/$",
+    path(
+        "locations/<uuid:location_uuid>/delete/",
         views.location_delete,
         name="location_delete",
     ),
-    re_path(
-        r"^locations/(?P<location_uuid>" + UUID + ")/switch_enabled/$",
+    path(
+        "locations/<uuid:location_uuid>/switch_enabled/",
         views.location_switch_enabled,
         name="location_switch_enabled",
     ),
@@ -32,13 +29,13 @@ urlpatterns = [
         views.package_delete_request,
         name="package_delete_request",
     ),
-    re_path(
-        r"^packages/(?P<uuid>" + UUID + ")/delete/$",
+    path(
+        "packages/<uuid:uuid>/delete/",
         views.package_delete,
         name="package_delete",
     ),
-    re_path(
-        r"^packages/(?P<uuid>" + UUID + ")/update_status/$",
+    path(
+        "packages/<uuid:uuid>/update_status/",
         views.package_update_status,
         name="package_update_status",
     ),
@@ -47,14 +44,14 @@ urlpatterns = [
         views.aip_recover_request,
         name="aip_recover_request",
     ),
-    re_path(
-        r"^packages/(?P<package_uuid>" + UUID + ")/reingest/$",
+    path(
+        "packages/<uuid:package_uuid>/reingest/",
         views.aip_reingest,
         name="aip_reingest",
     ),
     # Fixity check results
-    re_path(
-        r"^fixity/(?P<package_uuid>" + UUID + ")/$",
+    path(
+        "fixity/<uuid:package_uuid>/",
         views.package_fixity,
         name="package_fixity",
     ),
@@ -62,50 +59,42 @@ urlpatterns = [
     # Pipelines
     path("pipelines/", views.pipeline_list, name="pipeline_list"),
     path("pipelines/create/", views.pipeline_edit, name="pipeline_create"),
-    re_path(
-        r"^pipeline/(?P<uuid>" + UUID + ")/edit/$",
+    path(
+        "pipeline/<uuid:uuid>/edit/",
         views.pipeline_edit,
         name="pipeline_edit",
     ),
-    re_path(
-        r"^pipeline/(?P<uuid>" + UUID + ")/detail/$",
+    path(
+        "pipeline/<uuid:uuid>/detail/",
         views.pipeline_detail,
         name="pipeline_detail",
     ),
-    re_path(
-        r"^pipeline/(?P<uuid>" + UUID + ")/delete/$",
+    path(
+        "pipeline/<uuid:uuid>/delete/",
         views.pipeline_delete,
         name="pipeline_delete",
     ),
-    re_path(
-        r"^pipeline/(?P<uuid>" + UUID + ")/switch_enabled/$",
+    path(
+        "pipeline/<uuid:uuid>/switch_enabled/",
         views.pipeline_switch_enabled,
         name="pipeline_switch_enabled",
     ),
     # Spaces
     path("spaces/", views.space_list, name="space_list"),
-    re_path(
-        r"^spaces/(?P<uuid>" + UUID + ")/$", views.space_detail, name="space_detail"
-    ),
-    re_path(
-        r"^spaces/(?P<uuid>" + UUID + ")/edit/$", views.space_edit, name="space_edit"
-    ),
-    re_path(
-        r"^spaces/(?P<uuid>" + UUID + ")/delete/$",
+    path("spaces/<uuid:uuid>/", views.space_detail, name="space_detail"),
+    path("spaces/<uuid:uuid>/edit/", views.space_edit, name="space_edit"),
+    path(
+        "spaces/<uuid:uuid>/delete/",
         views.space_delete,
         name="space_delete",
     ),
-    re_path(
-        r"^spaces/(?P<space_uuid>" + UUID + ")/location_create/$",
+    path(
+        "spaces/<uuid:space_uuid>/location_create/",
         views.location_edit,
         name="location_create",
     ),
-    re_path(
-        r"^spaces/(?P<space_uuid>"
-        + UUID
-        + ")/location/(?P<location_uuid>"
-        + UUID
-        + ")/edit/$",
+    path(
+        "spaces/<uuid:space_uuid>/location/<uuid:location_uuid>/edit/",
         views.location_edit,
         name="location_edit",
     ),
@@ -118,24 +107,24 @@ urlpatterns = [
     ),
     # Callbacks
     path("callbacks/", views.callback_list, name="callback_list"),
-    re_path(
-        r"^callbacks/(?P<uuid>" + UUID + ")/$",
+    path(
+        "callbacks/<uuid:uuid>/",
         views.callback_detail,
         name="callback_detail",
     ),
     path("callbacks/create/", views.callback_edit, name="callback_create"),
-    re_path(
-        r"^callbacks/(?P<uuid>" + UUID + ")/edit/$",
+    path(
+        "callbacks/<uuid:uuid>/edit/",
         views.callback_edit,
         name="callback_edit",
     ),
-    re_path(
-        r"^callbacks/(?P<uuid>" + UUID + ")/delete/$",
+    path(
+        "callbacks/<uuid:uuid>/delete/",
         views.callback_delete,
         name="callback_delete",
     ),
-    re_path(
-        r"^callbacks/(?P<uuid>" + UUID + ")/switch_enabled/$",
+    path(
+        "callbacks/<uuid:uuid>/switch_enabled/",
         views.callback_switch_enabled,
         name="callback_switch_enabled",
     ),

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import include
 from django.urls import path
-from django.urls import re_path
 from django.views.generic import TemplateView
 
 from storage_service import views
@@ -15,7 +14,7 @@ from storage_service import views
 urlpatterns = [
     path("", TemplateView.as_view(template_name="index.html")),
     # Uncomment the next line to enable the admin:
-    re_path(r"^admin/", admin.site.urls),
+    path("admin/", admin.site.urls),
     path("", include(locations.urls)),
     path("administration/", include(administration.urls)),
     path("api/", include(locations.api.urls)),


### PR DESCRIPTION
Removing regex reference of UUID in urls.py and and used `path` for URL dispatcher.

Reference to : https://docs.djangoproject.com/en/4.2/topics/http/urls/#path-converters