### PR TITLE
Remove temporary bash scripts in compression details

### DIFF
--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -467,11 +467,13 @@ def get_tool_info_command(compression):
 
 
 def get_7z_version():
-    return [
-        line
-        for line in subprocess.check_output("7z").splitlines()
-        if b"Version" in line
-    ][0].decode("utf8")
+    lines = subprocess.check_output("7z").decode().splitlines()
+    if lines[2].startswith("p7zip Version"):
+        # 7-Zip 16.02: return only version line.
+        return lines[2]
+    else:
+        # 7-Zip 23.01: merge and return copyright and architecture lines.
+        return "".join(lines[1:3])
 
 
 def get_tar_version():

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -430,40 +430,31 @@ def get_compressed_package_checksum(pointer_path):
     return (checksum, checksum_algorithm)
 
 
-def get_tool_info_command(compression):
-    """Return command for outputting compression tool details
+def get_tool_info(compression):
+    """Return compression tool details
 
     :param compression: one of the constants in ``COMPRESSION_ALGORITHMS``.
-    :returns: command in string format
+    :returns: tool details in string format
     """
     if compression in (COMPRESSION_TAR, COMPRESSION_TAR_BZIP2, COMPRESSION_TAR_GZIP):
+        program = "tar"
         algo = {COMPRESSION_TAR_BZIP2: "-j", COMPRESSION_TAR_GZIP: "-z"}.get(
             compression, ""
         )
-
-        tool_info_command = (
-            'echo program="tar"\\; '
-            f'algorithm="{algo}"\\; '
-            'version="`tar --version | grep tar`"'
-        )
+        version = get_tar_version()
     elif compression in (COMPRESSION_7Z_BZIP, COMPRESSION_7Z_LZMA, COMPRESSION_7Z_COPY):
+        program = "7z"
         algo = {
             COMPRESSION_7Z_BZIP: COMPRESS_ALGO_BZIP2,
             COMPRESSION_7Z_LZMA: COMPRESS_ALGO_LZMA,
             COMPRESSION_7Z_COPY: COMPRESS_ALGO_7Z_COPY,
         }.get(compression, "")
-        tool_info_command = (
-            "#!/bin/bash\n"
-            'echo program="7z"\\; '
-            f'algorithm="{algo}"\\; '
-            'version="`7z | grep Version`"'
-        )
+        version = get_7z_version()
     else:
         raise NotImplementedError(
             _("Algorithm %(algorithm)s not implemented") % {"algorithm": compression}
         )
-
-    return tool_info_command
+    return f"program={program}; algorithm={algo}; version={version}"
 
 
 def get_7z_version():

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -165,14 +165,29 @@ def test_get_tool_info_fails_if_compression_algorithm_is_not_implemented():
             'program="7z"; version="p7zip Version 3.0"',
         ),
         (
+            utils.COMPRESSION_7Z_BZIP,
+            "\n7-Zip 23.01 (x64)\n 64-bit locale=C.UTF-8\nsomething else",
+            'program="7z"; version="7-Zip 23.01 (x64) 64-bit locale=C.UTF-8"',
+        ),
+        (
             utils.COMPRESSION_7Z_LZMA,
             "\n7z command\np7zip Version 3.0\nsomething else",
             'program="7z"; version="p7zip Version 3.0"',
         ),
         (
+            utils.COMPRESSION_7Z_LZMA,
+            "\n7-Zip 23.01 (x64)\n 64-bit locale=C.UTF-8\nsomething else",
+            'program="7z"; version="7-Zip 23.01 (x64) 64-bit locale=C.UTF-8"',
+        ),
+        (
             utils.COMPRESSION_7Z_COPY,
             "\n7z command\np7zip Version 3.0\nsomething else",
             'program="7z"; version="p7zip Version 3.0"',
+        ),
+        (
+            utils.COMPRESSION_7Z_COPY,
+            "\n7-Zip 23.01 (x64)\n 64-bit locale=C.UTF-8\nsomething else",
+            'program="7z"; version="7-Zip 23.01 (x64) 64-bit locale=C.UTF-8"',
         ),
         (
             utils.COMPRESSION_TAR,

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -128,18 +128,18 @@ def test_get_tool_info_command(compression, command):
     [
         (
             utils.COMPRESSION_7Z_BZIP,
-            "7z command\nVersion 3.0\nsomething else",
-            'program="7z"; version="Version 3.0"',
+            "\n7z command\np7zip Version 3.0\nsomething else",
+            'program="7z"; version="p7zip Version 3.0"',
         ),
         (
             utils.COMPRESSION_7Z_LZMA,
-            "7z command\nVersion 3.0\nsomething else",
-            'program="7z"; version="Version 3.0"',
+            "\n7z command\np7zip Version 3.0\nsomething else",
+            'program="7z"; version="p7zip Version 3.0"',
         ),
         (
             utils.COMPRESSION_7Z_COPY,
-            "7z command\nVersion 3.0\nsomething else",
-            'program="7z"; version="Version 3.0"',
+            "\n7z command\np7zip Version 3.0\nsomething else",
+            'program="7z"; version="p7zip Version 3.0"',
         ),
         (
             utils.COMPRESSION_TAR,

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 import shutil
 import tarfile
 from collections import namedtuple
@@ -13,9 +14,9 @@ TEST_DIR = pathlib.Path(__file__).resolve().parent
 FIXTURES_DIR = TEST_DIR / "fixtures"
 
 # Until further work is done to bring compression into its own module we can
-# use these constants for this test, but we can do better.
-PROG_VERS_7Z = "7z"
-PROG_VERS_TAR = "tar"
+# use these regular expression patterns for this test, but we can do better.
+PROG_VERS_7Z = r"(p7zip|7-Zip)"
+PROG_VERS_TAR = r"tar"
 
 # Specifically string types for the tuple we create.
 COMPRESS_ORDER_ONE = "1"
@@ -171,7 +172,7 @@ def test_get_compression_event_detail(
 
 
 @pytest.mark.parametrize(
-    "compression, version,extension,program_name,transform",
+    "compression,version,extension,program_name,transform",
     [
         (
             utils.COMPRESSION_7Z_BZIP,
@@ -256,7 +257,7 @@ def test_get_format_info(compression, version, extension, program_name, transfor
     """
     fsentry = FSEntry()
     vers, ext, prog_name = utils.set_compression_transforms(fsentry, compression, 1)
-    assert version in vers
+    assert re.search(version, vers) is not None
     assert ext == extension
     assert program_name in prog_name
     assert fsentry.transform_files == transform

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -88,39 +88,72 @@ def test_get_compress_command(compression, command):
 
 
 @pytest.mark.parametrize(
-    "compression,command",
+    "compression,expected_program,expected_algorithm",
     [
-        (
-            utils.COMPRESSION_7Z_BZIP,
-            '#!/bin/bash\necho program="7z"\\; algorithm="bzip2"\\; version="`7z | grep Version`"',
-        ),
+        (utils.COMPRESSION_7Z_BZIP, "7z", utils.COMPRESS_ALGO_BZIP2),
         (
             utils.COMPRESSION_7Z_LZMA,
-            '#!/bin/bash\necho program="7z"\\; algorithm="lzma"\\; version="`7z | grep Version`"',
+            "7z",
+            utils.COMPRESS_ALGO_LZMA,
         ),
         (
             utils.COMPRESSION_7Z_COPY,
-            '#!/bin/bash\necho program="7z"\\; algorithm="copy"\\; version="`7z | grep Version`"',
+            "7z",
+            utils.COMPRESS_ALGO_7Z_COPY,
         ),
         (
             utils.COMPRESSION_TAR,
-            'echo program="tar"\\; algorithm=""\\; version="`tar --version | grep tar`"',
+            "tar",
+            "",
         ),
         (
             utils.COMPRESSION_TAR_GZIP,
-            'echo program="tar"\\; algorithm="-z"\\; version="`tar --version | grep tar`"',
+            "tar",
+            "-z",
         ),
         (
             utils.COMPRESSION_TAR_BZIP2,
-            'echo program="tar"\\; algorithm="-j"\\; version="`tar --version | grep tar`"',
+            "tar",
+            "-j",
         ),
     ],
 )
-def test_get_tool_info_command(compression, command):
-    cmd = utils.get_tool_info_command(compression)
-    assert cmd == command, (
-        f"Incorrect tool info: {cmd} returned for compression input {compression}"
+@mock.patch("subprocess.check_output")
+def test_get_tool_info(check_output, compression, expected_program, expected_algorithm):
+    if expected_program == "7z":
+        expected_version = "p7zip Version 16.02"
+        command_output = b"\n".join(
+            [
+                b"",
+                b"7-Zip [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21",
+                expected_version.encode(),
+            ]
+        )
+    elif expected_program == "tar":
+        expected_version = "tar (GNU tar) 1.35"
+        command_output = b"\n".join(
+            [
+                expected_version.encode(),
+                b"Copyright (C) 2023 Free Software Foundation, Inc.",
+            ]
+        )
+    else:
+        raise AssertionError(f"unexpected program {expected_program}")
+    check_output.return_value = command_output
+    expected_output = f"program={expected_program}; algorithm={expected_algorithm}; version={expected_version}"
+
+    output = utils.get_tool_info(compression)
+
+    assert output == expected_output, (
+        f"Incorrect tool info: {output} returned for compression input {compression}"
     )
+
+
+def test_get_tool_info_fails_if_compression_algorithm_is_not_implemented():
+    with pytest.raises(
+        NotImplementedError, match="Algorithm unknown and random not implemented"
+    ):
+        utils.get_tool_info("unknown and random")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is preparatory work for upgrading to Ubuntu 24.04 which contains a newer version of the `7z` command.

A notable difference in the new version of `7z` is that the output doesn't include an explicit `Version` string which is what the Storage Service currently looks for, so this PR updates the `get_7z_version` helper to work across versions.

The current order of commits are:

* 998bd50425f61a516cef1cfd0d9905bc35c84b97 extends test coverage of the `import_aip` management command to ensure the PREMIS `compression` event has been created with the correct details
* 8fd5bf14cade87b23364b09519f66fccbc756b8a updates the test of the `get_format_info` helper to be compatible with newer `7z` versions
* a6f4e33c9ce51a8e516b2704bbd03886f75f82a9 updates the `get_7z_version` helper and its tests to be compatible with newer `7z` versions (check the commit message for output samples)
* fa79dc71f7fa3cb6e56ad68bb8d8e0e5e8e77aa6 replaces the temporary bash scripts created for getting the version of the compression tools with the `get_7z_version` and `get_tar_version` helpers.
* b214b335b347fd810a5ca56cfc09fd181c1e6f75 adds test cases to ensure the `get_7z_version` helper works correctly with the output of the latest `7z` version.

Connected to https://github.com/archivematica/Issues/issues/1729