### PR TITLE
Add integration test for Move package API endpoint

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -143,6 +143,15 @@ class Client:
     def download_file(self, file_id: uuid.UUID) -> HttpResponse:
         return self.admin_client.get(f"/api/v2/file/{file_id}/download/")
 
+    def get_file(self, file_id: uuid.UUID) -> HttpResponse:
+        return self.admin_client.get(f"/api/v2/file/{file_id}/")
+
+    def move_file(self, file_id: uuid.UUID, data: dict[str, str]) -> HttpResponse:
+        return self.admin_client.post(f"/api/v2/file/{file_id}/move/", data)
+
+    def get_async_task(self, async_task_url: str) -> HttpResponse:
+        return self.admin_client.get(async_task_url)
+
 
 @pytest.fixture(scope="session")
 def client(admin_client: TestClient) -> Client:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -998,6 +998,27 @@ class MoveAIPScenario(StorageScenario):
         ),
         pytest.param(
             MoveAIPScenario(
+                storage_protocol=Space.NFS,
+                pkg=COMPRESSED_PACKAGE,
+                compressed=True,
+                move_target_protocol=Space.RCLONE,
+            ),
+            id="move_compressed_from_nfs_to_rclone",
+        ),
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.NFS,
+                pkg=UNCOMPRESSED_PACKAGE,
+                compressed=False,
+                move_target_protocol=Space.RCLONE,
+            ),
+            id="move_uncompressed_from_nfs_to_rclone",
+            marks=pytest.mark.xfail(
+                reason="Fails because of https://github.com/archivematica/Issues/issues/1742"
+            ),
+        ),
+        pytest.param(
+            MoveAIPScenario(
                 storage_protocol=Space.LOCAL_FILESYSTEM,
                 pkg=COMPRESSED_PACKAGE,
                 compressed=True,
@@ -1031,6 +1052,27 @@ class MoveAIPScenario(StorageScenario):
                 move_target_protocol=Space.S3,
             ),
             id="move_uncompressed_from_local_fs_to_s3",
+            marks=pytest.mark.xfail(
+                reason="Fails because of https://github.com/archivematica/Issues/issues/1742"
+            ),
+        ),
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.LOCAL_FILESYSTEM,
+                pkg=COMPRESSED_PACKAGE,
+                compressed=True,
+                move_target_protocol=Space.RCLONE,
+            ),
+            id="move_compressed_from_local_fs_to_rclone",
+        ),
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.LOCAL_FILESYSTEM,
+                pkg=UNCOMPRESSED_PACKAGE,
+                compressed=False,
+                move_target_protocol=Space.RCLONE,
+            ),
+            id="move_uncompressed_from_local_fs_to_rclone",
             marks=pytest.mark.xfail(
                 reason="Fails because of https://github.com/archivematica/Issues/issues/1742"
             ),

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -186,6 +186,13 @@ def startup(working_directory_path: Path) -> None:
     startup(working_directory_path, start_async=False)  # TODO: get rid of this!
 
 
+@pytest.fixture(scope="function")
+def startup_async(working_directory_path: Path) -> None:
+    from archivematica.storage_service.common.startup import startup
+
+    startup(working_directory_path, start_async=True)
+
+
 def get_size(path: Path) -> int:
     if path.is_file():
         return path.stat().st_size

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -16,15 +16,18 @@ import shutil
 import tarfile
 import time
 import uuid
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from typing import Union
 
 import pytest
+from django.contrib.auth.models import Group
 from django.http import HttpResponse
 from django.test import Client as TestClient
 from django.urls import reverse
 from metsrw.plugins import premisrw
+from pytest_django.plugin import DjangoDbBlocker
 
 from archivematica.storage_service.common import utils
 from archivematica.storage_service.locations.models import Event
@@ -202,6 +205,22 @@ def startup_async(working_directory_path: Path) -> None:
     from archivematica.storage_service.common.startup import startup
 
     startup(working_directory_path, start_async=True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def recreate_user_groups(
+    django_db_setup: None, django_db_blocker: DjangoDbBlocker
+) -> Generator[None, None, None]:
+    """Recreate user groups added during the 0030_user_groups migration.
+
+    This ensures that tests dependent on these user groups can execute
+    correctly after transactional rollbacks executed by the test_move_aip test.
+    """
+    yield
+
+    with django_db_blocker.unblock():
+        Group.objects.get_or_create(name="Managers")
+        Group.objects.get_or_create(name="Reviewers")
 
 
 def get_size(path: Path) -> int:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -952,3 +952,103 @@ class MoveAIPScenario(StorageScenario):
                 utils.generate_checksum(extracted_path / self.pkg_name).hexdigest()
                 == utils.generate_checksum(self.pkg).hexdigest()
             )
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.NFS,
+                pkg=COMPRESSED_PACKAGE,
+                compressed=True,
+                move_target_protocol=Space.NFS,
+            ),
+            id="move_compressed_from_nfs_to_nfs",
+        ),
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.NFS,
+                pkg=UNCOMPRESSED_PACKAGE,
+                compressed=False,
+                move_target_protocol=Space.NFS,
+            ),
+            id="move_uncompressed_from_nfs_to_nfs",
+        ),
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.NFS,
+                pkg=COMPRESSED_PACKAGE,
+                compressed=True,
+                move_target_protocol=Space.S3,
+            ),
+            id="move_compressed_from_nfs_to_s3",
+        ),
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.NFS,
+                pkg=UNCOMPRESSED_PACKAGE,
+                compressed=False,
+                move_target_protocol=Space.S3,
+            ),
+            id="move_uncompressed_from_nfs_to_s3",
+            marks=pytest.mark.xfail(
+                reason="Fails because of https://github.com/archivematica/Issues/issues/1742"
+            ),
+        ),
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.LOCAL_FILESYSTEM,
+                pkg=COMPRESSED_PACKAGE,
+                compressed=True,
+                move_target_protocol=Space.LOCAL_FILESYSTEM,
+            ),
+            id="move_compressed_from_local_fs_to_local_fs",
+        ),
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.LOCAL_FILESYSTEM,
+                pkg=UNCOMPRESSED_PACKAGE,
+                compressed=False,
+                move_target_protocol=Space.LOCAL_FILESYSTEM,
+            ),
+            id="move_uncompressed_from_local_fs_to_local_fs",
+        ),
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.LOCAL_FILESYSTEM,
+                pkg=COMPRESSED_PACKAGE,
+                compressed=True,
+                move_target_protocol=Space.S3,
+            ),
+            id="move_compressed_from_local_fs_to_s3",
+        ),
+        pytest.param(
+            MoveAIPScenario(
+                storage_protocol=Space.LOCAL_FILESYSTEM,
+                pkg=UNCOMPRESSED_PACKAGE,
+                compressed=False,
+                move_target_protocol=Space.S3,
+            ),
+            id="move_uncompressed_from_local_fs_to_s3",
+            marks=pytest.mark.xfail(
+                reason="Fails because of https://github.com/archivematica/Issues/issues/1742"
+            ),
+        ),
+    ],
+)
+@pytest.mark.django_db(transaction=True)
+def test_move_aip(
+    startup_async: None,
+    scenario: MoveAIPScenario,
+    admin_client: TestClient,
+    working_directory_path: Path,
+    tmp_path: Path,
+) -> None:
+    scenario.init(admin_client, working_directory_path)
+    scenario.store_aip()
+    scenario.assert_stored()
+
+    move_target_location_uuid = scenario.register_move_target_aip_storage_location()
+    scenario.move_aip(move_target_location_uuid)
+    scenario.assert_moved(tmp_path, move_target_location_uuid)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -14,8 +14,10 @@ import json
 import os
 import shutil
 import tarfile
+import time
 import uuid
 from pathlib import Path
+from typing import Any
 from typing import Union
 
 import pytest
@@ -862,3 +864,91 @@ def test_aip_recovery_handles_recovery_copy_setup_error(
     content = resp.content.decode()
     assert "AIP restore failed: error accessing restore files" in content
     assert "Please contact an administrator or see logs for details" in content
+
+
+class MoveAIPScenario(StorageScenario):
+    def __init__(
+        self,
+        *,
+        storage_protocol: str,
+        pkg: Path,
+        compressed: bool,
+        move_target_protocol: str,
+    ) -> None:
+        super().__init__(
+            storage_protocol=storage_protocol, pkg=pkg, compressed=compressed
+        )
+        self.move_target_protocol = move_target_protocol
+
+    def register_move_target_aip_storage_location(self) -> uuid.UUID:
+        # Add space.
+        resp = self.client.add_space(
+            self._adjust_space_data(self.SPACES[self.move_target_protocol])
+        )
+        assert resp.status_code == 201
+        space = json.loads(resp.content)
+
+        # Add location.
+        resp = self.client.add_location(
+            {
+                "relative_path": "moved-aips",
+                "staging_path": "",
+                "purpose": Location.AIP_STORAGE,
+                "space": space["resource_uri"],
+                "pipeline": [f"/api/v2/pipeline/{self.PIPELINE_UUID}/"],
+            }
+        )
+        assert resp.status_code == 201
+        location = json.loads(resp.content)
+
+        return uuid.UUID(location["uuid"])
+
+    def move_aip(self, location_uuid: uuid.UUID) -> None:
+        resp = self.client.move_file(
+            self.PACKAGE_UUID, {"location_uuid": str(location_uuid)}
+        )
+        assert resp.status_code == 202
+
+        async_task_url = resp.headers["Location"]
+
+        # TODO: This might become unresponsive. Use tenacity retries.
+        async_task: dict[str, Any] = {}
+        while not async_task.get("completed"):
+            time.sleep(1)
+            resp = self.client.get_async_task(async_task_url)
+            async_task = json.loads(resp.content)
+
+        assert async_task["completed"]
+        assert async_task["result"] == "Package moved successfully"
+
+    def assert_moved(self, tmp_path: Path, location_uuid: uuid.UUID) -> None:
+        resp = self.client.get_file(self.PACKAGE_UUID)
+        assert resp.status_code == 200
+
+        aip = json.loads(resp.content)
+        assert aip["status"] == Package.UPLOADED
+
+        resp = self.client.get_locations({"uuid": str(location_uuid)})
+        assert resp.status_code == 200
+
+        location = json.loads(resp.content)["objects"][0]
+        assert aip["current_location"] == location["resource_uri"]
+
+        download_path = tmp_path / "download"
+        resp = self.client.download_file(self.PACKAGE_UUID)
+        download_path.write_bytes(b"".join(resp.streaming_content))
+
+        # Compare the downloaded package against the original fixtures.
+        if self.compressed:
+            assert (
+                utils.generate_checksum(download_path).hexdigest()
+                == utils.generate_checksum(self.pkg).hexdigest()
+            )
+        else:
+            assert tarfile.is_tarfile(download_path)
+            extracted_path = tmp_path / "extracted"
+            tarfile.TarFile(download_path).extractall(extracted_path)
+            assert (
+                utils.generate_checksum(extracted_path / self.pkg_name).hexdigest()
+                == utils.generate_checksum(self.pkg).hexdigest()
+            )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -238,7 +238,6 @@ class StorageScenario:
     """Storage test scenario."""
 
     PIPELINE_UUID = uuid.UUID("00000b87-1655-4b7e-bbf8-344b317da334")
-    PACKAGE_UUID = uuid.UUID("5658e603-277b-4292-9b58-20bf261c8f88")
 
     SPACES: dict[str, dict[str, Union[str, bool]]] = {
         Space.S3: {
@@ -282,6 +281,7 @@ class StorageScenario:
         pkg: Path,
         compressed: bool,
     ) -> None:
+        self.PACKAGE_UUID = uuid.uuid4()
         self.storage_protocol = storage_protocol
         self.replication_protocol = replication_protocol
         self.pkg = pkg


### PR DESCRIPTION
This adds an integration test for the [Move package](https://www.archivematica.org/en/docs/archivematica-1.17/dev-manual/api/api-reference-storage-service/#move-package) API endpoint that uses the asynchronous manager to wait for the move operations.

Notice that the combinations that involve moving an uncompressed AIP to object storage are expected to fail because of https://github.com/archivematica/Issues/issues/1742:

```console
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.9.22, pytest-8.3.5, pluggy-1.5.0 -- /pyenv/data/versions/3.9.22/bin/python3
Using --randomly-seed=2509819845
django: version: 4.2.20, settings: archivematica.storage_service.storage_service.settings.testmysql (from env)
rootdir: /src
configfile: pyproject.toml
plugins: randomly-3.16.0, base-url-2.1.0, playwright-0.7.0, django-4.10.0, cov-6.0.0
collected 508 items / 496 deselected / 12 selected                                                                                                                                                                  

tests/integration/test_integration.py::test_move_aip[move_compressed_from_local_fs_to_local_fs] PASSED                                                                                                        [  8%]
tests/integration/test_integration.py::test_move_aip[move_compressed_from_local_fs_to_rclone] PASSED                                                                                                          [ 16%]
tests/integration/test_integration.py::test_move_aip[move_uncompressed_from_nfs_to_rclone] XFAIL (Fails because of https://github.com/archivematica/Issues/issues/1742)                                       [ 25%]
tests/integration/test_integration.py::test_move_aip[move_compressed_from_local_fs_to_s3] PASSED                                                                                                              [ 33%]
tests/integration/test_integration.py::test_move_aip[move_uncompressed_from_nfs_to_nfs] PASSED                                                                                                                [ 41%]
tests/integration/test_integration.py::test_move_aip[move_compressed_from_nfs_to_s3] PASSED                                                                                                                   [ 50%]
tests/integration/test_integration.py::test_move_aip[move_uncompressed_from_nfs_to_s3] XFAIL (Fails because of https://github.com/archivematica/Issues/issues/1742)                                           [ 58%]
tests/integration/test_integration.py::test_move_aip[move_compressed_from_nfs_to_nfs] PASSED                                                                                                                  [ 66%]
tests/integration/test_integration.py::test_move_aip[move_uncompressed_from_local_fs_to_s3] XFAIL (Fails because of https://github.com/archivematica/Issues/issues/1742)                                      [ 75%]
tests/integration/test_integration.py::test_move_aip[move_uncompressed_from_local_fs_to_rclone] XFAIL (Fails because of https://github.com/archivematica/Issues/issues/1742)                                  [ 83%]
tests/integration/test_integration.py::test_move_aip[move_compressed_from_nfs_to_rclone] PASSED                                                                                                               [ 91%]
tests/integration/test_integration.py::test_move_aip[move_uncompressed_from_local_fs_to_local_fs] PASSED                                                                                                      [100%]
```

Once that is addressed the `pytest.params` objects can be replaced with the typical `[MoveAPIScenario(...), ...], ids=[...]` pattern used in the other tests.

Connected to https://github.com/archivematica/Issues/issues/1742