### PR TITLE
Replace importlib-resources package

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -110,8 +110,6 @@ importlib-metadata==8.6.1
     # via
     #   build
     #   pytest-randomly
-importlib-resources==6.5.2
-    # via -r /src/requirements.txt
 iniconfig==2.0.0
     # via pytest
 iso8601==2.1.0
@@ -372,10 +370,7 @@ wrapt==1.17.2
     #   -r /src/requirements.txt
     #   debtcollector
 zipp==3.21.0
-    # via
-    #   -r /src/requirements.txt
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata
 zope-event==5.0
     # via
     #   -r /src/requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,6 @@ django-tastypie
 dj-database-url
 gevent
 gunicorn
-importlib_resources
 jsonfield
 lxml
 metsrw

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,8 +66,6 @@ httplib2==0.22.0
     # via sword2
 idna==3.10
     # via requests
-importlib-resources==6.5.2
-    # via -r requirements.in
 iso8601==2.1.0
     # via
     #   keystoneauth1
@@ -212,8 +210,6 @@ whitenoise==6.9.0
     # via -r requirements.in
 wrapt==1.17.2
     # via debtcollector
-zipp==3.21.0
-    # via importlib-resources
 zope-event==5.0
     # via gevent
 zope-interface==7.2

--- a/src/archivematica/storage_service/locations/models/package.py
+++ b/src/archivematica/storage_service/locations/models/package.py
@@ -1,6 +1,7 @@
 import codecs
 import copy
 import distutils.dir_util
+import importlib.resources
 import json
 import logging
 import os
@@ -13,7 +14,6 @@ from pathlib import Path
 from uuid import uuid4
 
 import bagit
-import importlib_resources
 import jsonfield
 import metsrw
 import requests
@@ -1451,7 +1451,7 @@ class Package(models.Model):
 
         # Use local XML schemas for validation.
         os.environ["XML_CATALOG_FILES"] = str(
-            importlib_resources.files("archivematica.storage_service.common")
+            importlib.resources.files("archivematica.storage_service.common")
             / "assets"
             / "catalog.xml"
         )


### PR DESCRIPTION
Similar to https://github.com/artefactual/archivematica/pull/2044 this
update replaces the third-party `importlib-resources` package with
Python's built-in `importlib.resources` module for locating asset
files.

Connected to https://github.com/archivematica/Issues/issues/1720