### PR TITLE
Do not start the asynchronous task manager in tests

### DIFF
--- a/storage_service/common/startup.py
+++ b/storage_service/common/startup.py
@@ -17,7 +17,9 @@ from common import utils
 LOGGER = logging.getLogger(__name__)
 
 
-def startup(space_path: Optional[pathlib.Path] = None) -> None:
+def startup(
+    space_path: Optional[pathlib.Path] = None, start_async: bool = True
+) -> None:
     if space_path is None:
         space_path = pathlib.Path(os.sep)
 
@@ -29,7 +31,8 @@ def startup(space_path: Optional[pathlib.Path] = None) -> None:
     except PopulateLockError:
         LOGGER.warning("Another worker is initializing the database.")
 
-    start_async_manager()
+    if start_async:
+        start_async_manager()
 
 
 class PopulateLockError(Exception):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -185,7 +185,7 @@ def startup(working_directory_path: Path) -> None:
     """
     from common.startup import startup
 
-    startup(working_directory_path)  # TODO: get rid of this!
+    startup(working_directory_path, start_async=False)  # TODO: get rid of this!
 
 
 def get_size(path: Path) -> int:

--- a/tests/storage_service/test_startup.py
+++ b/tests/storage_service/test_startup.py
@@ -21,7 +21,7 @@ class TestStartup(TestCase):
         assert not models.Space.objects.all().exists()
         assert not models.Location.objects.all().exists()
         # Run test
-        self.startup()
+        self.startup(start_async=False)
         # Assert Space & Locations created
         assert models.Space.objects.get(access_protocol="FS")
         assert models.Location.objects.get(purpose="TS")
@@ -40,7 +40,7 @@ class TestStartup(TestCase):
         models.Space.objects.create(path="/", access_protocol="FS")
         assert len(models.Space.objects.filter(access_protocol="FS")) == 2
         # Run test
-        self.startup()
+        self.startup(start_async=False)
         # Verify no locations exist - space errored gracefully
         assert len(models.Space.objects.filter(access_protocol="FS")) == 2
         assert not models.Location.objects.all().exists()
@@ -63,7 +63,7 @@ class TestStartup(TestCase):
         assert len(models.Space.objects.filter(access_protocol="FS")) == 1
         assert len(models.Location.objects.filter(purpose="SS")) == 2
         # Run test
-        self.startup()
+        self.startup(start_async=False)
         # Verify no new Location was created
         assert len(models.Space.objects.filter(access_protocol="FS")) == 1
         assert len(models.Location.objects.filter(purpose="SS")) == 2
@@ -87,6 +87,6 @@ class TestStartup(TestCase):
         )
         assert len(models.Location.objects.all()) == 6
         # Run test
-        self.startup()
+        self.startup(start_async=False)
         # Verify no new Locations created
         assert len(models.Location.objects.all()) == 6


### PR DESCRIPTION
This avoids a runtime warning shown intermittently when tests are executed:

```console
WARNING   2024-10-02 08:31:10  locations.models.async_manager:async_manager:_watchdog:61:  Failure in watchdog thread: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
Traceback (most recent call last):
  File "/src/storage_service/locations/models/async_manager.py", line 59, in _watchdog
    AsyncManager._watchdog_loop()
  File "/src/storage_service/locations/models/async_manager.py", line 72, in _watchdog_loop
    Async.objects.filter(
  File "/pyenv/data/versions/3.9.20/lib/python3.9/site-packages/django/db/models/query.py", line 1148, in delete
    deleted, _rows_count = collector.delete()
  File "/pyenv/data/versions/3.9.20/lib/python3.9/site-packages/django/db/models/deletion.py", line 459, in delete
    with transaction.atomic(using=self.using, savepoint=False):
  File "/pyenv/data/versions/3.9.20/lib/python3.9/site-packages/django/db/transaction.py", line 198, in __enter__
    if not connection.get_autocommit():
  File "/pyenv/data/versions/3.9.20/lib/python3.9/site-packages/django/db/backends/base/base.py", line 464, in get_autocommit
    self.ensure_connection()
  File "/pyenv/data/versions/3.9.20/lib/python3.9/site-packages/pytest_django/plugin.py", line 813, in _blocking_wrapper
    raise RuntimeError(
RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
```