### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Ignore everything
+**
+
+# Include
+!/install/**
+!/storage_service/**
+!/tests/**
+!/.coveragerc
+!/.markdownlint.jsonc
+!/.pre-commit-config.yaml
+!/CHANGELOG.md
+!/CODE_OF_CONDUCT.md
+!/CONTRIBUTING.md
+!/LICENSE
+!/Makefile
+!/README.md
+!/SECURITY.md
+!/mypy.ini
+!/pytest.ini
+!/requirements*
+!/ruff.toml
+!/setup.py
+!/tox.ini


### PR DESCRIPTION
This adds a [.dockerignore](https://docs.docker.com/build/building/context/#dockerignore-files) file to avoid introducing unwanted content to the build context and image size.

It uses the same approach of the Archivematica [.dockerignore](https://github.com/artefactual/archivematica/blob/b9608cc055e26c4945b5de30b0742a0a9db91ebe/.dockerignore) where everything is omitted by default and specific paths are added to the context explicitly.