### PR TITLE
Fix mypy hook in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.1
+  rev: v0.5.6
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -39,7 +39,9 @@ repos:
         install/README\.md
       )
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.10.1
+  rev: v1.11.1
   hooks:
   - id: mypy
-    additional_dependencies: [types-all]
+    additional_dependencies:
+    - types-requests
+    - types-python-dateutil


### PR DESCRIPTION
Similar to https://github.com/artefactual/archivematica/pull/1964 this removes the `types-all` package from the `mypy` hook after `types-pkg-resources` has been deprecated and yanked from PyPI.

