### PR TITLE
Allow OIDC role config by provider

### DIFF
--- a/src/archivematica/storage_service/common/backends.py
+++ b/src/archivematica/storage_service/common/backends.py
@@ -54,13 +54,6 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
             settings, "OIDC_ROLE_CLAIM_READER", "reader"
         )
 
-        self.USER_ROLE_TO_ROLE_CLAIM_MAP = {
-            roles.USER_ROLE_ADMIN: self.OIDC_ROLE_CLAIM_ADMIN,
-            roles.USER_ROLE_MANAGER: self.OIDC_ROLE_CLAIM_MANAGER,
-            roles.USER_ROLE_REVIEWER: self.OIDC_ROLE_CLAIM_REVIEWER,
-            roles.USER_ROLE_READER: self.OIDC_ROLE_CLAIM_READER,
-        }
-
     def get_settings(self, attr: str, *args: Any) -> Any:
         if attr in [
             "OIDC_RP_CLIENT_ID",
@@ -73,6 +66,10 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
             "OIDC_OP_SET_ROLES_FROM_CLAIMS",
             "OIDC_OP_ROLE_CLAIM_PATH",
             "OIDC_ACCESS_ATTRIBUTE_MAP",
+            "OIDC_ROLE_CLAIM_ADMIN",
+            "OIDC_ROLE_CLAIM_MANAGER",
+            "OIDC_ROLE_CLAIM_REVIEWER",
+            "OIDC_ROLE_CLAIM_READER",
         ]:
             # Retrieve the request object stored in the instance.
             request = getattr(self, "request", None)
@@ -106,6 +103,10 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
         )
         self.OIDC_OP_ROLE_CLAIM_PATH = self.get_settings("OIDC_OP_ROLE_CLAIM_PATH")
         self.OIDC_ACCESS_ATTRIBUTE_MAP = self.get_settings("OIDC_ACCESS_ATTRIBUTE_MAP")
+        self.OIDC_ROLE_CLAIM_ADMIN = self.get_settings("OIDC_ROLE_CLAIM_ADMIN")
+        self.OIDC_ROLE_CLAIM_MANAGER = self.get_settings("OIDC_ROLE_CLAIM_MANAGER")
+        self.OIDC_ROLE_CLAIM_REVIEWER = self.get_settings("OIDC_ROLE_CLAIM_REVIEWER")
+        self.OIDC_ROLE_CLAIM_READER = self.get_settings("OIDC_ROLE_CLAIM_READER")
 
         return super().authenticate(request, **kwargs)
 
@@ -189,9 +190,16 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
         if not isinstance(role_claims, list):
             return None
 
+        USER_ROLE_TO_ROLE_CLAIM_MAP = {
+            roles.USER_ROLE_ADMIN: self.OIDC_ROLE_CLAIM_ADMIN,
+            roles.USER_ROLE_MANAGER: self.OIDC_ROLE_CLAIM_MANAGER,
+            roles.USER_ROLE_REVIEWER: self.OIDC_ROLE_CLAIM_REVIEWER,
+            roles.USER_ROLE_READER: self.OIDC_ROLE_CLAIM_READER,
+        }
+
         # Iterate over ordered roles.USER_ROLES and return the first match.
         for role_key, _ in roles.USER_ROLES:
-            token_claim = self.USER_ROLE_TO_ROLE_CLAIM_MAP.get(role_key)
+            token_claim = USER_ROLE_TO_ROLE_CLAIM_MAP.get(role_key)
             if token_claim in role_claims:
                 return role_key
 

--- a/src/archivematica/storage_service/common/helpers.py
+++ b/src/archivematica/storage_service/common/helpers.py
@@ -46,6 +46,18 @@ def get_oidc_secondary_providers(
         role_claim_path = environ.get(
             f"OIDC_OP_ROLE_CLAIM_PATH_{provider_name}", "realm_access.roles"
         )
+        role_claim_admin = environ.get(
+            f"OIDC_ROLE_CLAIM_ADMIN_{provider_name}", "admin"
+        )
+        role_claim_manager = environ.get(
+            f"OIDC_ROLE_CLAIM_MANAGER_{provider_name}", "manager"
+        )
+        role_claim_reviewer = environ.get(
+            f"OIDC_ROLE_CLAIM_REVIEWER_{provider_name}", "reviewer"
+        )
+        role_claim_reader = environ.get(
+            f"OIDC_ROLE_CLAIM_READER_{provider_name}", "reader"
+        )
         try:
             access_attribute_map = json.loads(
                 environ.get(
@@ -68,6 +80,10 @@ def get_oidc_secondary_providers(
                 "OIDC_OP_SET_ROLES_FROM_CLAIMS": set_roles_from_claims,
                 "OIDC_OP_ROLE_CLAIM_PATH": role_claim_path,
                 "OIDC_ACCESS_ATTRIBUTE_MAP": access_attribute_map,
+                "OIDC_ROLE_CLAIM_ADMIN": role_claim_admin,
+                "OIDC_ROLE_CLAIM_MANAGER": role_claim_manager,
+                "OIDC_ROLE_CLAIM_REVIEWER": role_claim_reviewer,
+                "OIDC_ROLE_CLAIM_READER": role_claim_reader,
             }
             providers[provider_name] = provider_config
 

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -44,6 +44,10 @@ services:
       OIDC_OP_LOGOUT_ENDPOINT: "http://keycloak:8080/realms/demo/protocol/openid-connect/logout"
       OIDC_OP_SET_ROLES_FROM_CLAIMS: "true"
       OIDC_OP_ROLE_CLAIM_PATH: "realm_access.roles"
+      OIDC_ROLE_CLAIM_ADMIN: "admin"
+      OIDC_ROLE_CLAIM_MANAGER: "manager"
+      OIDC_ROLE_CLAIM_REVIEWER: "reviewer"
+      OIDC_ROLE_CLAIM_READER: "reader"
       OIDC_ACCESS_ATTRIBUTE_MAP: >
         {"given_name": "first_name", "family_name": "last_name", "realm_access": "realm_access"}
       OIDC_SECONDARY_PROVIDER_NAMES: "secondary"
@@ -56,6 +60,10 @@ services:
       OIDC_OP_LOGOUT_ENDPOINT_SECONDARY: "http://keycloak:8080/realms/secondary/protocol/openid-connect/logout"
       OIDC_OP_SET_ROLES_FROM_CLAIMS_SECONDARY: "true"
       OIDC_OP_ROLE_CLAIM_PATH_SECONDARY: "realm_access.roles"
+      OIDC_ROLE_CLAIM_ADMIN_SECONDARY: "admin-secondary"
+      OIDC_ROLE_CLAIM_MANAGER_SECONDARY: "manager-secondary"
+      OIDC_ROLE_CLAIM_REVIEWER_SECONDARY: "reviewer-secondary"
+      OIDC_ROLE_CLAIM_READER_SECONDARY: "reader-secondary"
       OIDC_ACCESS_ATTRIBUTE_MAP_SECONDARY: >
         {"given_name": "first_name", "family_name": "last_name", "realm_access": "realm_access"}
       OIDC_RP_SIGN_ALGO: "RS256"

--- a/tests/integration/etc/keycloak/realm.json
+++ b/tests/integration/etc/keycloak/realm.json
@@ -83,11 +83,11 @@
     "roles": {
       "realm": [
         {
-          "name": "admin",
+          "name": "admin-secondary",
           "description": "Administrator role"
         },
         {
-          "name": "reader",
+          "name": "reader-secondary",
           "description": "Reader role"
         }
       ]
@@ -132,7 +132,7 @@
           }
         ],
         "realmRoles": [
-          "admin"
+          "admin-secondary"
         ]
       },
       {
@@ -151,7 +151,7 @@
           }
         ],
         "realmRoles": [
-          "reader"
+          "reader-secondary"
         ]
       }
     ]

--- a/tests/storage_service/test_helpers.py
+++ b/tests/storage_service/test_helpers.py
@@ -56,6 +56,10 @@ def test_get_oidc_secondary_providers_ignores_provider_if_client_id_and_secret_a
             },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
+            "OIDC_ROLE_CLAIM_ADMIN": "admin",
+            "OIDC_ROLE_CLAIM_MANAGER": "manager",
+            "OIDC_ROLE_CLAIM_REVIEWER": "reviewer",
+            "OIDC_ROLE_CLAIM_READER": "reader",
         }
     }
 
@@ -85,6 +89,10 @@ def test_get_oidc_secondary_providers_strips_provider_names(
             },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
+            "OIDC_ROLE_CLAIM_ADMIN": "admin",
+            "OIDC_ROLE_CLAIM_MANAGER": "manager",
+            "OIDC_ROLE_CLAIM_REVIEWER": "reviewer",
+            "OIDC_ROLE_CLAIM_READER": "reader",
         },
         "BAR": {
             "OIDC_OP_AUTHORIZATION_ENDPOINT": "",
@@ -100,6 +108,10 @@ def test_get_oidc_secondary_providers_strips_provider_names(
             },
             "OIDC_RP_CLIENT_ID": "bar-client-id",
             "OIDC_RP_CLIENT_SECRET": "bar-client-secret",
+            "OIDC_ROLE_CLAIM_ADMIN": "admin",
+            "OIDC_ROLE_CLAIM_MANAGER": "manager",
+            "OIDC_ROLE_CLAIM_REVIEWER": "reviewer",
+            "OIDC_ROLE_CLAIM_READER": "reader",
         },
     }
 
@@ -129,6 +141,10 @@ def test_get_oidc_secondary_providers_capitalizes_provider_names(
             },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
+            "OIDC_ROLE_CLAIM_ADMIN": "admin",
+            "OIDC_ROLE_CLAIM_MANAGER": "manager",
+            "OIDC_ROLE_CLAIM_REVIEWER": "reviewer",
+            "OIDC_ROLE_CLAIM_READER": "reader",
         },
         "BAR": {
             "OIDC_OP_AUTHORIZATION_ENDPOINT": "",
@@ -144,5 +160,9 @@ def test_get_oidc_secondary_providers_capitalizes_provider_names(
             },
             "OIDC_RP_CLIENT_ID": "bar-client-id",
             "OIDC_RP_CLIENT_SECRET": "bar-client-secret",
+            "OIDC_ROLE_CLAIM_ADMIN": "admin",
+            "OIDC_ROLE_CLAIM_MANAGER": "manager",
+            "OIDC_ROLE_CLAIM_REVIEWER": "reviewer",
+            "OIDC_ROLE_CLAIM_READER": "reader",
         },
     }


### PR DESCRIPTION
Allow the OIDC role claim settings to be configured individually for each configured provider.