### PR TITLE
Fix broken links in Markdown files

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^http://(127.0.0.1|localhost)"
+    }
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,9 @@ repos:
     - types-requests
     - types-python-dateutil
     - pytest
+- repo: https://github.com/tcort/markdown-link-check
+  rev: v3.12.2
+  hooks:
+  - id: markdown-link-check
+    stages: [manual]
+    args: [--quiet, --config, .markdown-link-check.json]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,9 +226,9 @@ CONTRIBUTING.md in the [Archivematica project].
 [GitHub]: https://github.com/
 [guide]: https://help.github.com/articles/fork-a-repo
 [excellent]: https://help.github.com/articles/using-pull-requests
-[Line comment]: http://i.imgur.com/FsWppGN.png
+[Line comment]: https://i.imgur.com/FsWppGN.png
 [code review guidelines]: https://github.com/artefactual/archivematica/blob/qa/1.x/code_review.md
-[interactive rebase feature]: http://www.git-scm.com/book/en/Git-Tools-Rewriting-History
+[interactive rebase feature]: https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History
 [Contributor's Agreement]: https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf
 [Apache Foundation]: http://apache.org
 [contributor license]: http://www.apache.org/licenses/icla.txt

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For more projects in the Archivematica ecosystem, see the [getting started] page
 [LICENSE]: LICENSE
 [Production installation]: https://www.archivematica.org/docs/latest/admin-manual/installation-setup/installation/installation/#installation
 [Development installation]: https://github.com/artefactual/archivematica/tree/qa/1.x/hack
-[Wiki]: https://www.archivematica.org/wiki/Development
+[Wiki]: https://wiki.archivematica.org/Development
 [Issues]: https://github.com/archivematica/Issues
 [User Google Group]: https://groups.google.com/forum/#!forum/archivematica
 [Paid support]: https://www.artefactual.com/services/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,7 +50,7 @@ the original report, there are a couple steps you can take:
 
 - Email the Archivematica Program Manager directly at
   [sromkey@artefactual.com](mailto:sromkey@artefactual.com)
-- Email Artefactual's info address: [info@artefactual.com](info@artefactual.com)
+- Email Artefactual's info address: [info@artefactual.com](mailto:info@artefactual.com)
 
 Any information you share with the Archivematica development team as a part of
 this process will be kept confidential within the team. If we determine that the

--- a/install/README.md
+++ b/install/README.md
@@ -698,7 +698,7 @@ services.
 [DB_HOST]: https://docs.djangoproject.com/en/1.8/ref/settings/#host
 [#813]: https://github.com/artefactual/archivematica/pull/813
 [USER]: http://docs.gunicorn.org/en/stable/settings.html#user
-[GROUP]: http://docs.gunicorn.org/en/styable/settings.html#group
+[GROUP]: http://docs.gunicorn.org/en/stable/settings.html#group
 [BIND]: http://docs.gunicorn.org/en/stable/settings.html#bind
 [WORKERS]: http://docs.gunicorn.org/en/stable/settings.html#workers
 [WORKER-CLASS]: http://docs.gunicorn.org/en/stable/settings.html#worker-class


### PR DESCRIPTION
This also introduces `markdown-link-check` as a `pre-commit` hook to check broken links in the Markdown files of the repository. The hook has been set as `manual` so developers need to run it explicitly.

Similar to https://github.com/artefactual/archivematica/pull/1996