### PR TITLE
Add ability to set user roles from OIDC claims 

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -579,6 +579,22 @@ If `SS_OIDC_AUTHENTICATION` is false, none of the other ones are used.
   - **Type:** `string`
   - **Default:** `''`
 
+- **`OIDC_OP_SET_ROLES_FROM_CLAIMS`**:
+  - **Description:** Set user roles from OIDC token claims
+  - **Type:** `boolean`
+  - **Default:** `False`
+
+- **`OIDC_OP_ROLE_CLAIM_PATH`**:
+  - **Description:** Set OIDC token path for extracting role info
+  - **Type:** `string`
+  - **Default:** `'realm_access.roles'`
+
+- **`OIDC_ACCESS_ATTRIBUTE_MAP`**
+  - **Description:** Set OIDC token details to extract. This string should be
+    JSON-decodable.
+  - **Type:** `string`
+  - **Default:** `{"given_name": "first_name", "family_name": "last_name"}`
+
 - **`OIDC_RP_SIGN_ALGO`**:
   - **Description:** Algorithm used by the ID provider to sign ID tokens
   - **Type:** `string`

--- a/src/archivematica/storage_service/administration/roles.py
+++ b/src/archivematica/storage_service/administration/roles.py
@@ -15,6 +15,11 @@ USER_ROLE_ADMIN = "admin"
 USER_ROLE_MANAGER = "manager"
 USER_ROLE_REVIEWER = "reviewer"
 USER_ROLE_READER = "reader"
+
+# The roles are ordered from highest to lowest permission in this list. This
+# feature is used in OIDC authentication to determine the highest permission
+# role of a user based on the claims received when multiple roles are
+# received.
 USER_ROLES = [
     # Users with the is_superuser flag enabled.
     (USER_ROLE_ADMIN, _("Administrator")),

--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -637,13 +637,24 @@ if OIDC_AUTHENTICATION:
         OIDC_OP_JWKS_ENDPOINT = environ.get("OIDC_OP_JWKS_ENDPOINT", "")
         OIDC_OP_LOGOUT_ENDPOINT = environ.get("OIDC_OP_LOGOUT_ENDPOINT", "")
 
+    OIDC_OP_SET_ROLES_FROM_CLAIMS = is_true(
+        environ.get("OIDC_OP_SET_ROLES_FROM_CLAIMS", "")
+    )
+    OIDC_OP_ROLE_CLAIM_PATH = environ.get(
+        "OIDC_OP_ROLE_CLAIM_PATH", "realm_access.roles"
+    )
+
+    DEFAULT_OIDC_CLAIMS = {"given_name": "first_name", "family_name": "last_name"}
+
     OIDC_SECONDARY_PROVIDER_NAMES = environ.get(
         "OIDC_SECONDARY_PROVIDER_NAMES", ""
     ).split(",")
     OIDC_PROVIDER_QUERY_PARAM_NAME = environ.get(
         "OIDC_PROVIDER_QUERY_PARAM_NAME", "secondary"
     )
-    OIDC_PROVIDERS = get_oidc_secondary_providers(OIDC_SECONDARY_PROVIDER_NAMES)
+    OIDC_PROVIDERS = get_oidc_secondary_providers(
+        OIDC_SECONDARY_PROVIDER_NAMES, DEFAULT_OIDC_CLAIMS
+    )
 
     if OIDC_OP_LOGOUT_ENDPOINT:
         OIDC_OP_LOGOUT_URL_METHOD = (
@@ -664,7 +675,12 @@ if OIDC_AUTHENTICATION:
     OIDC_USERNAME_ALGO = _get_email
 
     # map attributes from access token
-    OIDC_ACCESS_ATTRIBUTE_MAP = {"given_name": "first_name", "family_name": "last_name"}
+    try:
+        OIDC_ACCESS_ATTRIBUTE_MAP = json.loads(
+            environ.get("OIDC_ACCESS_ATTRIBUTE_MAP", json.dumps(DEFAULT_OIDC_CLAIMS))
+        )
+    except json.JSONDecodeError:
+        OIDC_ACCESS_ATTRIBUTE_MAP = DEFAULT_OIDC_CLAIMS
 
     # map attributes from id token
     OIDC_ID_ATTRIBUTE_MAP = {"email": "email"}

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -42,6 +42,10 @@ services:
       OIDC_OP_USER_ENDPOINT: "http://keycloak:8080/realms/demo/protocol/openid-connect/userinfo"
       OIDC_OP_JWKS_ENDPOINT: "http://keycloak:8080/realms/demo/protocol/openid-connect/certs"
       OIDC_OP_LOGOUT_ENDPOINT: "http://keycloak:8080/realms/demo/protocol/openid-connect/logout"
+      OIDC_OP_SET_ROLES_FROM_CLAIMS: "true"
+      OIDC_OP_ROLE_CLAIM_PATH: "realm_access.roles"
+      OIDC_ACCESS_ATTRIBUTE_MAP: >
+        {"given_name": "first_name", "family_name": "last_name", "realm_access": "realm_access"}
       OIDC_SECONDARY_PROVIDER_NAMES: "secondary"
       OIDC_RP_CLIENT_ID_SECONDARY: "am-storage-service-secondary"
       OIDC_RP_CLIENT_SECRET_SECONDARY: "example-secret-secondary"
@@ -50,6 +54,10 @@ services:
       OIDC_OP_USER_ENDPOINT_SECONDARY: "http://keycloak:8080/realms/secondary/protocol/openid-connect/userinfo"
       OIDC_OP_JWKS_ENDPOINT_SECONDARY: "http://keycloak:8080/realms/secondary/protocol/openid-connect/certs"
       OIDC_OP_LOGOUT_ENDPOINT_SECONDARY: "http://keycloak:8080/realms/secondary/protocol/openid-connect/logout"
+      OIDC_OP_SET_ROLES_FROM_CLAIMS_SECONDARY: "true"
+      OIDC_OP_ROLE_CLAIM_PATH_SECONDARY: "realm_access.roles"
+      OIDC_ACCESS_ATTRIBUTE_MAP_SECONDARY: >
+        {"given_name": "first_name", "family_name": "last_name", "realm_access": "realm_access"}
       OIDC_RP_SIGN_ALGO: "RS256"
     volumes:
       - "../../:/src"

--- a/tests/integration/etc/keycloak/realm.json
+++ b/tests/integration/etc/keycloak/realm.json
@@ -11,6 +11,18 @@
     "attributes": {
       "adminEventsExpiration": "900"
     },
+    "roles": {
+      "realm": [
+        {
+          "name": "admin",
+          "description": "Administrator role"
+        },
+        {
+          "name": "reader",
+          "description": "Reader role"
+        }
+      ]
+    },
     "clients": [
       {
         "id": "am-storage-service",
@@ -49,6 +61,9 @@
             "type": "password",
             "value": "demo"
           }
+        ],
+        "realmRoles": [
+          "reader"
         ]
       }
     ]
@@ -64,6 +79,18 @@
     "adminEventsDetailsEnabled": true,
     "attributes": {
       "adminEventsExpiration": "900"
+    },
+    "roles": {
+      "realm": [
+        {
+          "name": "admin",
+          "description": "Administrator role"
+        },
+        {
+          "name": "reader",
+          "description": "Reader role"
+        }
+      ]
     },
     "clients": [
       {
@@ -90,10 +117,10 @@
     ],
     "users": [
       {
-        "id": "support",
-        "email": "support@example.com",
-        "username": "support",
-        "firstName": "Support",
+        "id": "support-admin",
+        "email": "supportadmin@example.com",
+        "username": "supportadmin",
+        "firstName": "SupportAdmin",
         "lastName": "User",
         "enabled": true,
         "emailVerified": true,
@@ -103,6 +130,28 @@
             "type": "password",
             "value": "support"
           }
+        ],
+        "realmRoles": [
+          "admin"
+        ]
+      },
+      {
+        "id": "support-reader",
+        "email": "supportreader@example.com",
+        "username": "supportreader",
+        "firstName": "SupportReader",
+        "lastName": "User",
+        "enabled": true,
+        "emailVerified": true,
+        "credentials": [
+          {
+            "temporary": false,
+            "type": "password",
+            "value": "support"
+          }
+        ],
+        "realmRoles": [
+          "reader"
         ]
       }
     ]

--- a/tests/storage_service/test_helpers.py
+++ b/tests/storage_service/test_helpers.py
@@ -39,13 +39,21 @@ def test_get_oidc_secondary_providers_ignores_provider_if_client_id_and_secret_a
     monkeypatch.setenv("OIDC_RP_CLIENT_ID_BAR", "bar-client-id")
     monkeypatch.setenv("OIDC_RP_CLIENT_SECRET_BAZ", "foo-secret")
 
-    assert helpers.get_oidc_secondary_providers(["FOO", "BAR", "BAZ"]) == {
+    assert helpers.get_oidc_secondary_providers(
+        ["FOO", "BAR", "BAZ"], {"given_name": "first_name", "family_name": "last_name"}
+    ) == {
         "FOO": {
             "OIDC_OP_AUTHORIZATION_ENDPOINT": "",
             "OIDC_OP_JWKS_ENDPOINT": "",
             "OIDC_OP_LOGOUT_ENDPOINT": "",
             "OIDC_OP_TOKEN_ENDPOINT": "",
             "OIDC_OP_USER_ENDPOINT": "",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS": False,
+            "OIDC_OP_ROLE_CLAIM_PATH": "realm_access.roles",
+            "OIDC_ACCESS_ATTRIBUTE_MAP": {
+                "given_name": "first_name",
+                "family_name": "last_name",
+            },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
         }
@@ -60,13 +68,21 @@ def test_get_oidc_secondary_providers_strips_provider_names(
     monkeypatch.setenv("OIDC_RP_CLIENT_ID_BAR", "bar-client-id")
     monkeypatch.setenv("OIDC_RP_CLIENT_SECRET_BAR", "bar-client-secret")
 
-    assert helpers.get_oidc_secondary_providers(["  FOO", " BAR  "]) == {
+    assert helpers.get_oidc_secondary_providers(
+        ["  FOO", " BAR  "], {"given_name": "first_name", "family_name": "last_name"}
+    ) == {
         "FOO": {
             "OIDC_OP_AUTHORIZATION_ENDPOINT": "",
             "OIDC_OP_JWKS_ENDPOINT": "",
             "OIDC_OP_LOGOUT_ENDPOINT": "",
             "OIDC_OP_TOKEN_ENDPOINT": "",
             "OIDC_OP_USER_ENDPOINT": "",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS": False,
+            "OIDC_OP_ROLE_CLAIM_PATH": "realm_access.roles",
+            "OIDC_ACCESS_ATTRIBUTE_MAP": {
+                "given_name": "first_name",
+                "family_name": "last_name",
+            },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
         },
@@ -76,6 +92,12 @@ def test_get_oidc_secondary_providers_strips_provider_names(
             "OIDC_OP_LOGOUT_ENDPOINT": "",
             "OIDC_OP_TOKEN_ENDPOINT": "",
             "OIDC_OP_USER_ENDPOINT": "",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS": False,
+            "OIDC_OP_ROLE_CLAIM_PATH": "realm_access.roles",
+            "OIDC_ACCESS_ATTRIBUTE_MAP": {
+                "given_name": "first_name",
+                "family_name": "last_name",
+            },
             "OIDC_RP_CLIENT_ID": "bar-client-id",
             "OIDC_RP_CLIENT_SECRET": "bar-client-secret",
         },
@@ -90,13 +112,21 @@ def test_get_oidc_secondary_providers_capitalizes_provider_names(
     monkeypatch.setenv("OIDC_RP_CLIENT_ID_BAR", "bar-client-id")
     monkeypatch.setenv("OIDC_RP_CLIENT_SECRET_BAR", "bar-client-secret")
 
-    assert helpers.get_oidc_secondary_providers(["fOo", "bar"]) == {
+    assert helpers.get_oidc_secondary_providers(
+        ["fOo", "bar"], {"given_name": "first_name", "family_name": "last_name"}
+    ) == {
         "FOO": {
             "OIDC_OP_AUTHORIZATION_ENDPOINT": "",
             "OIDC_OP_JWKS_ENDPOINT": "",
             "OIDC_OP_LOGOUT_ENDPOINT": "",
             "OIDC_OP_TOKEN_ENDPOINT": "",
             "OIDC_OP_USER_ENDPOINT": "",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS": False,
+            "OIDC_OP_ROLE_CLAIM_PATH": "realm_access.roles",
+            "OIDC_ACCESS_ATTRIBUTE_MAP": {
+                "given_name": "first_name",
+                "family_name": "last_name",
+            },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
         },
@@ -106,6 +136,12 @@ def test_get_oidc_secondary_providers_capitalizes_provider_names(
             "OIDC_OP_LOGOUT_ENDPOINT": "",
             "OIDC_OP_TOKEN_ENDPOINT": "",
             "OIDC_OP_USER_ENDPOINT": "",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS": False,
+            "OIDC_OP_ROLE_CLAIM_PATH": "realm_access.roles",
+            "OIDC_ACCESS_ATTRIBUTE_MAP": {
+                "given_name": "first_name",
+                "family_name": "last_name",
+            },
             "OIDC_RP_CLIENT_ID": "bar-client-id",
             "OIDC_RP_CLIENT_SECRET": "bar-client-secret",
         },


### PR DESCRIPTION
Added new OIDC setting that will allow admins to configure whether user
roles will be set from the OIDC claims, or assigned the system default
role. The setting name is 'OIDC_OP_SET_ROLES_FROM_CLAIMS' and defaults
to False.

Added new OIDC setting that will configure the token path for retrieving
the role info. The setting name is 'OIDC_OP_ROLE_CLAIM_PATH' and
defaults to "realm_access.roles" which is the standard Keycloak location
for user role info.

Added new OIDC setting that will configure what information is extracted
from the OIDC token. The setting name is 'OIDC_ACCESS_ATTRIBUTE_MAP'
and the setting contents should be JSON-decodable.

These settings should be configured individually for each provider
appending the provider name for secondary providers as necessary.