### PR TITLE
Allow configurable OIDC role claim values

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -595,6 +595,26 @@ If `SS_OIDC_AUTHENTICATION` is false, none of the other ones are used.
   - **Type:** `string`
   - **Default:** `{"given_name": "first_name", "family_name": "last_name"}`
 
+- **`OIDC_ROLE_CLAIM_ADMIN`**:
+  - **Description:** The OIDC role claim value which maps to the Admin role.
+  - **Type:** `string`
+  - **Default:** `admin`
+
+- **`OIDC_ROLE_CLAIM_MANAGER`**:
+  - **Description:** The OIDC role claim value which maps to the Manager role.
+  - **Type:** `string`
+  - **Default:** `manager`
+
+- **`OIDC_ROLE_CLAIM_REVIEWER`**:
+  - **Description:** The OIDC role claim value which maps to the Reviewer role.
+  - **Type:** `string`
+  - **Default:** `reviewer`
+
+- **`OIDC_ROLE_CLAIM_READER`**:
+  - **Description:** The OIDC role claim value which maps to the Reader role.
+  - **Type:** `string`
+  - **Default:** `reader`
+
 - **`OIDC_RP_SIGN_ALGO`**:
   - **Description:** Algorithm used by the ID provider to sign ID tokens
   - **Type:** `string`

--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -643,6 +643,10 @@ if OIDC_AUTHENTICATION:
     OIDC_OP_ROLE_CLAIM_PATH = environ.get(
         "OIDC_OP_ROLE_CLAIM_PATH", "realm_access.roles"
     )
+    OIDC_ROLE_CLAIM_ADMIN = environ.get("OIDC_ROLE_CLAIM_ADMIN", "admin")
+    OIDC_ROLE_CLAIM_MANAGER = environ.get("OIDC_ROLE_CLAIM_MANAGER", "manager")
+    OIDC_ROLE_CLAIM_REVIEWER = environ.get("OIDC_ROLE_CLAIM_REVIEWER", "reviewer")
+    OIDC_ROLE_CLAIM_READER = environ.get("OIDC_ROLE_CLAIM_READER", "reader")
 
     DEFAULT_OIDC_CLAIMS = {"given_name": "first_name", "family_name": "last_name"}
 


### PR DESCRIPTION
Create a map relating OIDC role claim values to internal Archivematica roles. This allows us to map arbitrary token role values to standard Dashboard user types.