### PR TITLE
Remove pytest-mock dependency

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,7 +4,6 @@
 pip-tools
 pytest-cov
 pytest-django
-pytest-mock
 pytest-playwright
 pytest-randomly
 pytest
@@ -15,5 +14,6 @@ tox
 # See https://github.com/microsoft/playwright-python/issues/2190
 git+https://github.com/microsoft/playwright-python.git@d9cdfbb1e178b6770625e9f857139aff77516af0#egg=playwright
 
-# coverage 7.6.2 dropped support for Python 3.8, so pinning it for now.
+# These dependencies dropped support for Python 3.8, so pinning them for now.
 coverage==7.6.1
+pytest-randomly==3.15.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,9 +12,9 @@ asgiref==3.8.1
     #   django
 bagit==1.8.1
     # via -r requirements.txt
-boto3==1.35.45
+boto3==1.35.49
     # via -r requirements.txt
-botocore==1.35.45
+botocore==1.35.49
     # via
     #   -r requirements.txt
     #   boto3
@@ -258,7 +258,6 @@ pytest==8.3.3
     #   pytest-base-url
     #   pytest-cov
     #   pytest-django
-    #   pytest-mock
     #   pytest-playwright
     #   pytest-randomly
 pytest-base-url==2.1.0
@@ -266,8 +265,6 @@ pytest-base-url==2.1.0
 pytest-cov==5.0.0
     # via -r requirements-dev.in
 pytest-django==4.9.0
-    # via -r requirements-dev.in
-pytest-mock==3.14.0
     # via -r requirements-dev.in
 pytest-playwright==0.5.2
     # via -r requirements-dev.in
@@ -387,7 +384,7 @@ zope-event==5.0
     # via
     #   -r requirements.txt
     #   gevent
-zope-interface==7.1.0
+zope-interface==7.1.1
     # via
     #   -r requirements.txt
     #   gevent

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ brotli
 Django>=4.2,<5
 django-csp
 django-tastypie
-dj-database-url
 gunicorn
 importlib_resources
 jsonfield
@@ -31,7 +30,8 @@ django-cas-ng
 # Required for OpenID Connect authentication
 mozilla-django-oidc
 
-# gevent 24.10.1 dropped support for Python 3.8, so pinning it for now.
+# These dependencies dropped support for Python 3.8, so pinning them for now.
+dj-database-url==2.2.0
 django-auth-ldap==5.0.0
 gevent==24.2.1
 pyparsing==3.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@ asgiref==3.8.1
     # via django
 bagit==1.8.1
     # via -r requirements.in
-boto3==1.35.45
+boto3==1.35.49
     # via -r requirements.in
-botocore==1.35.45
+botocore==1.35.49
     # via
     #   boto3
     #   s3transfer
@@ -219,7 +219,7 @@ zipp==3.20.2
     # via importlib-resources
 zope-event==5.0
     # via gevent
-zope-interface==7.1.0
+zope-interface==7.1.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tests/administration/test_views.py
+++ b/tests/administration/test_views.py
@@ -9,7 +9,7 @@ from locations.models import Space
 
 
 @pytest.mark.parametrize(
-    "check_output,expected_result",
+    "output,expected_result",
     [
         (
             b"d9c93f388a770287cf6337d4f9bcbbe60c25fdb8\n",
@@ -19,8 +19,9 @@ from locations.models import Space
     ],
     ids=["success", "error"],
 )
-def test_get_git_commit(check_output, expected_result, mocker):
-    mocker.patch("subprocess.check_output", side_effect=[check_output])
+@mock.patch("subprocess.check_output")
+def test_get_git_commit(check_output, output, expected_result):
+    check_output.side_effect = [output]
 
     assert get_git_commit() == expected_result
 

--- a/tests/common/conftest.py
+++ b/tests/common/conftest.py
@@ -1,12 +1,15 @@
+from unittest import mock
+
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def do_not_reset_the_root_logger(mocker):
+def do_not_reset_the_root_logger():
     # Some management commands suppress logging from models/package.py
     # by calling logging.config.dictConfig directly which breaks the caplog
     # fixture. See https://github.com/pytest-dev/pytest/discussions/11011
     #
     # This avoids breaking the caplog fixture when those management command
     # modules are imported or called during tests.
-    mocker.patch("logging.config")
+    with mock.patch("logging.config"):
+        yield

--- a/tests/locations/test_package.py
+++ b/tests/locations/test_package.py
@@ -143,7 +143,7 @@ class TestPackage(TestCase):
         # once for our source object.
         with mock.patch("locations.models.Space.delete_path") as mocked_delete:
             package.delete_from_storage()
-            assert mocked_delete.called
+            mocked_delete.assert_called()
 
         # Ensure that location properties are updated reflecting the
         # size remaining.
@@ -176,7 +176,7 @@ class TestPackage(TestCase):
         # measured three times per our test parameters.
         with mock.patch("locations.models.Space.delete_path") as mocked_delete:
             package.delete_from_storage()
-            assert mocked_delete.called
+            mocked_delete.assert_called()
             assert mocked_delete.call_count == 3
 
         # Ensure locations sizes are updated to reflect the size
@@ -217,7 +217,7 @@ class TestPackage(TestCase):
             "locations.models.Space.delete_path", side_effect=NotImplementedError
         ) as mocked_delete:
             package.delete_from_storage()
-            assert mocked_delete.called
+            mocked_delete.assert_called()
             assert mocked_delete.call_count == 1
 
         # Ensure locations sizes are the same as they were because no


### PR DESCRIPTION
`pytest-mock` provided value while we migrated from Python 2 to Python 3, but it's become less relevant now that the `unittest.mock` is included in the standard library. We also don't use any of its extra features like `Spy`s or `Stub`s.

This replaces it with `unittest.mock` and removes the dependency from the requirements files.