### PR TITLE
Make CSRF_TRUSTED_ORIGINS and USE_X_FORWARDED_HOST configurable

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -73,6 +73,20 @@ of these settings or provide values to mandatory fields.
   - **Type:** `string`
   - :red_circle: **Mandatory!**
 
+- **`CSRF_TRUSTED_ORIGINS`**:
+  - **Description:** a comma separated list of trusted origins for unsafe
+    requests (e.g. POST). Must include the schema, e.g:
+    `"https://example.com,https://example2.com"`. <https://docs.djangoproject.com/en/dev/ref/settings/#csrf-trusted-origins>
+  - **Type:** `string`
+  - **Default:** `""`
+
+- **`USE_X_FORWARDED_HOST`**:
+  - **Description:** a boolean that specifies whether to use the
+    X-Forwarded-Host header in preference to the Host header. This should only
+    be enabled if a proxy which sets this header is in use. <https://docs.djangoproject.com/en/dev/ref/settings/#use-x-forwarded-host>
+  - **Type:** `boolean`
+  - **Defalt:** `false`
+
 - **`TIME_ZONE`**:
   - **Description:** application time zone. See [TIME_ZONE] for more details.
   - **Type:** `string`

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -556,6 +556,15 @@ if CAS_AUTHENTICATION:
 
 ######### END CAS CONFIGURATION #########
 
+# Fetch the CSRF_TRUSTED_ORIGINS environment variable, split by comma, or default to an empty list
+CSRF_TRUSTED_ORIGINS = (
+    environ.get("CSRF_TRUSTED_ORIGINS").split(",")
+    if environ.get("CSRF_TRUSTED_ORIGINS", "").strip()
+    else []
+)
+
+USE_X_FORWARDED_HOST = is_true(environ.get("USE_X_FORWARDED_HOST", ""))
+
 OIDC_AUTHENTICATION = is_true(environ.get("SS_OIDC_AUTHENTICATION", ""))
 if OIDC_AUTHENTICATION:
     ALLOW_USER_EDITS = False


### PR DESCRIPTION
Make USE_X_FORWARDED_HOST and CSRF_TRUSTED_ORIGINS django settings configurable as environment variables.

Connects to https://github.com/archivematica/Issues/issues/1675