### PR TITLE
Remove /usr reference from gunicorn configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,6 @@ ARG GROUP_ID=1000
 
 ENV DJANGO_SETTINGS_MODULE=archivematica.storage_service.storage_service.settings.local
 ENV SS_GUNICORN_BIND=0.0.0.0:8000
-ENV SS_GUNICORN_CHDIR=/src/src/archivematica/storage_service
 ENV SS_GUNICORN_ACCESSLOG=-
 ENV SS_GUNICORN_ERRORLOG=-
 ENV FORWARDED_ALLOW_IPS=*

--- a/install/README.md
+++ b/install/README.md
@@ -298,9 +298,11 @@ This is the current list of strings supported:
   - **Default:** `auto`
 
 - **`SS_GUNICORN_CHDIR`**:
-  - **Description:** directory to load apps from. See [CHDIR].
+  - **Description:** directory to load apps from. See [CHDIR]. If this is
+    empty, Archivematica will load apps from the top level directory of the
+    `archivematica.storage_service` package.
   - **Type:** `string`
-  - **Default:** `/usr/lib/archivematica/storage-service`
+  - **Default:** `""`
 
 - **`SS_GUNICORN_ACCESSLOG`**:
   - **Description:** location to write access log to. See [ACCESSLOG].

--- a/install/storage-service.gunicorn-config.py
+++ b/install/storage-service.gunicorn-config.py
@@ -1,11 +1,14 @@
 # Documentation: http://docs.gunicorn.org/en/stable/configure.html
 # Example: https://github.com/benoitc/gunicorn/blob/master/examples/example_config.py
+import importlib.resources
 import os
 import shutil
 import tempfile
 
 from gunicorn.arbiter import Arbiter
 from gunicorn.workers.base import Worker
+
+storage_service_path = str(importlib.resources.files("archivematica.storage_service"))
 
 # http://docs.gunicorn.org/en/stable/settings.html#user
 user = os.environ.get("SS_GUNICORN_USER", "archivematica")
@@ -36,7 +39,7 @@ reload = os.environ.get("SS_GUNICORN_RELOAD", "false")
 reload_engine = os.environ.get("SS_GUNICORN_RELOAD_ENGINE", "auto")
 
 # http://docs.gunicorn.org/en/stable/settings.html#chdir
-chdir = os.environ.get("SS_GUNICORN_CHDIR", "/usr/lib/archivematica/storage-service")
+chdir = os.environ.get("SS_GUNICORN_CHDIR", storage_service_path)
 
 # http://docs.gunicorn.org/en/stable/settings.html#accesslog
 accesslog = os.environ.get("SS_GUNICORN_ACCESSLOG", None)


### PR DESCRIPTION
This updates the gunicorn configuration to load apps from the top level directory of the `archivematica.storage_service` package when the `SS_GUNICORN_CHDIR` setting is not explicitly defined by the user.

Connected to https://github.com/archivematica/Issues/issues/1749