### PR TITLE
Add current password validation to user edit form

### DIFF
--- a/src/archivematica/storage_service/administration/forms.py
+++ b/src/archivematica/storage_service/administration/forms.py
@@ -338,6 +338,35 @@ class UserChangeForm(auth.forms.UserChangeForm):
         super().save(commit)
 
 
+class SetPasswordForm(auth.forms.SetPasswordForm):
+    def __init__(self, *args, **kwargs):
+        self.requesting_user = kwargs.pop("requesting_user", None)
+        super().__init__(*args, **kwargs)
+        self.error_messages["current_password_incorrect"] = _(
+            "Your current password is incorrect."
+        )
+
+    current_password = forms.CharField(
+        widget=forms.PasswordInput(attrs={"autocomplete": "current-password"}),
+        label=_("Your current password"),
+    )
+
+    field_order = [
+        "current_password",
+        "new_password1",
+        "new_password2",
+    ]
+
+    def clean_current_password(self):
+        current_password = self.cleaned_data.get("current_password")
+        if not self.requesting_user.check_password(current_password):
+            raise ValidationError(
+                self.error_messages["current_password_incorrect"],
+                code="current_password_incorrect",
+            )
+        return current_password
+
+
 # ######################### KEYS ##########################
 
 

--- a/src/archivematica/storage_service/administration/views.py
+++ b/src/archivematica/storage_service/administration/views.py
@@ -119,7 +119,7 @@ def user_edit(request, id):
         password_form.save()
         messages.success(request, _("Password changed."))
         return redirect("administration:user_edit", id=edit_user.pk)
-    elif "password":
+    else:
         # Ensure user form information still displays after an invalid
         # password change attempt.
         user_form = settings_forms.UserChangeForm(

--- a/src/archivematica/storage_service/administration/views.py
+++ b/src/archivematica/storage_service/administration/views.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import permission_required
-from django.contrib.auth.forms import SetPasswordForm
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
@@ -103,8 +102,10 @@ def user_edit(request, id):
     user_form = settings_forms.UserChangeForm(
         request.POST or None, instance=edit_user, current_user=request.user
     )
-    password_form = SetPasswordForm(
-        data=request.POST if "password" in request.POST else None, user=edit_user
+    password_form = settings_forms.SetPasswordForm(
+        data=request.POST if "password" in request.POST else None,
+        user=edit_user,
+        requesting_user=request.user,
     )
     if "user" in request.POST and user_form.is_valid():
         if user_form.cleaned_data["regenerate_api_key"]:


### PR DESCRIPTION
This updates the user edit form to require the current password from
the user setting a new password.

Connected to https://github.com/archivematica/Issues/issues/1757