### PR TITLE
Use Ruff for Python linting and formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,52 +1,15 @@
 repos:
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.2
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.4.5
   hooks:
-  - id: pyupgrade
-    args: [--py38-plus]
-- repo: https://github.com/asottile/reorder_python_imports
-  rev: v3.12.0
-  hooks:
-  - id: reorder-python-imports
-    args: [--py38-plus]
+  - id: ruff
+    args: [--fix, --exit-non-zero-on-fix]
+  - id: ruff-format
 - repo: https://github.com/adamchainz/django-upgrade
   rev: "1.16.0"
   hooks:
   - id: django-upgrade
     args: [--target-version, "4.2"]
-- repo: https://github.com/psf/black
-  rev: "23.12.1"
-  hooks:
-  - id: black
-    args: [--safe, --quiet]
-- repo: https://github.com/pycqa/flake8
-  rev: "7.0.0"
-  hooks:
-  - id: flake8
-    additional_dependencies:
-    - flake8-bugbear==23.9.16
-    - flake8-comprehensions==3.14.0
-    exclude: |
-      (?x)^(
-        storage_service/storage_service/settings/.*\.py
-      )
-- repo: https://github.com/pycqa/flake8
-  # This is a temporary hook to port os.path code to pathlib gradually. Add
-  # the ported modules/packages explicitly to `files` below. For reference see
-  # https://github.com/archivematica/Issues/issues/1622#issuecomment-1912524642
-  rev: "7.0.0"
-  hooks:
-  - id: flake8
-    name: flake8-use-pathlib
-    args: [--select, "PL"]
-    additional_dependencies:
-    - flake8-use-pathlib==0.3.0
-    files: |
-      (?x)^(
-        storage_service/storage_service/settings/.*\.py |
-        storage_service/common/.*\.py |
-        tests/common/.*\.py
-      )
 - repo: https://github.com/pre-commit/mirrors-eslint
   rev: v8.56.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     args: [--fix, --exit-non-zero-on-fix]
   - id: ruff-format
 - repo: https://github.com/adamchainz/django-upgrade
-  rev: "1.16.0"
+  rev: "1.17.0"
   hooks:
   - id: django-upgrade
     args: [--target-version, "4.2"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,4 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
-  hooks:
-  - id: pretty-format-json
-    args: [--no-ensure-ascii, --autofix]
-    files: |
-      (?x)^(
-        osdeps/.*\.json
-      )
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.15.2
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - eslint-plugin-prettier@5.1.3
     - prettier@3.0.3
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.39.0
+  rev: v0.40.0
   hooks:
   - id: markdownlint
     exclude: |

--- a/install/make_key.py
+++ b/install/make_key.py
@@ -1,7 +1,6 @@
 import hashlib
 import os
 
-
 """
 - Update django secret key
 - syncdb

--- a/install/storage-service.gunicorn-config.py
+++ b/install/storage-service.gunicorn-config.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import tempfile
 
-
 # http://docs.gunicorn.org/en/stable/settings.html#user
 user = os.environ.get("SS_GUNICORN_USER", "archivematica")
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 [lint]
-select = ["B", "C4", "E", "F", "I", "PTH", "W"]
-ignore = ["B904", "E501"]
+select = ["B", "C4", "E", "F", "I", "PTH", "UP", "W"]
+ignore = ["B904", "E501", "UP031"]
 
 [lint.per-file-ignores]
 "{storage_service,tests}/locations/*" = ["PTH"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,6 @@
 [lint]
-select = ["I"]
+select = ["E", "I", "W"]
+ignore = ["E501"]
 
 [lint.isort]
 force-single-line = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,9 @@
 [lint]
-select = ["C4", "E", "F", "I", "W"]
+select = ["C4", "E", "F", "I", "PTH", "W"]
 ignore = ["E501"]
+
+[lint.per-file-ignores]
+"{storage_service,tests}/locations/*" = ["PTH"]
 
 [lint.isort]
 force-single-line = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+[lint]
+select = ["I"]
+
+[lint.isort]
+force-single-line = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,20 @@
 [lint]
-select = ["B", "C4", "E", "F", "I", "PTH", "UP", "W"]
-ignore = ["B904", "E501", "UP031"]
+# Rule reference: https://docs.astral.sh/ruff/rules/
+select = [
+  "B",
+  "C4",
+  "E",
+  "F",
+  "I",
+  "PTH",
+  "UP",
+  "W",
+]
+ignore = [
+  "B904",
+  "E501",
+  "UP031",
+]
 
 [lint.per-file-ignores]
 "{storage_service,tests}/locations/*" = ["PTH"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 [lint]
-select = ["E", "I", "W"]
+select = ["C4", "E", "I", "W"]
 ignore = ["E501"]
 
 [lint.isort]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 [lint]
-select = ["C4", "E", "I", "W"]
+select = ["C4", "E", "F", "I", "W"]
 ignore = ["E501"]
 
 [lint.isort]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 [lint]
-select = ["C4", "E", "F", "I", "PTH", "W"]
-ignore = ["E501"]
+select = ["B", "C4", "E", "F", "I", "PTH", "W"]
+ignore = ["B904", "E501"]
 
 [lint.per-file-ignores]
 "{storage_service,tests}/locations/*" = ["PTH"]

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@
 # along with archivematica-storage-service.  If not,
 # see <http://www.gnu.org/licenses/>.
 import codecs
-import os
+import pathlib
 import re
 
 from setuptools import setup
 
 
 def read(*parts):
-    path = os.path.join(os.path.dirname(__file__), *parts)
+    path = pathlib.Path(pathlib.Path(__file__).parent, *parts)
     with codecs.open(path, encoding="utf-8") as fobj:
         return fobj.read()
 

--- a/storage_service/administration/forms.py
+++ b/storage_service/administration/forms.py
@@ -19,12 +19,12 @@ class DefaultLocationWidget(forms.MultiWidget):
 
     def __init__(self, *args, **kwargs):
         widgets = [
-            forms.Select(choices=[], *args, **kwargs),  # space_id
+            forms.Select(*args, choices=[], **kwargs),  # space_id
             forms.TextInput(*args, **kwargs),  # relative_path
             forms.TextInput(*args, **kwargs),  # description
             forms.TextInput(*args, **kwargs),  # quota
         ]
-        super().__init__(widgets=widgets, *args, **kwargs)
+        super().__init__(*args, widgets=widgets, **kwargs)
 
     def set_space_id_choices(self, choices):
         self.widgets[0].choices += choices
@@ -52,13 +52,13 @@ class DefaultLocationField(forms.MultiValueField):
     """Field for entering required information to create a new location."""
 
     def __init__(self, *args, **kwargs):
-        space_id = forms.ChoiceField(choices=[], *args, **kwargs)
+        space_id = forms.ChoiceField(*args, choices=[], **kwargs)
         relative_path = forms.CharField(*args, **kwargs)
         description = forms.CharField(*args, **kwargs)
-        quota = forms.IntegerField(min_value=0, *args, **kwargs)
+        quota = forms.IntegerField(*args, min_value=0, **kwargs)
         fields = [space_id, relative_path, description, quota]
         widget = DefaultLocationWidget()
-        super().__init__(fields=fields, widget=widget, *args, **kwargs)
+        super().__init__(*args, fields=fields, widget=widget, **kwargs)
 
     def set_space_id_choices(self, choices):
         self.fields[0].choices += choices

--- a/storage_service/administration/forms.py
+++ b/storage_service/administration/forms.py
@@ -9,7 +9,6 @@ from locations.models import Space
 
 from . import roles
 
-
 # ######################## CUSTOM FIELDS/WIDGETS ##########################
 
 

--- a/storage_service/administration/roles.py
+++ b/storage_service/administration/roles.py
@@ -4,6 +4,7 @@ Every user in the system has a role. The role determines what the user can do.
 An administrator uses the `is_superuser` flag. Managers and reviewers are
 implemented as Django groups.
 """
+
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db import transaction

--- a/storage_service/administration/roles.py
+++ b/storage_service/administration/roles.py
@@ -10,7 +10,6 @@ from django.contrib.auth.models import Group
 from django.db import transaction
 from django.utils.translation import gettext as _
 
-
 # User roles codenames and labels used in this application.
 USER_ROLE_ADMIN = "admin"
 USER_ROLE_MANAGER = "manager"

--- a/storage_service/administration/urls.py
+++ b/storage_service/administration/urls.py
@@ -1,5 +1,6 @@
-from administration import views
 from django.urls import path
+
+from administration import views
 
 app_name = "administration"
 urlpatterns = [

--- a/storage_service/administration/views.py
+++ b/storage_service/administration/views.py
@@ -20,9 +20,9 @@ from locations.models import GPG
 from locations.models import Package
 from tastypie.models import ApiKey
 
-from . import forms as settings_forms
 from storage_service import __version__ as ss_version
 
+from . import forms as settings_forms
 
 LOGGER = logging.getLogger(__name__)
 

--- a/storage_service/common/apps.py
+++ b/storage_service/common/apps.py
@@ -3,7 +3,6 @@ from prometheus_client import Info
 
 from storage_service import __version__
 
-
 version_info = Info("version", "Archivematica Storage Service version info")
 
 

--- a/storage_service/common/gpgutils.py
+++ b/storage_service/common/gpgutils.py
@@ -7,6 +7,7 @@ needed by both the GPG space and the administration view which can be used to
 manage (i.e., list, created, import, delete) GPG keys.
 
 """
+
 import logging
 from pathlib import Path
 from shutil import which

--- a/storage_service/common/management/commands/create_aip_replicas.py
+++ b/storage_service/common/management/commands/create_aip_replicas.py
@@ -15,9 +15,10 @@ Execution example:
 import logging
 
 from administration.models import Settings
-from common.management.commands import StorageServiceCommand
 from django.core.management.base import CommandError
 from locations.models.package import Package
+
+from common.management.commands import StorageServiceCommand
 
 # Suppress the logging from models/package.py.
 logging.config.dictConfig({"version": 1, "disable_existing_loggers": True})

--- a/storage_service/common/management/commands/create_aip_replicas.py
+++ b/storage_service/common/management/commands/create_aip_replicas.py
@@ -11,6 +11,7 @@ location.
 Execution example:
 ./manage.py create_aip_replicas --location <UUID>
 """
+
 import logging
 
 from administration.models import Settings

--- a/storage_service/common/management/commands/create_aip_replicas.py
+++ b/storage_service/common/management/commands/create_aip_replicas.py
@@ -126,10 +126,8 @@ class Command(StorageServiceCommand):
             success_count += 1
 
         self.success(
-            "Replica creation complete. {} existing replicas deleted. "
-            "New replicas created for {} of {} AIPs in location.".format(
-                deleted_count, success_count, aips_count
-            )
+            f"Replica creation complete. {deleted_count} existing replicas deleted. "
+            f"New replicas created for {success_count} of {aips_count} AIPs in location."
         )
 
     def _delete_replicas(self, aip_uuid, replicator_uuid):
@@ -155,9 +153,7 @@ class Command(StorageServiceCommand):
                 deleted_count += 1
             except ReplicaDeleteException as err:
                 self.error(
-                    "Unable to delete existing replica {} of AIP {}: {}".format(
-                        replica.uuid, aip_uuid, err
-                    )
+                    f"Unable to delete existing replica {replica.uuid} of AIP {aip_uuid}: {err}"
                 )
         return deleted_count
 

--- a/storage_service/common/management/commands/import_aip.py
+++ b/storage_service/common/management/commands/import_aip.py
@@ -43,6 +43,7 @@ via a pipeline? Should this be fixed by the import command?::
     -rwxrwxr-x  1 joeldunham  wheel    51M 30 Jul 22:58 /tmp/am-pipeline-data/www/AIPsStore/237e/12b4/03c9/451a/9be7/4915/b0bd/9012/FakeCVA2-237e12b4-03c9-451a-9be7-4915b0bd9012.7z
 
 """
+
 import logging
 import os
 import pathlib

--- a/storage_service/common/management/commands/import_aip.py
+++ b/storage_service/common/management/commands/import_aip.py
@@ -116,7 +116,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--unix-owner",
             help="The Unix system user that should own the file(s) of the"
-            " imported AIP. Default: {}".format(DEFAULT_UNIX_OWNER),
+            f" imported AIP. Default: {DEFAULT_UNIX_OWNER}",
             default=DEFAULT_UNIX_OWNER,
         )
         parser.add_argument(
@@ -271,9 +271,7 @@ def get_aip_storage_locations(aip_storage_location_uuid):
         final_as_location = models.Location.objects.get(uuid=aip_storage_location_uuid)
     except models.Location.DoesNotExist:
         raise ImportAIPException(
-            "Unable to find an AIP storage location matching {}.".format(
-                aip_storage_location_uuid
-            )
+            f"Unable to find an AIP storage location matching {aip_storage_location_uuid}."
         )
     else:
         if final_as_location.space.access_protocol != models.Space.LOCAL_FILESYSTEM:
@@ -309,9 +307,7 @@ def copy_aip_to_aip_storage_location(
     fix_ownership(dest, unix_owner)
     print(
         okgreen(
-            "Location: {} ({}).".format(
-                local_as_location.uuid, local_as_location.space.access_protocol
-            )
+            f"Location: {local_as_location.uuid} ({local_as_location.space.access_protocol})."
         )
     )
 
@@ -364,9 +360,9 @@ def check_if_aip_already_exists(aip_uuid):
     duplicates = models.Package.objects.filter(uuid=aip_uuid).all()
     if duplicates:
         prompt = warning(
-            "An AIP with UUID {} already exists in this Storage Service? If you"
+            f"An AIP with UUID {aip_uuid} already exists in this Storage Service? If you"
             " want to import this AIP anyway (and destroy the existing one),"
-            ' then enter "y" or "yes": '.format(aip_uuid)
+            ' then enter "y" or "yes": '
         )
         user_response = input(prompt)
         if user_response.lower() not in ("y", "yes"):

--- a/storage_service/common/management/commands/import_aip.py
+++ b/storage_service/common/management/commands/import_aip.py
@@ -57,12 +57,12 @@ from pwd import getpwnam
 
 import bagit
 from administration.models import Settings
-from common import premis
-from common import utils
 from django.core.management.base import BaseCommand
 from django.db.utils import IntegrityError
 from locations import models
 
+from common import premis
+from common import utils
 
 # Suppress the logging from models/package.py
 logging.config.dictConfig({"version": 1, "disable_existing_loggers": True})

--- a/storage_service/common/management/commands/populate_aip_checksums.py
+++ b/storage_service/common/management/commands/populate_aip_checksums.py
@@ -16,11 +16,12 @@ Execution example:
 
 import pathlib
 
-from common import utils
-from common.management.commands import StorageServiceCommand
 from django.core.management.base import CommandError
 from locations.models.package import Package
 from locations.models.package import Space
+
+from common import utils
+from common.management.commands import StorageServiceCommand
 
 
 class Command(StorageServiceCommand):

--- a/storage_service/common/management/commands/populate_aip_checksums.py
+++ b/storage_service/common/management/commands/populate_aip_checksums.py
@@ -93,9 +93,7 @@ class Command(StorageServiceCommand):
             )
             if checksum is None:
                 self.error(
-                    "Unable to retrieve checksum information from pointer file for compressed AIP {}".format(
-                        aip.uuid
-                    )
+                    f"Unable to retrieve checksum information from pointer file for compressed AIP {aip.uuid}"
                 )
                 error_count += 1
                 continue
@@ -104,9 +102,7 @@ class Command(StorageServiceCommand):
             aip.checksum_algorithm = checksum_algorithm
             aip.save()
             self.info(
-                "AIP {} updated with {} checksum {}".format(
-                    aip.uuid, aip.checksum_algorithm, aip.checksum
-                )
+                f"AIP {aip.uuid} updated with {aip.checksum_algorithm} checksum {aip.checksum}"
             )
             success_count += 1
 
@@ -119,9 +115,7 @@ class Command(StorageServiceCommand):
             ).hexdigest()
             if checksum is None:
                 self.error(
-                    "Unable to calculate tagmanifest checksum for uncompressed AIP {}".format(
-                        aip.uuid
-                    )
+                    f"Unable to calculate tagmanifest checksum for uncompressed AIP {aip.uuid}"
                 )
                 error_count += 1
                 continue
@@ -130,9 +124,7 @@ class Command(StorageServiceCommand):
             aip.checksum_algorithm = Package.DEFAULT_CHECKSUM_ALGORITHM
             aip.save()
             self.info(
-                "AIP {} updated with {} checksum {}".format(
-                    aip.uuid, aip.checksum_algorithm, aip.checksum
-                )
+                f"AIP {aip.uuid} updated with {aip.checksum_algorithm} checksum {aip.checksum}"
             )
             success_count += 1
 
@@ -140,13 +132,9 @@ class Command(StorageServiceCommand):
             self.info("Complete. No matching AIPs identified.")
         elif success_count == total_aip_count:
             self.info(
-                "Complete. Checksums added for all {} identified AIPs.".format(
-                    total_aip_count
-                )
+                f"Complete. Checksums added for all {total_aip_count} identified AIPs."
             )
         else:
             self.info(
-                "Complete. Checksums added for {} of {} identified AIPs. See output for details.".format(
-                    success_count, total_aip_count
-                )
+                f"Complete. Checksums added for {success_count} of {total_aip_count} identified AIPs. See output for details."
             )

--- a/storage_service/common/management/commands/populate_aip_checksums.py
+++ b/storage_service/common/management/commands/populate_aip_checksums.py
@@ -13,6 +13,7 @@ have the Package.checksum and Package.checksum_algorithm fields populated.
 Execution example:
 ./manage.py populate_aip_checksums
 """
+
 import pathlib
 
 from common import utils

--- a/storage_service/common/management/commands/populate_aip_stored_dates.py
+++ b/storage_service/common/management/commands/populate_aip_stored_dates.py
@@ -10,7 +10,7 @@ Execution example:
 """
 
 import logging
-import os
+import pathlib
 from datetime import datetime
 
 from django.core.management.base import CommandError
@@ -63,8 +63,8 @@ class Command(StorageServiceCommand):
                 continue
 
             try:
-                modified_unix = os.path.getmtime(aip.full_path)
-            except OSError as err:
+                modified_unix = pathlib.Path(aip.full_path).stat().st_mtime
+            except (TypeError, FileNotFoundError) as err:
                 self.error(
                     "Unable to get timestamp for local AIP {}. Details: {}".format(
                         aip.uuid, err

--- a/storage_service/common/management/commands/populate_aip_stored_dates.py
+++ b/storage_service/common/management/commands/populate_aip_stored_dates.py
@@ -8,6 +8,7 @@ AIPs that already have timestamps are ignored and not updated.
 Execution example:
 ./manage.py populate_aip_stored_dates
 """
+
 import logging
 import os
 from datetime import datetime

--- a/storage_service/common/management/commands/populate_aip_stored_dates.py
+++ b/storage_service/common/management/commands/populate_aip_stored_dates.py
@@ -66,9 +66,7 @@ class Command(StorageServiceCommand):
                 modified_unix = pathlib.Path(aip.full_path).stat().st_mtime
             except (TypeError, FileNotFoundError) as err:
                 self.error(
-                    "Unable to get timestamp for local AIP {}. Details: {}".format(
-                        aip.uuid, err
-                    )
+                    f"Unable to get timestamp for local AIP {aip.uuid}. Details: {err}"
                 )
                 continue
 
@@ -80,13 +78,9 @@ class Command(StorageServiceCommand):
             self.success("Complete. No matching AIPs found.")
         elif skipped_count == aip_count:
             self.success(
-                "Complete. All {} AIPs that already have stored_dates skipped.".format(
-                    aip_count
-                )
+                f"Complete. All {aip_count} AIPs that already have stored_dates skipped."
             )
         else:
             self.success(
-                "Complete. Datestamps for {} of {} identified AIPs added. {} AIPs that already have stored_dates were skipped.".format(
-                    success_count, aip_count, skipped_count
-                )
+                f"Complete. Datestamps for {success_count} of {aip_count} identified AIPs added. {skipped_count} AIPs that already have stored_dates were skipped."
             )

--- a/storage_service/common/management/commands/populate_aip_stored_dates.py
+++ b/storage_service/common/management/commands/populate_aip_stored_dates.py
@@ -13,11 +13,12 @@ import logging
 import os
 from datetime import datetime
 
-from common.management.commands import StorageServiceCommand
 from django.core.management.base import CommandError
 from django.utils.timezone import get_current_timezone
 from locations.models.package import Package
 from locations.models.package import Space
+
+from common.management.commands import StorageServiceCommand
 
 # Suppress the logging from models/package.py.
 logging.config.dictConfig({"version": 1, "disable_existing_loggers": True})

--- a/storage_service/common/middleware.py
+++ b/storage_service/common/middleware.py
@@ -50,9 +50,7 @@ class LoginRequiredMiddleware(MiddlewareMixin):
         if not request.user.is_authenticated:
             path = request.path_info.lstrip("/")
             if not any(m.match(path) for m in EXEMPT_URLS):
-                fullURL = "{}?next={}".format(
-                    settings.LOGIN_URL, quote(request.get_full_path())
-                )
+                fullURL = f"{settings.LOGIN_URL}?next={quote(request.get_full_path())}"
                 return HttpResponseRedirect(fullURL)
 
 

--- a/storage_service/common/middleware.py
+++ b/storage_service/common/middleware.py
@@ -7,7 +7,6 @@ from django.http import HttpResponseRedirect
 from django.utils.deprecation import MiddlewareMixin
 from shibboleth.middleware import ShibbolethRemoteUserMiddleware
 
-
 # Login required code from https://gist.github.com/ryanwitt/130583
 # With modifications from comments on
 # http://onecreativeblog.com/post/59051248/django-login-required-middleware

--- a/storage_service/common/middleware.py
+++ b/storage_service/common/middleware.py
@@ -42,9 +42,7 @@ class LoginRequiredMiddleware(MiddlewareMixin):
     """
 
     def process_request(self, request):
-        assert hasattr(
-            request, "user"
-        ), "The Login Required middleware\
+        assert hasattr(request, "user"), "The Login Required middleware\
  requires authentication middleware to be installed. Edit your\
  MIDDLEWARE setting to insert\
  'django.contrib.auth.middlware.AuthenticationMiddleware'. If that doesn't\

--- a/storage_service/common/premis.py
+++ b/storage_service/common/premis.py
@@ -5,11 +5,10 @@ PREMIS metadata generation.
 import uuid
 
 import metsrw
-from common import utils
 from django.utils import timezone
 
+from common import utils
 from storage_service import __version__ as ss_version
-
 
 PREMIS_META = metsrw.plugins.premisrw.PREMIS_3_0_META
 SS_AGENT = metsrw.plugins.premisrw.PREMISAgent(

--- a/storage_service/common/premis.py
+++ b/storage_service/common/premis.py
@@ -55,8 +55,8 @@ def create_replication_event(
 ):
     """Return a PREMISEvent for replication of an AIP."""
     outcome_detail_note = (
-        "Replicated Archival Information Package (AIP) {} by creating"
-        " replica {}.".format(original_package_uuid, replica_package_uuid)
+        f"Replicated Archival Information Package (AIP) {original_package_uuid} by creating"
+        f" replica {replica_package_uuid}."
     )
     if not agents:
         agents = [SS_AGENT]
@@ -96,12 +96,12 @@ def create_premis_aip_creation_event(
     """Return a PREMISEvent for creation of an AIP."""
     if master_aip_uuid:
         outcome_detail_note = (
-            "Created Archival Information Package (AIP) {} by replicating"
-            " previously created AIP {}".format(package_uuid, master_aip_uuid)
+            f"Created Archival Information Package (AIP) {package_uuid} by replicating"
+            f" previously created AIP {master_aip_uuid}"
         )
     else:
-        outcome_detail_note = "Created Archival Information Package (AIP) {}".format(
-            package_uuid
+        outcome_detail_note = (
+            f"Created Archival Information Package (AIP) {package_uuid}"
         )
     if not agents:
         agents = [SS_AGENT]
@@ -180,9 +180,7 @@ def create_replication_validation_event(
     outcome = success and "success" or "failure"
     detail = (
         "Validated the replication of Archival Information Package (AIP)"
-        " {master_aip_uuid} to replica AIP {replica_aip_uuid}".format(
-            master_aip_uuid=master_aip_uuid, replica_aip_uuid=replica_package_uuid
-        )
+        f" {master_aip_uuid} to replica AIP {replica_package_uuid}"
     )
     if fixity_report:
         detail += " by performing a BagIt fixity check and by comparing" " checksums"

--- a/storage_service/common/premis.py
+++ b/storage_service/common/premis.py
@@ -1,6 +1,7 @@
 """
 PREMIS metadata generation.
 """
+
 import uuid
 
 import metsrw

--- a/storage_service/common/signals.py
+++ b/storage_service/common/signals.py
@@ -8,7 +8,6 @@ from django.dispatch import receiver
 from django_auth_ldap.backend import populate_user
 from django_cas_ng.signals import cas_user_authenticated
 
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/storage_service/common/startup.py
+++ b/storage_service/common/startup.py
@@ -4,11 +4,11 @@ import os
 import pathlib
 
 import django.core.exceptions
-from common import utils
 from django.db import connection
 from locations import models as locations_models
 from locations.models.async_manager import start_async_manager
 
+from common import utils
 
 LOGGER = logging.getLogger(__name__)
 

--- a/storage_service/common/templatetags/user.py
+++ b/storage_service/common/templatetags/user.py
@@ -1,7 +1,6 @@
 from django import template
 from django.urls import reverse
 
-
 register = template.Library()
 
 

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -271,9 +271,7 @@ def mets_ss_agent(xml, digiprov_id, agent_value=None, agent_type="storage servic
     if agent_value is None:
         agent_value = _storage_service_agent()
     existing_agent = xml.xpath(
-        ".//mets:agentIdentifier[mets:agentIdentifierType='{}' and mets:agentIdentifierValue='{}']".format(
-            agent_type, agent_value
-        ),
+        f".//mets:agentIdentifier[mets:agentIdentifierType='{agent_type}' and mets:agentIdentifierValue='{agent_value}']",
         namespaces=NSMAP,
     )
     if existing_agent:
@@ -443,8 +441,8 @@ def get_tool_info_command(compression):
 
         tool_info_command = (
             'echo program="tar"\\; '
-            'algorithm="{}"\\; '
-            'version="`tar --version | grep tar`"'.format(algo)
+            f'algorithm="{algo}"\\; '
+            'version="`tar --version | grep tar`"'
         )
     elif compression in (COMPRESSION_7Z_BZIP, COMPRESSION_7Z_LZMA, COMPRESSION_7Z_COPY):
         algo = {
@@ -455,8 +453,8 @@ def get_tool_info_command(compression):
         tool_info_command = (
             "#!/bin/bash\n"
             'echo program="7z"\\; '
-            'algorithm="{}"\\; '
-            'version="`7z | grep Version`"'.format(algo)
+            f'algorithm="{algo}"\\; '
+            'version="`7z | grep Version`"'
         )
     else:
         raise NotImplementedError(
@@ -606,9 +604,7 @@ def create_tar(path, extension=False):
     LOGGER.info(
         "creating archive of %s at %s, relative to %s", source, tarpath, changedir
     )
-    fail_msg = "Failed to create a tarfile at {tarpath} for dir at {path}".format(
-        tarpath=tarpath, path=path
-    )
+    fail_msg = f"Failed to create a tarfile at {tarpath} for dir at {path}"
     try:
         subprocess.check_output(cmd)
     except (OSError, subprocess.CalledProcessError):

--- a/storage_service/locations/admin.py
+++ b/storage_service/locations/admin.py
@@ -1,9 +1,9 @@
 from django.contrib import admin
 
+from .models import NFS
 from .models import Event
 from .models import LocalFilesystem
 from .models import Location
-from .models import NFS
 from .models import Package
 from .models import Pipeline
 from .models import Space

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -1769,9 +1769,7 @@ class PackageResource(ModelResource):
         or package deletion: DEL_REQ.
         """
         LOGGER.info(
-            "Package event: '{}' requested, with package status: '{}'".format(
-                event_type, event_status
-            )
+            f"Package event: '{event_type}' requested, with package status: '{event_status}'"
         )
         LOGGER.debug(pprint.pformat(request_info))
 

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -22,8 +22,6 @@ from django.http import HttpResponseRedirect
 from django.urls import re_path
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from locations import signals
-from locations.api.sword import views as sword_views
 from tastypie import fields
 from tastypie import http
 from tastypie.authentication import ApiKeyAuthentication
@@ -36,6 +34,9 @@ from tastypie.resources import ALL_WITH_RELATIONS
 from tastypie.resources import ModelResource
 from tastypie.utils import trailing_slash
 from tastypie.validation import CleanedDataFormValidation
+
+from locations import signals
+from locations.api.sword import views as sword_views
 
 from ..constants import PROTOCOL
 from ..forms import SpaceForm
@@ -52,7 +53,6 @@ from ..models import PosixMoveUnsupportedError
 from ..models import Space
 from ..models import StorageException
 from ..models.async_manager import AsyncManager
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/storage_service/locations/api/sword/helpers.py
+++ b/storage_service/locations/api/sword/helpers.py
@@ -13,9 +13,9 @@ from django.http import HttpResponse
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.translation import gettext as _
+
 from locations import models
 from locations.models.async_manager import AsyncManager
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/storage_service/locations/api/sword/views.py
+++ b/storage_service/locations/api/sword/views.py
@@ -9,8 +9,9 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext as _
-from locations import models
 from lxml import etree as etree
+
+from locations import models
 
 from . import helpers
 

--- a/storage_service/locations/api/urls.py
+++ b/storage_service/locations/api/urls.py
@@ -1,9 +1,10 @@
 from django.urls import include
 from django.urls import path
+from tastypie.api import Api
+
 from locations.api import v1
 from locations.api import v2
 from locations.api.sword import views
-from tastypie.api import Api
 
 v1_api = Api(api_name="v1")
 v1_api.register(v1.SpaceResource())

--- a/storage_service/locations/api/v1.py
+++ b/storage_service/locations/api/v1.py
@@ -1,5 +1,6 @@
-import locations.api.resources as resources
 from tastypie import fields
+
+import locations.api.resources as resources
 
 
 class PipelineResource(resources.PipelineResource):

--- a/storage_service/locations/api/v2.py
+++ b/storage_service/locations/api/v2.py
@@ -1,7 +1,8 @@
 import base64
 
-import locations.api.resources as resources
 from tastypie import fields
+
+import locations.api.resources as resources
 
 
 def b64encode_string(data):

--- a/storage_service/locations/datatable_utils.py
+++ b/storage_service/locations/datatable_utils.py
@@ -7,6 +7,7 @@ service (in the Packages and the Location detail views).
 The request and response details are documented in:
 http://legacy.datatables.net/usage/server-side
 """
+
 import os
 import uuid
 

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -8,8 +8,8 @@ from common import gpgutils
 from django import forms
 from django.db.models import Count
 from django.utils.translation import gettext_lazy as _
-from locations import models
 
+from locations import models
 
 LOGGER = logging.getLogger(__name__)
 

--- a/storage_service/locations/metrics.py
+++ b/storage_service/locations/metrics.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from prometheus_client import Counter
 from prometheus_client import Gauge
 
-
 async_manager_running_tasks = Gauge(
     "async_manager_running_tasks",
     "Number of tasks being executed",

--- a/storage_service/locations/migrations/0001_initial.py
+++ b/storage_service/locations/migrations/0001_initial.py
@@ -1,10 +1,11 @@
 import uuid
 
 import common.fields
-import locations.models
 from django.conf import settings
 from django.db import migrations
 from django.db import models
+
+import locations.models
 
 
 class Migration(migrations.Migration):

--- a/storage_service/locations/migrations/0002_v0_4.py
+++ b/storage_service/locations/migrations/0002_v0_4.py
@@ -1,7 +1,8 @@
 import jsonfield.fields
-import locations.models
 from django.db import migrations
 from django.db import models
+
+import locations.models
 
 
 class Migration(migrations.Migration):

--- a/storage_service/locations/migrations/0014_verbose_field_names.py
+++ b/storage_service/locations/migrations/0014_verbose_field_names.py
@@ -1,7 +1,8 @@
 import common.fields
-import locations.models.space
 from django.db import migrations
 from django.db import models
+
+import locations.models.space
 
 
 class Migration(migrations.Migration):

--- a/storage_service/locations/migrations/0027_update_default_transfer_source_description.py
+++ b/storage_service/locations/migrations/0027_update_default_transfer_source_description.py
@@ -1,4 +1,5 @@
 """Add description to default transfer source location."""
+
 import ast
 
 from django.db import migrations

--- a/storage_service/locations/migrations/0027_update_default_transfer_source_description.py
+++ b/storage_service/locations/migrations/0027_update_default_transfer_source_description.py
@@ -3,6 +3,7 @@
 import ast
 
 from django.db import migrations
+
 from locations.models import Location
 
 # We can't use apps.get_model for this model as we need to access class

--- a/storage_service/locations/migrations/0028_offline_replica_space.py
+++ b/storage_service/locations/migrations/0028_offline_replica_space.py
@@ -1,4 +1,5 @@
 """Migration to add an Offline Replica Staging Space to the Storage Service."""
+
 import django.db.models.deletion
 from django.db import migrations
 from django.db import models

--- a/storage_service/locations/migrations/0030_user_groups.py
+++ b/storage_service/locations/migrations/0030_user_groups.py
@@ -7,6 +7,7 @@ like regular authenticated users, i.e. they can read and list records, with an
 extra `locations.approve_package_deletion` permission that allows them to
 accept/reject package deletion requests.
 """
+
 from django.contrib.auth.management import create_permissions
 from django.db import migrations
 

--- a/storage_service/locations/models/archipelago.py
+++ b/storage_service/locations/models/archipelago.py
@@ -145,9 +145,7 @@ class Archipelago(models.Model):
                 return mets_el
             except subprocess.CalledProcessError as err:
                 raise Exception(
-                    "Could not extract {} from {}: {}.".format(
-                        mets_path, input_path, err
-                    )
+                    f"Could not extract {mets_path} from {input_path}: {err}."
                 )
 
     def _get_metadata(self, input_path, aip_uuid, package_type):

--- a/storage_service/locations/models/arkivum.py
+++ b/storage_service/locations/models/arkivum.py
@@ -82,9 +82,7 @@ class Arkivum(models.Model):
         # Get from watched dir
         if self.remote_user and self.remote_name:
             # Rsync from remote
-            src_path = "{user}@{host}:{path}".format(
-                user=self.remote_user, host=self.remote_name, path=src_path
-            )
+            src_path = f"{self.remote_user}@{self.remote_name}:{src_path}"
         self.space.create_local_directory(dest_path)
         self.space.move_rsync(src_path, dest_path)
 
@@ -96,9 +94,7 @@ class Arkivum(models.Model):
             self.space.create_rsync_directory(
                 destination_path, self.remote_user, self.remote_name
             )
-            rsync_dest = "{}@{}:{}".format(
-                self.remote_user, self.remote_name, destination_path
-            )
+            rsync_dest = f"{self.remote_user}@{self.remote_name}:{destination_path}"
         else:
             rsync_dest = destination_path
             self.space.create_local_directory(destination_path)

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -159,9 +159,7 @@ class Dataverse(URLMixin, models.Model):
         ``dataset_identifier`` (conforming to ``browse`` protocol).
         """
         files_in_dataset_path = (
-            "/api/v1/datasets/{dataset_identifier}/versions/:latest".format(
-                dataset_identifier=dataset_identifier
-            )
+            f"/api/v1/datasets/{dataset_identifier}/versions/:latest"
         )
         url = self._generate_dataverse_url(slug=files_in_dataset_path)
         params = {"key": self.api_key, "sort": "name", "order": "asc"}

--- a/storage_service/locations/models/dspace.py
+++ b/storage_service/locations/models/dspace.py
@@ -79,7 +79,7 @@ class DSpace(models.Model):
     ALLOWED_LOCATION_PURPOSE = [Location.AIP_STORAGE]
 
     def __str__(self):
-        return "space: {s.space_id}; sd_iri: {s.sd_iri}; user: {s.user}".format(s=self)
+        return f"space: {self.space_id}; sd_iri: {self.sd_iri}; user: {self.user}"
 
     def _get_sword_connection(self):
         if self.sword_connection is None:

--- a/storage_service/locations/models/dspace.py
+++ b/storage_service/locations/models/dspace.py
@@ -4,6 +4,7 @@ Integration with DSpace, using SWORD2 as the protocol.
 Space path can be left empty, and the Location path should be the collection's
 IRI.
 """
+
 import logging
 import mimetypes
 import os
@@ -90,7 +91,7 @@ class DSpace(models.Model):
                 user_pass=self.password,
                 keep_history=False,
                 cache_deposit_receipts=False,
-                http_impl=sword2.http_layer.HttpLib2Layer(cache_dir=None)
+                http_impl=sword2.http_layer.HttpLib2Layer(cache_dir=None),
                 # http_impl=sword2.http_layer.UrlLib2Layer(),  # This causes the deposit receipt to return the wrong URLs
             )
             LOGGER.debug("Getting service document")

--- a/storage_service/locations/models/dspace_rest.py
+++ b/storage_service/locations/models/dspace_rest.py
@@ -22,7 +22,6 @@ from requests import RequestException
 
 from .location import Location
 
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/storage_service/locations/models/dspace_rest.py
+++ b/storage_service/locations/models/dspace_rest.py
@@ -2,6 +2,7 @@
 Integration with DSpace, using REST API as the protocol.
 
 """
+
 import json
 import logging
 import os

--- a/storage_service/locations/models/gpg.py
+++ b/storage_service/locations/models/gpg.py
@@ -14,7 +14,6 @@ from . import space
 from .location import Location
 from .package import Package
 
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/storage_service/locations/models/lockssomatic.py
+++ b/storage_service/locations/models/lockssomatic.py
@@ -15,7 +15,6 @@ from lxml import etree
 from .location import Location
 from .package import Package
 
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/storage_service/locations/models/lockssomatic.py
+++ b/storage_service/locations/models/lockssomatic.py
@@ -506,9 +506,7 @@ class Lockssomatic(models.Model):
             amdsec,
             event_type="division",
             event_detail=event_detail,
-            event_outcome_detail_note="{} LOCKSS chunks created".format(
-                len(output_files)
-            ),
+            event_outcome_detail_note=f"{len(output_files)} LOCKSS chunks created",
         )
 
         # Update structMap & fileSec
@@ -672,9 +670,7 @@ class Lockssomatic(models.Model):
 
             # Get checksum and size from pointer file (or generate if not found)
             file_e = self.pointer_root.find(
-                ".//mets:fileGrp[@USE='LOCKSS chunk']/mets:file[@ID='{}']".format(
-                    os.path.basename(file_path)
-                ),
+                f".//mets:fileGrp[@USE='LOCKSS chunk']/mets:file[@ID='{os.path.basename(file_path)}']",
                 namespaces=utils.NSMAP,
             )
             if file_e is not None:

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -1,5 +1,6 @@
 import codecs
 import copy
+import distutils.dir_util
 import json
 import logging
 import os
@@ -12,7 +13,6 @@ from pathlib import Path
 from uuid import uuid4
 
 import bagit
-import distutils.dir_util
 import importlib_resources
 import jsonfield
 import metsrw
@@ -24,9 +24,10 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from locations import signals
 from lxml import etree
 from metsrw.plugins import premisrw
+
+from locations import signals
 
 from . import StorageException
 from .event import Callback
@@ -36,7 +37,6 @@ from .fixity_log import FixityLog
 from .location import Location
 from .space import PosixMoveUnsupportedError
 from .space import Space
-
 
 __all__ = ("Package",)
 

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -387,9 +387,7 @@ class Package(models.Model):
                     LOGGER.debug(f"Deleted Storage Service internal tempdir: {tempdir}")
                 except OSError as err:
                     LOGGER.debug(
-                        "Error deleting Storage Service internal tempdir: {}".format(
-                            err
-                        )
+                        f"Error deleting Storage Service internal tempdir: {err}"
                     )
 
     def get_base_directory(self):
@@ -1998,9 +1996,7 @@ class Package(models.Model):
                     self.uuid,
                     self.checksum,
                 )
-                failure = "Expected package checksum {}; calculated {} instead".format(
-                    self.checksum, checksum
-                )
+                failure = f"Expected package checksum {self.checksum}; calculated {checksum} instead"
                 return (False, [failure], _("Incorrect package checksum"), None)
             if self.is_compressed:
                 return (True, [], "", None)
@@ -2227,9 +2223,7 @@ class Package(models.Model):
             return {
                 "error": True,
                 "status_code": 405,
-                "message": "Package with type {} cannot be re-ingested.".format(
-                    self.get_package_type_display()
-                ),
+                "message": f"Package with type {self.get_package_type_display()} cannot be re-ingested.",
             }
 
         # Check and set reingest pipeline
@@ -2563,8 +2557,8 @@ class Package(models.Model):
                         "copy": utils.COMPRESSION_7Z_COPY,
                     }[compression_algorithm]
                     LOGGER.info(
-                        'Extracted compression "{}" from AM-passed'
-                        " PREMIS events".format(compression)
+                        f'Extracted compression "{compression}" from AM-passed'
+                        " PREMIS events"
                     )
                 except KeyError:
                     msg = (
@@ -3174,26 +3168,15 @@ def _get_checksum_report(
     success = replica_checksum == master_checksum
     if success:
         message = (
-            "Master AIP {m_uuid} and replica AIP {r_uuid} both"
-            " have checksum {checksum} when using algorithm"
-            " {algorithm}.".format(
-                m_uuid=master_uuid,
-                r_uuid=replica_uuid,
-                checksum=master_checksum,
-                algorithm=algorithm,
-            )
+            f"Master AIP {master_uuid} and replica AIP {replica_uuid} both"
+            f" have checksum {master_checksum} when using algorithm"
+            f" {algorithm}."
         )
     else:
         message = (
-            "Using algorithm {algorithm}, master AIP {m_uuid}"
-            " has checksum {m_checksum} while replica AIP"
-            " {r_uuid} has checksum {r_checksum}.".format(
-                m_uuid=master_uuid,
-                r_uuid=replica_uuid,
-                m_checksum=master_checksum,
-                r_checksum=replica_checksum,
-                algorithm=algorithm,
-            )
+            f"Using algorithm {algorithm}, master AIP {master_uuid}"
+            f" has checksum {master_checksum} while replica AIP"
+            f" {replica_uuid} has checksum {replica_checksum}."
         )
     return {"success": success, "message": message}
 

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -297,9 +297,7 @@ class Package(models.Model):
         try:
             return FixityLog.objects.filter(package=self).order_by(
                 "-datetime_reported"
-            )[
-                0
-            ]  # limit 1
+            )[0]  # limit 1
         except IndexError:
             return None
 

--- a/storage_service/locations/models/pipeline.py
+++ b/storage_service/locations/models/pipeline.py
@@ -148,8 +148,8 @@ class Pipeline(URLMixin, models.Model):
         ]
         for p in purposes:
             defaults = utils.get_setting(p["default"], [])
-            for uuid in defaults:
-                if uuid == "new":
+            for location_uuid in defaults:
+                if location_uuid == "new":
                     # Create new location
                     new_location = utils.get_setting(p["new"])
                     location = Location.objects.create(
@@ -157,7 +157,7 @@ class Pipeline(URLMixin, models.Model):
                     )
                 else:
                     # Fetch existing location
-                    location = Location.objects.get(uuid=uuid)
+                    location = Location.objects.get(uuid=location_uuid)
                     assert location.purpose == p["purpose"]
                 location.default = True
                 location.save()

--- a/storage_service/locations/models/pipeline.py
+++ b/storage_service/locations/models/pipeline.py
@@ -15,7 +15,6 @@ from .managers import Enabled
 from .space import Space
 from .urlmixin import URLMixin
 
-
 __all__ = ("Pipeline",)
 
 LOGGER = logging.getLogger(__name__)

--- a/storage_service/locations/models/rclone.py
+++ b/storage_service/locations/models/rclone.py
@@ -80,9 +80,7 @@ class RClone(models.Model):
                 if proc.returncode in self.RETRIABLE_EXIT_CODES:
                     attempt += 1
                     if attempt >= self.MAX_RETRIES:
-                        err_msg = "rclone failed to succesfully run command after {} attempts".format(
-                            self.MAX_RETRIES
-                        )
+                        err_msg = f"rclone failed to succesfully run command after {self.MAX_RETRIES} attempts"
                         LOGGER.error(err_msg)
                         raise StorageException(err_msg)
 
@@ -104,9 +102,7 @@ class RClone(models.Model):
                 LOGGER.error(err_msg)
                 raise StorageException(err_msg)
             except Exception as err:
-                err_msg = "Error running rclone command. Command called: {}. Details: {}".format(
-                    cmd, err
-                )
+                err_msg = f"Error running rclone command. Command called: {cmd}. Details: {err}"
                 LOGGER.error(err_msg)
                 raise StorageException(err_msg)
 
@@ -138,8 +134,8 @@ class RClone(models.Model):
             try:
                 self._execute_rclone_subcommand(create_container_cmd)
             except StorageException:
-                err_msg = "Unable to find or create container {}".format(
-                    prefixed_container_name
+                err_msg = (
+                    f"Unable to find or create container {prefixed_container_name}"
                 )
                 LOGGER.error(err_msg)
                 raise StorageException(err_msg)
@@ -195,9 +191,7 @@ class RClone(models.Model):
         """Delete package."""
         if delete_path.startswith(os.sep):
             LOGGER.info(
-                "Rclone path to delete {} begins with {}; removing from path prior to deletion".format(
-                    delete_path, os.sep
-                )
+                f"Rclone path to delete {delete_path} begins with {os.sep}; removing from path prior to deletion"
             )
             delete_path = delete_path.lstrip(os.sep)
 

--- a/storage_service/locations/models/replica_staging.py
+++ b/storage_service/locations/models/replica_staging.py
@@ -93,7 +93,5 @@ class OfflineReplicaStaging(models.Model):
             os.rmdir(dest_path)
         except OSError as err:
             LOGGER.warning(
-                "Unable to cleanup expected temporary artefact {}: {}".format(
-                    dest_path, err
-                )
+                f"Unable to cleanup expected temporary artefact {dest_path}: {err}"
             )

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -182,9 +182,7 @@ class S3(models.Model):
         """
         if delete_path.startswith(os.sep):
             LOGGER.info(
-                "S3 path to delete {} begins with {}; removing from path prior to deletion".format(
-                    delete_path, os.sep
-                )
+                f"S3 path to delete {delete_path} begins with {os.sep}; removing from path prior to deletion"
             )
             delete_path = delete_path.lstrip(os.sep)
         obj = self.resource.Bucket(self.bucket_name).objects.filter(Prefix=delete_path)

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -15,7 +15,6 @@ from django.utils.translation import gettext_lazy as _
 from . import StorageException
 from .location import Location
 
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -188,11 +188,7 @@ class Space(models.Model):
         app_label = "locations"
 
     def __str__(self):
-        return "{uuid}: {path} ({access_protocol})".format(
-            uuid=self.uuid,
-            access_protocol=self.get_access_protocol_display(),
-            path=self.path,
-        )
+        return f"{self.uuid}: {self.path} ({self.get_access_protocol_display()})"
 
     def clean(self):
         # Object storage spaces do not require a path, or for it to start with /

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -433,10 +433,10 @@ class Space(models.Model):
             )
         try:
             self.get_child_space().post_move_from_storage_service(
+                *args,
                 staging_path=staging_path,
                 destination_path=destination_path,
                 package=package,
-                *args,
                 **kwargs,
             )
         except AttributeError:

--- a/storage_service/locations/signals.py
+++ b/storage_service/locations/signals.py
@@ -33,20 +33,17 @@ def _notify_administrators(subject, message):
 @receiver(deletion_request, dispatch_uid="deletion_request")
 def report_deletion_request(sender, **kwargs):
     subject = _("Deletion request for package %(uuid)s") % {"uuid": kwargs["uuid"]}
-    message = (
-        _(
-            """A package deletion request was received:
+    message = _(
+        """A package deletion request was received:
 
 Pipeline UUID: %(pipeline)s
 Package UUID: %(uuid)s
 Package location: %(location)s"""
-        )
-        % {
-            "pipeline": kwargs["pipeline"],
-            "uuid": kwargs["uuid"],
-            "location": kwargs["location"],
-        }
-    )
+    ) % {
+        "pipeline": kwargs["pipeline"],
+        "uuid": kwargs["uuid"],
+        "location": kwargs["location"],
+    }
 
     # The URL may not be configured in the site; if it isn't,
     # don't try to tell the user the URL to approve/deny the request.
@@ -78,17 +75,14 @@ def report_failed_fixity_check(sender, **kwargs):
     )
 
     subject = _("Fixity check failed for package %(uuid)s") % {"uuid": kwargs["uuid"]}
-    message = (
-        _(
-            """
+    message = _(
+        """
 [%(timestamp)s] A fixity check failed for the package with UUID %(uuid)s.
 """
-        )
-        % {
-            "timestamp": timestamp,
-            "uuid": kwargs["uuid"],
-        }
-    )
+    ) % {
+        "timestamp": timestamp,
+        "uuid": kwargs["uuid"],
+    }
 
     _notify_administrators(subject, message)
 

--- a/storage_service/locations/signals.py
+++ b/storage_service/locations/signals.py
@@ -5,8 +5,8 @@ import sys
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models import signals
-from django.dispatch import receiver
 from django.dispatch import Signal
+from django.dispatch import receiver
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext as _

--- a/storage_service/locations/urls.py
+++ b/storage_service/locations/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+
 from locations import views
 
 app_name = "locations"

--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -26,10 +26,10 @@ from tastypie.models import ApiKey
 from . import datatable_utils
 from . import forms
 from .constants import PROTOCOL
+from .models import GPG
 from .models import Callback
 from .models import Event
 from .models import FixityLog
-from .models import GPG
 from .models import Location
 from .models import LocationPipeline
 from .models import Package

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -9,7 +9,7 @@ from sys import path
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
 
-from .components.s3 import *
+from .components.s3 import *  # noqa: F403
 from storage_service.settings.helpers import is_true
 
 try:
@@ -184,7 +184,7 @@ TEMPLATES = [
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#authentication-backends
 AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
 
-from .components.auth import *
+from .components.auth import *  # noqa: E402, F403
 
 # ######### END AUTHENTICATION CONFIGURATION
 
@@ -608,7 +608,10 @@ if OIDC_AUTHENTICATION:
     OIDC_RP_SIGN_ALGO = environ.get("OIDC_RP_SIGN_ALGO", "HS256")
 
     # Username is email address
-    OIDC_USERNAME_ALGO = lambda email: email
+    def _get_email(email):
+        return email
+
+    OIDC_USERNAME_ALGO = _get_email
 
     # map attributes from access token
     OIDC_ACCESS_ATTRIBUTE_MAP = {"given_name": "first_name", "family_name": "last_name"}

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -441,10 +441,8 @@ if LDAP_AUTHENTICATION:
             AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_HARD
         else:
             raise ImproperlyConfigured(
-                (
-                    "Unexpected value for AUTH_LDAP_TLS_REQUIRE_CERT: {}. "
-                    "Supported values: 'never', 'allow', try', 'hard', or 'demand'."
-                ).format(require_cert)
+                f"Unexpected value for AUTH_LDAP_TLS_REQUIRE_CERT: {require_cert}. "
+                "Supported values: 'never', 'allow', try', 'hard', or 'demand'."
             )
     # Non-configurable sane defaults
     AUTH_LDAP_ALWAYS_UPDATE_USER = True
@@ -520,10 +518,8 @@ if CAS_AUTHENTICATION:
     CAS_VERSION = environ.get("AUTH_CAS_PROTOCOL_VERSION", "3")
     if CAS_VERSION not in ALLOWED_CAS_VERSION_VALUES:
         raise ImproperlyConfigured(
-            (
-                "Unexpected value for AUTH_CAS_PROTOCOL_VERSION: {}. "
-                "Supported values: '1', '2', '3', or 'CAS_2_SAML_1_0'."
-            ).format(CAS_VERSION)
+            f"Unexpected value for AUTH_CAS_PROTOCOL_VERSION: {CAS_VERSION}. "
+            "Supported values: '1', '2', '3', or 'CAS_2_SAML_1_0'."
         )
 
     CAS_CHECK_ADMIN_ATTRIBUTES = environ.get("AUTH_CAS_CHECK_ADMIN_ATTRIBUTES", False)

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -1,4 +1,5 @@
 """Common settings and globals."""
+
 import json
 import logging.config
 from os import environ
@@ -9,7 +10,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
 
 from .components.s3 import *
-from storage_service.settings.helpers import get_env_variable
 from storage_service.settings.helpers import is_true
 
 try:
@@ -433,9 +433,9 @@ if LDAP_AUTHENTICATION:
         elif require_cert == "try":
             AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_TRY
         elif require_cert == "demand":
-            AUTH_LDAP_GLOBAL_OPTIONS[
-                ldap.OPT_X_TLS_REQUIRE_CERT
-            ] = ldap.OPT_X_TLS_DEMAND
+            AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = (
+                ldap.OPT_X_TLS_DEMAND
+            )
         elif require_cert == "hard":
             AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_HARD
         else:

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -9,8 +9,9 @@ from sys import path
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
 
-from .components.s3 import *  # noqa: F403
 from storage_service.settings.helpers import is_true
+
+from .components.s3 import *  # noqa: F403
 
 try:
     import ldap

--- a/storage_service/storage_service/settings/components/auth.py
+++ b/storage_service/storage_service/settings/components/auth.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 """Settings for basic user authentication."""
+
 from os import environ
 
 from storage_service.settings.helpers import is_true

--- a/storage_service/storage_service/settings/components/s3.py
+++ b/storage_service/storage_service/settings/components/s3.py
@@ -2,6 +2,7 @@
 
 From here we can configure aspects of S3 in the Storage Service.
 """
+
 from os import environ
 
 from django.core.exceptions import ImproperlyConfigured

--- a/storage_service/storage_service/settings/local.py
+++ b/storage_service/storage_service/settings/local.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 """Development settings and globals."""
+
 import dj_database_url
 
 from .base import *

--- a/storage_service/storage_service/settings/production.py
+++ b/storage_service/storage_service/settings/production.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 """Production settings and globals."""
+
 import dj_database_url
 
 from .base import *

--- a/storage_service/storage_service/settings/test.py
+++ b/storage_service/storage_service/settings/test.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 """Test settings and globals."""
+
 from .base import *
 
 
@@ -34,8 +35,8 @@ LOGGING = {
 }
 
 # Disable whitenoise
-STORAGES["staticfiles"][
-    "BACKEND"
-] = "django.contrib.staticfiles.storage.StaticFilesStorage"
+STORAGES["staticfiles"]["BACKEND"] = (
+    "django.contrib.staticfiles.storage.StaticFilesStorage"
+)
 if MIDDLEWARE[0] == "whitenoise.middleware.WhiteNoiseMiddleware":
     del MIDDLEWARE[0]

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -10,7 +10,6 @@ from django.views.generic import TemplateView
 
 from storage_service import views
 
-
 urlpatterns = [
     path("", TemplateView.as_view(template_name="index.html")),
     path("admin/", admin.site.urls),

--- a/storage_service/storage_service/wsgi.py
+++ b/storage_service/storage_service/wsgi.py
@@ -13,6 +13,7 @@ middleware here, or combine a Django application with an application of another
 framework.
 
 """
+
 import os
 from os.path import abspath
 from os.path import dirname

--- a/storage_service/storage_service/wsgi.py
+++ b/storage_service/storage_service/wsgi.py
@@ -15,8 +15,7 @@ framework.
 """
 
 import os
-from os.path import abspath
-from os.path import dirname
+import pathlib
 from sys import path
 
 import django
@@ -25,7 +24,7 @@ from django.core.wsgi import get_wsgi_application
 django.setup()
 from common.startup import startup  # noqa: E402
 
-SITE_ROOT = dirname(dirname(abspath(__file__)))
+SITE_ROOT = str(pathlib.Path(__file__).resolve().parent.parent)
 path.append(SITE_ROOT)
 
 

--- a/storage_service/storage_service/wsgi.py
+++ b/storage_service/storage_service/wsgi.py
@@ -25,7 +25,6 @@ from django.core.wsgi import get_wsgi_application
 django.setup()
 from common.startup import startup  # noqa: E402
 
-
 SITE_ROOT = dirname(dirname(abspath(__file__)))
 path.append(SITE_ROOT)
 

--- a/tests/administration/test_languages.py
+++ b/tests/administration/test_languages.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import User
-from django.test import override_settings
 from django.test import TestCase
+from django.test import override_settings
 
 
 class TestLanguageSwitching(TestCase):

--- a/tests/common/test_premis.py
+++ b/tests/common/test_premis.py
@@ -4,7 +4,6 @@ from common import premis
 
 from storage_service import __version__ as ss_version
 
-
 FakeGPGRet = namedtuple("FakeGPGRet", "ok status stderr")
 GPG_VERSION = "1.4.16"
 SUCCESS_STATUS = "good times"

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -49,9 +49,7 @@ def test_get_compression(pronom, algorithm, compression):
 
     assert (
         utils.get_compression(StringIO(xml)) == compression
-    ), "Incorrect compression value: {} returned for XML (pointer file) input".format(
-        compression
-    )
+    ), f"Incorrect compression value: {compression} returned for XML (pointer file) input"
 
 
 @pytest.mark.parametrize(
@@ -86,9 +84,7 @@ def test_get_compress_command(compression, command):
     )
     assert (
         " ".join(cmd) == command
-    ), "Incorrect compression command: {} returned for compression input {}".format(
-        cmd, compression
-    )
+    ), f"Incorrect compression command: {cmd} returned for compression input {compression}"
 
 
 @pytest.mark.parametrize(
@@ -124,9 +120,7 @@ def test_get_tool_info_command(compression, command):
     cmd = utils.get_tool_info_command(compression)
     assert (
         cmd == command
-    ), "Incorrect tool info: {} returned for compression input {}".format(
-        cmd, compression
-    )
+    ), f"Incorrect tool info: {cmd} returned for compression input {compression}"
 
 
 @pytest.mark.parametrize(
@@ -174,9 +168,7 @@ def test_get_compression_event_detail(
 
     assert (
         detail == expected_detail
-    ), "Incorrect detail: {} returned for compression input {}".format(
-        detail, compression
-    )
+    ), f"Incorrect detail: {detail} returned for compression input {compression}"
 
 
 @pytest.mark.parametrize(
@@ -420,9 +412,10 @@ def test_create_tar(
     else:
         with pytest.raises(utils.TARException) as excinfo:
             ret = utils.create_tar(path, extension=extension)
-        assert "Failed to create a tarfile at {} for dir at {}".format(
-            tarpath, fixed_path
-        ) == str(excinfo.value)
+        assert (
+            f"Failed to create a tarfile at {tarpath} for dir at {fixed_path}"
+            == str(excinfo.value)
+        )
         assert not shutil.rmtree.called
         assert not pathlib.Path.rename.called
     if not sp_raises:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,3 @@
 import sys
 
-
 sys.path.append("/src/storage_service")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -9,6 +9,7 @@ worth investigating a setup where pytest orchestrates Compose services instead.
 Missing: encryption, multiple replicators, packages generated with older versions
 of Archivematica, etc...
 """
+
 import json
 import os
 import shutil

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -117,15 +117,13 @@ def startup(scope="function"):
 
 
 def get_size(path):
-    if isinstance(path, Path):
-        path = str(path)
-    if os.path.isfile(path):
-        return os.path.getsize(path)
+    if path.is_file():
+        return path.stat().st_size
     size = 0
     for dirpath, _, filenames in os.walk(path):
+        directory = Path(dirpath)
         for filename in filenames:
-            file_path = os.path.join(dirpath, filename)
-            size += os.path.getsize(file_path)
+            size += (directory / filename).stat().st_size
     return size
 
 
@@ -328,7 +326,7 @@ class StorageScenario:
                 "origin_path": self.pkg.name,
                 "current_location": as_location["resource_uri"],
                 "current_path": self.pkg.name,
-                "size": get_size(str(self.pkg)),
+                "size": get_size(self.pkg),
                 "package_type": Package.AIP,
                 "aip_subtype": "Archival Information Package",
                 "origin_pipeline": f"/api/v2/pipeline/{self.PIPELINE_UUID}/",

--- a/tests/locations/test_archipelago.py
+++ b/tests/locations/test_archipelago.py
@@ -1,8 +1,8 @@
 import json
 import logging  # Added import
 from unittest.mock import ANY
-from unittest.mock import call
 from unittest.mock import Mock
+from unittest.mock import call
 from unittest.mock import mock_open
 from unittest.mock import patch
 

--- a/tests/locations/test_datatable.py
+++ b/tests/locations/test_datatable.py
@@ -1,4 +1,5 @@
 """Tests for the datatable utilities."""
+
 import pathlib
 import uuid
 

--- a/tests/locations/test_dataverse.py
+++ b/tests/locations/test_dataverse.py
@@ -7,7 +7,6 @@ from locations import models
 
 from . import TempDirMixin
 
-
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 
 

--- a/tests/locations/test_dspace_rest.py
+++ b/tests/locations/test_dspace_rest.py
@@ -11,12 +11,11 @@ import pytest
 import requests
 from agentarchives import archivesspace
 from agentarchives.archivesspace.client import CommunicationError
-from locations.models import dspace_rest
 from locations.models import DSpaceREST
 from locations.models import Package
 from locations.models import Space
+from locations.models import dspace_rest
 from lxml import etree
-
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_DIR = os.path.abspath(os.path.join(THIS_DIR, "fixtures"))

--- a/tests/locations/test_dspace_rest.py
+++ b/tests/locations/test_dspace_rest.py
@@ -1,4 +1,5 @@
 """Tests for the DSpace REST space."""
+
 import json
 import os
 import subprocess

--- a/tests/locations/test_dspace_rest.py
+++ b/tests/locations/test_dspace_rest.py
@@ -83,11 +83,11 @@ DIP_SOURCE_PATH = f"{SOURCE_PATH}{DIP_NAME}"
 DIP_METS_PATH = os.path.join(DIP_SOURCE_PATH, AIP_METS_FILENAME)
 
 AIP_DEST_PATH = f"/x/y/z/{AIP_NAME}.7z"
-DS_REST_AIP_DEPO_URL = "{}/items/{}/bitstreams?name={}".format(
-    DS_REST_URL, DS_ITEM_UUID, AIP_FILENAME
+DS_REST_AIP_DEPO_URL = (
+    f"{DS_REST_URL}/items/{DS_ITEM_UUID}/bitstreams?name={AIP_FILENAME}"
 )
-DS_REST_DIP_DEPO_URL = "{}/items/{}/bitstreams?name={}".format(
-    DS_REST_URL, DS_ITEM_UUID, AIP_METS_FILENAME
+DS_REST_DIP_DEPO_URL = (
+    f"{DS_REST_URL}/items/{DS_ITEM_UUID}/bitstreams?name={AIP_METS_FILENAME}"
 )
 DSPACE_SPACE_EXTRACTABLE_METADATA = [
     {"language": "", "value": AIP_NAME_ORIG.title(), "key": "dc.title"}
@@ -406,8 +406,8 @@ def test_move_from_storage_service(
             )
         assert excinfo.value.message == (
             "Error depositing to DSpace or ArchiveSpace: Could not login to"
-            " ArchivesSpace server: {}, port: {}, user: {}, repository:"
-            " {}".format(AS_URL_NO_PORT, AS_PORT, AS_USER, AS_REPOSITORY)
+            f" ArchivesSpace server: {AS_URL_NO_PORT}, port: {AS_PORT}, user: {AS_USER}, repository:"
+            f" {AS_REPOSITORY}"
         )
         return
 
@@ -474,9 +474,7 @@ def test_move_from_storage_service(
                 AS_URL_NO_PORT, AS_USER, AS_PASSWORD, AS_PORT, AS_REPOSITORY
             )
             assert fake_as_client.args == (
-                "/repositories/{}/archival_objects/{}".format(
-                    AS_REPOSITORY, AS_ARCHIVAL_OBJECT
-                ),
+                f"/repositories/{AS_REPOSITORY}/archival_objects/{AS_ARCHIVAL_OBJECT}",
                 PACKAGE_UUID,
             )
             assert fake_as_client.kwargs == {

--- a/tests/locations/test_gpg.py
+++ b/tests/locations/test_gpg.py
@@ -9,8 +9,8 @@ import pytest
 from common import gpgutils
 from common import utils
 from django.test import TestCase
-from locations.models import gpg
 from locations.models import Package
+from locations.models import gpg
 from locations.models import space
 from metsrw.plugins import premisrw
 

--- a/tests/locations/test_gpg.py
+++ b/tests/locations/test_gpg.py
@@ -138,16 +138,14 @@ def test_move_to_storage_service(
             gpg_space.move_to_storage_service(src_path, dst_path, None)
         if not encr_path:
             assert (
-                "Unable to move {}; this file/dir does not exist;"
-                " nor is it in an encrypted directory.".format(src_path)
-                == str(excinfo.value)
+                f"Unable to move {src_path}; this file/dir does not exist;"
+                " nor is it in an encrypted directory." == str(excinfo.value)
             )
         if not src_exists2:
             assert (
-                "Unable to move {}; this file/dir does not"
+                f"Unable to move {src_path}; this file/dir does not"
                 " exist, not even in encrypted directory"
-                " {}.".format(src_path, encr_path)
-                == str(excinfo.value)
+                f" {encr_path}." == str(excinfo.value)
             )
     if src_exists2 and encr_path:
         gpg_space.space.move_rsync.assert_called_once_with(src_path, dst_path)
@@ -421,9 +419,10 @@ def test__gpg_decrypt(
         with pytest.raises(gpg.GPGException) as excinfo:
             gpg._gpg_decrypt(path)
         if isfile:
-            assert "Failed to decrypt {}. Reason: {}".format(
-                path, DECRYPT_RET_FAIL_STATUS
-            ) == str(excinfo.value)
+            assert (
+                f"Failed to decrypt {path}. Reason: {DECRYPT_RET_FAIL_STATUS}"
+                == str(excinfo.value)
+            )
         else:
             assert f"Cannot decrypt file at {path}; no such file." == str(excinfo.value)
         assert not os.remove.called
@@ -468,6 +467,6 @@ class TestGPG(TestCase):
         with pytest.raises(gpg.GPGException) as excinfo:
             encr_path = "/some/non/matching/path.jpg"
             gpg._encr_path2key_fingerprint(encr_path)
-        assert "Unable to find package matching encrypted path {}".format(
-            encr_path
-        ) in str(excinfo.value)
+        assert f"Unable to find package matching encrypted path {encr_path}" in str(
+            excinfo.value
+        )

--- a/tests/locations/test_gpg.py
+++ b/tests/locations/test_gpg.py
@@ -1,4 +1,5 @@
 """Tests for the GPG encrypted space."""
+
 import os
 import pathlib
 import tarfile
@@ -145,7 +146,8 @@ def test_move_to_storage_service(
             assert (
                 "Unable to move {}; this file/dir does not"
                 " exist, not even in encrypted directory"
-                " {}.".format(src_path, encr_path) == str(excinfo.value)
+                " {}.".format(src_path, encr_path)
+                == str(excinfo.value)
             )
     if src_exists2 and encr_path:
         gpg_space.space.move_rsync.assert_called_once_with(src_path, dst_path)

--- a/tests/locations/test_package.py
+++ b/tests/locations/test_package.py
@@ -17,7 +17,6 @@ from django.test import TestCase
 from django.urls import reverse
 from locations import models
 
-
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 
 # Fixture files are not cleanly separated, with potential for

--- a/tests/locations/test_package.py
+++ b/tests/locations/test_package.py
@@ -88,9 +88,7 @@ class TestPackage(TestCase):
         packages = models.Package.objects.all()
         assert (
             len(packages) == TOTAL_FIXTURE_PACKAGES
-        ), "Packages not loaded from fixtures correctly, got '{}' expected '{}'".format(
-            len(packages), TOTAL_FIXTURE_PACKAGES
-        )
+        ), f"Packages not loaded from fixtures correctly, got '{len(packages)}' expected '{TOTAL_FIXTURE_PACKAGES}'"
 
         self.package = packages[0]
         self.mets_path = os.path.normpath(os.path.join(__file__, "..", "fixtures"))

--- a/tests/locations/test_package_pointer.py
+++ b/tests/locations/test_package_pointer.py
@@ -6,7 +6,6 @@ from django.test import TestCase
 from locations import models
 from metsrw.plugins import premisrw
 
-
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 
 TEST_PREMIS_OBJECT_UUID = str(uuid4())

--- a/tests/locations/test_rclone.py
+++ b/tests/locations/test_rclone.py
@@ -186,7 +186,7 @@ def test_rclone_remote_prefix(
         assert remote_prefix == expected_return
     else:
         with pytest.raises(models.StorageException):
-            rclone_space.remote_prefix
+            assert rclone_space.remote_prefix is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/locations/test_replica_staging.py
+++ b/tests/locations/test_replica_staging.py
@@ -7,7 +7,6 @@ from locations import models
 
 from . import TempDirMixin
 
-
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 
 

--- a/tests/locations/test_space.py
+++ b/tests/locations/test_space.py
@@ -175,7 +175,7 @@ C5 = "0e-11112222-3333-8888-9999-aaaabbbbcccc.7z"
 C6 = "0f-11112222-8888-9999-aaaa-bbbbccccdddd.tar.gz"
 C7 = "1a-11118888-9999-aaaa-bbbb-cccceeeeeeee.zip"
 
-MAGIC = b"\x37\x7A\xBC\xAF\x27\x1C"
+MAGIC = b"\x37\x7a\xbc\xaf\x27\x1c"
 
 AIPSTORE = "AIPstore"
 

--- a/tests/storage_service/test_cas.py
+++ b/tests/storage_service/test_cas.py
@@ -10,7 +10,6 @@ from django.test import RequestFactory
 from django.test import TestCase
 from django.test.client import Client
 
-
 TEST_CAS_USER = "casuser"
 TEST_CAS_ADMIN_ATTRIBUTE = "usertype"
 TEST_CAS_ADMIN_ATTRIBUTE_VALUE_POSITIVE = "admin"

--- a/tests/storage_service/test_oidc.py
+++ b/tests/storage_service/test_oidc.py
@@ -2,8 +2,8 @@ import pytest
 from administration import roles
 from common.backends import CustomOIDCBackend
 from django.conf import settings
-from django.test import override_settings
 from django.test import TestCase
+from django.test import override_settings
 
 
 @pytest.mark.skipif(

--- a/tests/storage_service/test_shibboleth.py
+++ b/tests/storage_service/test_shibboleth.py
@@ -1,8 +1,8 @@
 import pytest
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import override_settings
 from django.test import TestCase
+from django.test import override_settings
 
 
 @pytest.mark.skipif(

--- a/tox.ini
+++ b/tox.ini
@@ -32,20 +32,3 @@ setenv =
 basepython = python3
 deps = -r {toxinidir}/requirements-dev.txt
 commands = django-admin makemigrations --check --dry-run
-
-[flake8]
-exclude = .tox, .git, __pycache__, .cache, build, dist, *.pyc, *.egg-info, .eggs
-# Error codes:
-# - https://flake8.pycqa.org/en/latest/user/error-codes.html
-# - https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
-# - https://github.com/PyCQA/flake8-bugbear#list-of-warnings
-#
-# B950: line too long
-# E203: whitespace before ‘,’, ‘;’, or ‘:’
-# E501: line too long
-# W503: line break before binary operator
-ignore =
-    B950,
-    E203,
-    E501,
-    W503


### PR DESCRIPTION
This replaces the `black`, `pyupgrade`, `reorder-python-imports` and `flake8` hooks in `pre-commit` with `ruff`,

It also removes the hook for formatting `osdeps` JSON manifests removed in https://github.com/artefactual/archivematica-storage-service/pull/682 and upgrades the `django-upgrade` and `markdownlint-cli` hooks.

Connected to https://github.com/archivematica/Issues/issues/1693