### PR TITLE
Fix migrations CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,11 @@ jobs:
           cache: "pip"
           cache-dependency-path: |
             requirements-dev.txt
+      - name: "Install OS packages"
+        run: |
+          sudo apt-get --quiet update
+          sudo apt-get install --quiet --yes build-essential \
+            libmysqlclient-dev libsasl2-dev libldap2-dev libssl-dev
       - name: "Install tox"
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This adds a step to the `tox` job to install development OS packages so `tox` can build packages with C dependencies.