### PR TITLE
Allow triggering the test CI workflow manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,13 @@ jobs:
         ]
     steps:
       - name: "Check out repository"
+        if: "${{ github.event_name != 'workflow_dispatch' }}"
         uses: "actions/checkout@v4"
+      - name: "Check out repository (manually triggered)"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "${{ inputs.ss_version || 'qa/0.x' }}"
       - name: "Set up Python 3.9"
         uses: "actions/setup-python@v5"
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 ---
 name: "Test"
 on:
+  workflow_dispatch:
+    inputs:
+      ss_version:
+        description: "Archivematica Storage Service ref (branch, tag or SHA to checkout)"
+        default: "qa/0.x"
+        required: true
+        type: "string"
   pull_request:
   push:
     branches:
@@ -25,7 +32,13 @@ jobs:
         ]
     steps:
       - name: "Check out repository"
+        if: "${{ github.event_name != 'workflow_dispatch' }}"
         uses: "actions/checkout@v4"
+      - name: "Check out repository (manually triggered)"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "${{ inputs.ss_version || 'qa/0.x' }}"
       - name: "Save user id"
         id: user_id
         run: |


### PR DESCRIPTION
With this PR the `test` workflow can be [triggered manually](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) from the Actions tab and it accepts a branch, tag or commit hash for the Storage Service checkout.