### PR TITLE
Add OIDC session refresh middleware

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -543,6 +543,17 @@ If `SS_OIDC_AUTHENTICATION` is false, none of the other ones are used.
   - **Type:** `boolean`
   - **Default:** `true`
 
+- **`SS_OIDC_USE_SESSION_REFRESH_MIDDLEWARE`**:
+  - **Description:** Allows existing sessions to be refreshed when OIDC tokens expire
+  - **Type:** `boolean`
+  - **Default:** `false`
+
+- **`SS_OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS`**:
+  - **Description:** Time in seconds before reauthentication is required to
+    refresh the ID token. Should align with the token lifetime set by your OIDC Provider.
+  - **Type:** `integer`
+  - **Default:** `900`
+
 - **`OIDC_RP_CLIENT_ID`**:
   - **Description:** OIDC client ID
   - **Type:** `string`

--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -591,6 +591,21 @@ if OIDC_AUTHENTICATION:
         "archivematica.storage_service.common.middleware.OidcCaptureQueryParamMiddleware",
     )
 
+    OIDC_USE_SESSION_REFRESH_MIDDLEWARE = is_true(
+        environ.get("SS_OIDC_USE_SESSION_REFRESH_MIDDLEWARE", "false")
+    )
+
+    if OIDC_USE_SESSION_REFRESH_MIDDLEWARE:
+        OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = int(
+            environ.get("SS_OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS", 60 * 15)
+        )
+
+        MIDDLEWARE.insert(
+            MIDDLEWARE.index("django.contrib.auth.middleware.AuthenticationMiddleware")
+            + 1,
+            "mozilla_django_oidc.middleware.SessionRefresh",
+        )
+
     OIDC_ALLOW_LOCAL_AUTHENTICATION = is_true(
         environ.get("SS_OIDC_ALLOW_LOCAL_AUTHENTICATION", "true")
     )


### PR DESCRIPTION
mozilla_django_oidc session refresh middleware will be available when
OIDC authentication is in use. Session refresh will default to OFF