### PR TITLE
Do not show private data in GPG encryption key views

### DIFF
--- a/src/archivematica/storage_service/administration/views.py
+++ b/src/archivematica/storage_service/administration/views.py
@@ -212,6 +212,16 @@ def key_detail(request, key_fingerprint):
     return render(request, "administration/key_detail.html", locals())
 
 
+def _show_private_key_alert(request, fingerprint):
+    _, private_armor = gpgutils.export_gpg_key(fingerprint)
+    messages.success(
+        request,
+        render_to_string(
+            "administration/key_armor_alert.html", {"armor": private_armor}, request
+        ),
+    )
+
+
 @permission_required("administration.change_settings", raise_exception=True)
 def key_create(request):
     """Create a new key using the POST params; currently these are just the
@@ -231,8 +241,11 @@ def key_create(request):
                     % {"fingerprint": key.fingerprint}
                 ),
             )
+            _show_private_key_alert(request, key.fingerprint)
             LOGGER.debug('created new GPG key for "%s"', cd["name_real"])
-            return redirect("administration:key_list")
+            return redirect(
+                "administration:key_detail", key_fingerprint=key.fingerprint
+            )
         else:
             messages.warning(
                 request,

--- a/src/archivematica/storage_service/locations/forms.py
+++ b/src/archivematica/storage_service/locations/forms.py
@@ -185,10 +185,7 @@ class DSpaceRESTForm(forms.ModelForm):
 
 
 def get_gpg_key_choices():
-    return [
-        (key["fingerprint"], ", ".join(key["uids"]))
-        for key in gpgutils.get_gpg_key_list()
-    ]
+    return [(key["fingerprint"], key["keyid"]) for key in gpgutils.get_gpg_key_list()]
 
 
 class GPGForm(forms.ModelForm):

--- a/src/archivematica/storage_service/locations/views.py
+++ b/src/archivematica/storage_service/locations/views.py
@@ -668,7 +668,7 @@ def get_child_space_value(value, field, child):
     """
     if field == "key" and isinstance(child, GPG):
         key = gpgutils.get_gpg_key(value)
-        return " ".join(key["uids"][0].split()[:-1])
+        return key["keyid"]
     return value
 
 

--- a/src/archivematica/storage_service/locations/views.py
+++ b/src/archivematica/storage_service/locations/views.py
@@ -630,7 +630,9 @@ def space_list(request):
             child, PROTOCOL[space.access_protocol]["fields"] or [""]
         )
         child_dict = {
-            child._meta.get_field(field).verbose_name: value
+            child._meta.get_field(field).verbose_name: get_child_space_value(
+                value, field, child
+            )
             for field, value in child_dict_raw.items()
         }
         space.child = child_dict

--- a/src/archivematica/storage_service/static/js/project.js
+++ b/src/archivematica/storage_service/static/js/project.js
@@ -273,40 +273,51 @@ $(document).ready(function () {
     $last_header.after($clone);
   });
 
-  // Set up the button which allows users to copy the API key to the clipboard.
-  $("#copy-api-key-button")
-    .tooltip()
-    .click(function () {
-      var $button = $(this);
-      navigator.clipboard
-        .writeText($("#api-key").val())
-        .then(function () {
-          var $button_icon = $("#copy-button-icon");
-          var $icon_original_class = $button_icon.data("icon-original-class");
-          var $icon_clicked_class = $button_icon.data("icon-clicked-class");
+  function setUpCopyButton(buttonId, targetId, iconId) {
+    $(buttonId)
+      .tooltip()
+      .click(function () {
+        var $button = $(this);
+        navigator.clipboard
+          .writeText($(targetId).val())
+          .then(function () {
+            var $button_icon = $(iconId);
+            var $icon_original_class = $button_icon.data("icon-original-class");
+            var $icon_clicked_class = $button_icon.data("icon-clicked-class");
 
-          // Update the button icon.
-          $button_icon
-            .removeClass($icon_original_class)
-            .addClass($icon_clicked_class);
-
-          // Update the button tooltip.
-          $button
-            .attr("data-original-title", $button.data("label-clicked"))
-            .tooltip("show");
-
-          // Reset the button after 2 seconds.
-          setTimeout(function () {
+            // Update the button icon.
             $button_icon
-              .removeClass($icon_clicked_class)
-              .addClass($icon_original_class);
+              .removeClass($icon_original_class)
+              .addClass($icon_clicked_class);
+
+            // Update the button tooltip.
             $button
-              .attr("data-original-title", $button.data("label-original"))
-              .tooltip("hide");
-          }, 2000);
-        })
-        .catch(function (err) {
-          console.error("Failed to copy API key to clipboard: ", err);
-        });
-    });
+              .attr("data-original-title", $button.data("label-clicked"))
+              .tooltip("show");
+
+            // Reset the button after 2 seconds.
+            setTimeout(function () {
+              $button_icon
+                .removeClass($icon_clicked_class)
+                .addClass($icon_original_class);
+              $button
+                .attr("data-original-title", $button.data("label-original"))
+                .tooltip("hide");
+            }, 2000);
+          })
+          .catch(function (err) {
+            console.error("Failed to copy to clipboard: ", err);
+          });
+      });
+  }
+
+  // Set up the button which allows users to copy the API key to the clipboard.
+  setUpCopyButton("#copy-api-key-button", "#api-key", "#copy-button-icon");
+
+  // Set up the button which allows users to copy the GPG armor key to the clipboard.
+  setUpCopyButton(
+    "#copy-key-armor-button",
+    "#key-armor",
+    "#copy-key-armor-button-icon",
+  );
 });

--- a/src/archivematica/storage_service/templates/administration/key_armor_alert.html
+++ b/src/archivematica/storage_service/templates/administration/key_armor_alert.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<p>{% trans "Make sure to copy the Private Key ASCII Armor now as you will not be able to see it again." %}</p>
+{% trans 'Copy' as label_copy %}
+{% trans 'Copied!' as label_copied %}
+<div class="input-prepend">
+  <button id="copy-key-armor-button" class="btn"
+      title="{{ label_copy }}"
+      data-label-original="{{ label_copy }}"
+      data-label-clicked="{{ label_copied }}"
+      data-placement="bottom" style="margin: 0 -1px 0 0;">
+      <i id="copy-key-armor-button-icon" class="icon-share" data-icon-original-class="icon-share" data-icon-clicked-class="icon-ok"></i>
+  </button>
+  <textarea id="key-armor" class="input-xxlarge uneditable-input" disabled style="cursor: default; resize: vertical; height: 100px;">{{ armor }}</textarea>
+</div>

--- a/src/archivematica/storage_service/templates/administration/key_detail.html
+++ b/src/archivematica/storage_service/templates/administration/key_detail.html
@@ -7,14 +7,10 @@
 
 <div class='key'>
   <dl>
-    <dt>{% trans "UIDs" %}</dt>
-    <dd>{{ key.uids|join:", " }}</dd>
     <dt>{% trans "Fingerprint" %}</dt>
     <dd>{{ key.fingerprint }}</dd>
     <dt>{% trans "Keyid" %}</dt>
     <dd>{{ key.keyid }}</dd>
-    <dt>{% trans "Private Key ASCII Armor" %}</dt>
-    <dd><pre>{{ private_armor }}</pre></dd>
     <dt>{% trans "Public Key ASCII Armor" %}</dt>
     <dd><pre>{{ public_armor }}</pre></dd>
     <dt>{% trans "Actions" %}</dt>

--- a/src/archivematica/storage_service/templates/administration/key_list.html
+++ b/src/archivematica/storage_service/templates/administration/key_list.html
@@ -11,7 +11,7 @@
   <table class="datatable">
     <thead>
       <tr>
-        <th>{% trans "User ID(s)" %}</th>
+        <th>{% trans "Keyid" %}</th>
         <th>{% trans "Fingerprint" %}</th>
         <th>{% trans "Actions" %}</th>
       </tr>
@@ -19,7 +19,7 @@
     {% for key_display in keys %}
       <tr>
         <td><a href="{% url 'administration:key_detail' key_display.fingerprint %}"
-               >{{ key_display.uids|join:", " }}</a></td>
+               >{{ key_display.keyid }}</a></td>
         <td>{{ key_display.fingerprint }}</td>
         <td><a href="{% url 'administration:key_delete' key_display.fingerprint %}?next={{ request.path }}">{% trans "Delete" %}</a></td>
       </tr>


### PR DESCRIPTION
This update removes the `UIDs` and `Private Key ASCII Armor` fields from all `GPG` encryption key views and uses the `Keyid` field as the key identifier throughout the user interface.

Connected to https://github.com/archivematica/Issues/issues/1737