### PR TITLE
Do not show user API keys

### DIFF
--- a/src/archivematica/storage_service/administration/forms.py
+++ b/src/archivematica/storage_service/administration/forms.py
@@ -293,7 +293,7 @@ class UserChangeForm(auth.forms.UserChangeForm):
     )
     regenerate_api_key = forms.BooleanField(
         widget=forms.CheckboxInput,
-        label="Regenerate API key (shown below)?",
+        label="Regenerate API key?",
         required=False,
     )
 

--- a/src/archivematica/storage_service/administration/forms.py
+++ b/src/archivematica/storage_service/administration/forms.py
@@ -291,6 +291,11 @@ class UserChangeForm(auth.forms.UserChangeForm):
         choices=roles.USER_ROLES,
         help_text=ROLE_FIELD_HELP_TEXT,
     )
+    regenerate_api_key = forms.BooleanField(
+        widget=forms.CheckboxInput,
+        label="Regenerate API key (shown below)?",
+        required=False,
+    )
 
     class Meta:
         model = auth.get_user_model()

--- a/src/archivematica/storage_service/administration/views.py
+++ b/src/archivematica/storage_service/administration/views.py
@@ -93,7 +93,9 @@ def user_edit(request, id):
     user_form = settings_forms.UserChangeForm(
         request.POST or None, instance=edit_user, current_user=request.user
     )
-    password_form = SetPasswordForm(data=request.POST or None, user=edit_user)
+    password_form = SetPasswordForm(
+        data=request.POST if "password" in request.POST else None, user=edit_user
+    )
     if "user" in request.POST and user_form.is_valid():
         if user_form.cleaned_data["regenerate_api_key"]:
             api_key = ApiKey.objects.get(user=edit_user)
@@ -101,11 +103,11 @@ def user_edit(request, id):
             api_key.save()
         user_form.save()
         messages.success(request, _("User information saved."))
-        return redirect("administration:user_list")
+        return redirect("administration:user_edit", id=edit_user.pk)
     elif "password" in request.POST and password_form.is_valid():
         password_form.save()
         messages.success(request, _("Password changed."))
-        return redirect("administration:user_list")
+        return redirect("administration:user_edit", id=edit_user.pk)
     elif "password":
         # Ensure user form information still displays after an invalid
         # password change attempt.

--- a/src/archivematica/storage_service/administration/views.py
+++ b/src/archivematica/storage_service/administration/views.py
@@ -95,14 +95,15 @@ def user_edit(request, id):
     )
     password_form = SetPasswordForm(data=request.POST or None, user=edit_user)
     if "user" in request.POST and user_form.is_valid():
+        if user_form.cleaned_data["regenerate_api_key"]:
+            api_key = ApiKey.objects.get(user=edit_user)
+            api_key.key = api_key.generate_key()
+            api_key.save()
         user_form.save()
         messages.success(request, _("User information saved."))
         return redirect("administration:user_list")
     elif "password" in request.POST and password_form.is_valid():
         password_form.save()
-        api_key = ApiKey.objects.get(user=edit_user)
-        api_key.key = api_key.generate_key()
-        api_key.save()
         messages.success(request, _("Password changed."))
         return redirect("administration:user_list")
     elif "password":

--- a/src/archivematica/storage_service/administration/views.py
+++ b/src/archivematica/storage_service/administration/views.py
@@ -10,6 +10,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
 from django.shortcuts import render
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import get_language
 from django.utils.translation import gettext as _
@@ -81,6 +82,15 @@ def user_list(request):
     return render(request, "administration/user_list.html", locals())
 
 
+def _show_api_key_alert(request, key):
+    messages.success(
+        request,
+        render_to_string(
+            "administration/user_api_key_alert.html", {"key": key}, request
+        ),
+    )
+
+
 def user_edit(request, id):
     edit_allowed = settings.ALLOW_USER_EDITS and (
         request.user.has_perm("auth.change_user") or request.user.id == id
@@ -101,6 +111,7 @@ def user_edit(request, id):
             api_key = ApiKey.objects.get(user=edit_user)
             api_key.key = api_key.generate_key()
             api_key.save()
+            _show_api_key_alert(request, api_key.key)
         user_form.save()
         messages.success(request, _("User information saved."))
         return redirect("administration:user_edit", id=edit_user.pk)

--- a/src/archivematica/storage_service/locations/forms.py
+++ b/src/archivematica/storage_service/locations/forms.py
@@ -56,6 +56,13 @@ class PipelineForm(forms.ModelForm):
         help_text=_("Enabled if default locations should be created for this pipeline"),
     )
 
+    api_key = forms.CharField(
+        label=_("API key"),
+        help_text=_("API key to use when making API calls to the pipeline."),
+        required=False,
+        widget=forms.PasswordInput,
+    )
+
     class Meta:
         model = models.Pipeline
         fields = (
@@ -66,6 +73,13 @@ class PipelineForm(forms.ModelForm):
             "api_key",
             "enabled",
         )
+
+    def save(self, *args, **kwargs):
+        if not self.cleaned_data["api_key"]:
+            # If the API key was not provided, remove it from the cleaned data
+            # to avoid overwriting its existing stored value.
+            del self.cleaned_data["api_key"]
+        return super().save(*args, **kwargs)
 
 
 class SpaceForm(forms.ModelForm):

--- a/src/archivematica/storage_service/static/js/project.js
+++ b/src/archivematica/storage_service/static/js/project.js
@@ -272,4 +272,41 @@ $(document).ready(function () {
     // Append modified clone after last header
     $last_header.after($clone);
   });
+
+  // Set up the button which allows users to copy the API key to the clipboard.
+  $("#copy-api-key-button")
+    .tooltip()
+    .click(function () {
+      var $button = $(this);
+      navigator.clipboard
+        .writeText($("#api-key").val())
+        .then(function () {
+          var $button_icon = $("#copy-button-icon");
+          var $icon_original_class = $button_icon.data("icon-original-class");
+          var $icon_clicked_class = $button_icon.data("icon-clicked-class");
+
+          // Update the button icon.
+          $button_icon
+            .removeClass($icon_original_class)
+            .addClass($icon_clicked_class);
+
+          // Update the button tooltip.
+          $button
+            .attr("data-original-title", $button.data("label-clicked"))
+            .tooltip("show");
+
+          // Reset the button after 2 seconds.
+          setTimeout(function () {
+            $button_icon
+              .removeClass($icon_clicked_class)
+              .addClass($icon_original_class);
+            $button
+              .attr("data-original-title", $button.data("label-original"))
+              .tooltip("hide");
+          }, 2000);
+        })
+        .catch(function (err) {
+          console.error("Failed to copy API key to clipboard: ", err);
+        });
+    });
 });

--- a/src/archivematica/storage_service/templates/administration/user_api_key_alert.html
+++ b/src/archivematica/storage_service/templates/administration/user_api_key_alert.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<p>{% trans "Make sure to copy the API key now as you will not be able to see it again." %}</p>
+{% trans 'Copy' as label_copy %}
+{% trans 'Copied!' as label_copied %}
+<div class="input-prepend">
+  <button id="copy-api-key-button" class="btn"
+      title="{{ label_copy }}"
+      data-label-original="{{ label_copy }}"
+      data-label-clicked="{{ label_copied }}"
+      data-placement="bottom" style="margin: 0 -1px 0 0;">
+      <i id="copy-button-icon" class="icon-share" data-icon-original-class="icon-share" data-icon-clicked-class="icon-ok"></i>
+  </button>
+  <input type="text" id="api-key" value="{{ key }}" class="input-xxlarge" disabled style="cursor: default;" >
+</div>

--- a/src/archivematica/storage_service/templates/administration/user_detail.html
+++ b/src/archivematica/storage_service/templates/administration/user_detail.html
@@ -14,10 +14,6 @@
       <dd>{{ user.get_full_name }}</dd>
       <dt>{% trans "E-mail" %}</dt>
       <dd>{{ user.email }}</dd>
-      {% if display_user.api_key %}
-        <dt>{% trans "API key" %}:</dt>
-        <dd><code>{{ display_user.api_key.key }}</code></dd>
-      {% endif %}
     </dl>
 </div>
 {% endblock %}

--- a/src/archivematica/storage_service/templates/administration/user_form.html
+++ b/src/archivematica/storage_service/templates/administration/user_form.html
@@ -13,6 +13,11 @@
     {% endif %}
       {% csrf_token %}
       {{ user_form.as_p }}
+      {% if edit_user and edit_user.api_key %}
+      <p>
+        <code>{{ edit_user.api_key.key }}</code>
+      </p>
+      {% endif %}
       <input type="submit" name='user' value="{{ action }}" class='btn btn-primary' />
     </form>
 
@@ -20,16 +25,9 @@
     <form action="{% url 'administration:user_edit' edit_user.id %}" method="post">
       {% csrf_token %}
       {{ password_form.as_p }}
-      <p>{% trans "Note: if you change your password, your API key will also be changed to a new, randomly generated one." %}</p>
       <input type="submit" name='password' value="{% trans "Change Password" %}" class='btn btn-primary' />
     </form>
     {% endif %}
 
-    {% if edit_user and edit_user.api_key %}
-    <p>
-      <label>{% trans "API key" %}:</label>
-      <code>{{ edit_user.api_key.key }}</code>
-    </p>
-    {% endif %}
 </div>
 {% endblock %}

--- a/src/archivematica/storage_service/templates/administration/user_form.html
+++ b/src/archivematica/storage_service/templates/administration/user_form.html
@@ -13,11 +13,6 @@
     {% endif %}
       {% csrf_token %}
       {{ user_form.as_p }}
-      {% if edit_user and edit_user.api_key %}
-      <p>
-        <code>{{ edit_user.api_key.key }}</code>
-      </p>
-      {% endif %}
       <input type="submit" name='user' value="{{ action }}" class='btn btn-primary' />
     </form>
 

--- a/src/archivematica/storage_service/templates/locations/pipeline_detail.html
+++ b/src/archivematica/storage_service/templates/locations/pipeline_detail.html
@@ -10,7 +10,7 @@
     <dt>{% trans "UUID" %}</dt> <dd>{{ pipeline.uuid }}</dd>
     <dt>{% trans "Description" %}</dt> <dd>{{ pipeline.description|default:_("&lt;None&gt;") }}</dd>
     <dt>{% trans "Remote name" %}</dt> <dd>{{ pipeline.remote_name|default:_("&lt;None&gt;") }}</dd>
-    <dt>{% trans "API Username / Key" %}</dt> <dd> {{ pipeline.api_username|default:_("&lt;None&gt;") }} / {{ pipeline.api_key|default:_("&lt;None&gt;") }}</dd>
+    <dt>{% trans "API Username" %}</dt> <dd>{{ pipeline.api_username|default:_("&lt;None&gt;") }}</dd>
     <dt>{% trans "Enabled" %}</dt> <dd>{{ pipeline.enabled|yesno:_("Enabled,Disabled") }}</dd>
     {% if perms.locations.change_pipeline %}
       <dt>{% trans "Actions" %}</dt> <dd>

--- a/tests/administration/test_users.py
+++ b/tests/administration/test_users.py
@@ -183,8 +183,6 @@ def test_user_edit_view_regenerates_api_key(
     admin_user_apikey: ApiKey,
 ) -> None:
     user = django_user_model.objects.get(username="admin")
-    assert user.check_password("password")
-    new_password = "ck61Qc873.KxoZ5G"
     expected_uuid = uuid.uuid4()
     expected_key = hmac.new(expected_uuid.bytes, digestmod=sha1).hexdigest()
 
@@ -192,17 +190,15 @@ def test_user_edit_view_regenerates_api_key(
         response = admin_client.post(
             reverse("administration:user_edit", kwargs={"id": user.pk}),
             {
-                "new_password1": new_password,
-                "new_password2": new_password,
-                "password": "1",
+                "user": "Edit User",
+                "username": user.username,
+                "regenerate_api_key": True,
             },
             follow=True,
         )
         assert response.status_code == 200
 
-    user.refresh_from_db()
-    assert user.check_password(new_password)
-    assert "Password changed" in response.content.decode()
+    assert "User information saved." in response.content.decode()
 
     admin_user_apikey.refresh_from_db()
     assert admin_user_apikey.key == expected_key

--- a/tests/locations/test_pipeline.py
+++ b/tests/locations/test_pipeline.py
@@ -264,7 +264,7 @@ def test_pipeline_detail_view_shows_pipeline_fields(
     assert f"<dd>{pipeline.uuid}</dd>" in content
     assert f"<dd>{pipeline.description}</dd>" in content
     assert f"<dd>{pipeline.remote_name}</dd>" in content
-    assert f"<dd> {pipeline.api_username} / {pipeline.api_key}</dd>" in content
+    assert f"<dd>{pipeline.api_username}</dd>" in content
     assert "No locations currently exist" in content
 
 

--- a/tests/locations/test_pipeline.py
+++ b/tests/locations/test_pipeline.py
@@ -221,6 +221,37 @@ def test_view_edit_pipeline_post(
     assert str(messages[0]) == "Pipeline saved."
 
 
+def test_view_edit_pipeline_post_updates_fields_when_api_key_is_not_set(
+    admin_client: Client, pipeline: models.Pipeline
+) -> None:
+    url = reverse("locations:pipeline_edit", args=[pipeline.uuid])
+    description = "Pipeline 3ebf"
+    remote_name = "localhost"
+    api_username = "newapiusername"
+    old_api_key = pipeline.api_key
+
+    resp = admin_client.post(
+        url,
+        follow=True,
+        data={
+            "uuid": str(pipeline.uuid),
+            "description": description,
+            "remote_name": remote_name,
+            "api_username": api_username,
+        },
+    )
+    messages = list(resp.context["messages"])
+
+    pipeline.refresh_from_db()
+    assert pipeline.description == description
+    assert pipeline.remote_name == remote_name
+    assert pipeline.api_username == api_username
+    assert str(messages[0]) == "Pipeline saved."
+
+    # The existing API key value was not modified.
+    assert pipeline.api_key == old_api_key
+
+
 def test_pipeline_detail_view_shows_pipeline_fields(
     admin_client: Client, pipeline: models.Pipeline
 ) -> None:


### PR DESCRIPTION
This is similar to https://github.com/artefactual/archivematica/pull/2041

It updates the detail and edit view of pipelines to not show the API key of the user that connects with the Archivematica pipeline. The current plain text field has been replaced with a password field to do so.

The user edit view has been updated to have a `Regenerate API key` checkbox similar to the one in the Dashboard which replaces the `if you change your password, your API key will also be changed to a new, randomly generated one` approach.

![Captura desde 2025-03-31 09-54-00](https://github.com/user-attachments/assets/3d92490a-4f69-422b-82fc-82fcc34569d6)

Finally the Storage Service user views and their redirects have been updated to show the API key only once on re-generation.  This uses Django's [messages framework](https://docs.djangoproject.com/en/4.2/ref/contrib/messages/) to render an alert with a button to copy the API key to the browser's clipboard.

![Captura desde 2025-03-31 09-54-19](https://github.com/user-attachments/assets/ca571eee-38aa-45be-9994-e254b3098b79)

![Captura desde 2025-03-31 09-54-35](https://github.com/user-attachments/assets/d0fc8129-c4e5-4ba3-8b3a-0d7c6e99dd78)







Connected to https://github.com/archivematica/Issues/issues/1736