### PR TITLE
Fix casing build warning in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN set -ex \
 
 # -----------------------------------------------------------------------------
 
-FROM base-builder as base
+FROM base-builder AS base
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000


### PR DESCRIPTION
The `test` GitHub workflow started showing these warnings:

![imagen](https://github.com/user-attachments/assets/f83a09a2-f724-4b87-b1ef-bbaf0667665d)

The `docker/build-push-action` now shows warnings generated with the new `docker build --check` command that allows you to [check your build configuration](https://docs.docker.com/build/checks/). :tada: finally!