### PR TITLE
Add trailing slash to AIP recovery destination

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,4 @@ repos:
     additional_dependencies:
     - types-requests
     - types-python-dateutil
+    - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,12 @@ module = [
 ]
 ignore_errors = true
 
+[[tool.mypy.overrides]]
+module = [
+    "tests.integration.test_integration",
+]
+ignore_errors = false
+
 [tool.tox]
 legacy_tox_ini = """
     [tox]

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -12,6 +12,8 @@ import tarfile
 import uuid
 from collections import deque
 from collections import namedtuple
+from typing import Any
+from typing import Union
 
 from administration import models
 from django import http
@@ -654,7 +656,9 @@ def extract_tar(tarpath):
 # ########### OTHER ############
 
 
-def generate_checksum(file_path, checksum_type="md5"):
+def generate_checksum(
+    file_path: Union[str, pathlib.Path], checksum_type: str = "md5"
+) -> Any:
     """
     Returns checksum object for `file_path` using `checksum_type`.
 

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -1500,7 +1500,7 @@ class PackageResource(ModelResource):
 
             package_dir = os.path.join(tmpdir, basedir)
         else:
-            package_dir = package.full_path()
+            package_dir = package.full_path
             tmpdir = None
 
         safe_files = ("bag-info.txt", "manifest-sha512.txt", "bagit.txt")

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -583,7 +583,7 @@ class Package(models.Model):
         # Copy recovery files to storage service staging
         source_path = os.path.join(temp_aip.current_location.relative_path, origin_path)
         destination_path = os.path.join(
-            self.current_location.relative_path, os.path.dirname(self.current_path)
+            self.current_location.relative_path, os.path.dirname(self.current_path), ""
         )
 
         origin_space.move_to_storage_service(

--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -174,7 +174,7 @@ def aip_recover_request(request):
             )
         except StorageException:
             recover_path = os.path.join(
-                recover_location.full_path(), os.path.basename(aip.full_path())
+                recover_location.full_path, os.path.basename(aip.full_path)
             )
             message = _("error accessing restore files at %(path)s") % {
                 "path": recover_path

--- a/storage_service/locations/views.py
+++ b/storage_service/locations/views.py
@@ -169,7 +169,7 @@ def aip_recover_request(request):
         ).location
 
         try:
-            (success, _, message) = aip.recover_aip(
+            (success, failures, message) = aip.recover_aip(
                 recover_location, os.path.basename(aip.current_path)
             )
         except StorageException:


### PR DESCRIPTION
This also adds an integration test for [AIP recovery](https://www.archivematica.org/en/docs/storage-service-latest/recovery/) of compressed and uncompressed AIPs stored in a local file system space.

Connected to https://github.com/archivematica/Issues/issues/420