### PR TITLE
Remove warnings about autocreated index fields

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -223,6 +223,12 @@ of these settings or provide values to mandatory fields.
   - **Type:** `integer`
   - **Default:** `900`
 
+- **`SS_SILENCED_SYSTEM_CHECKS`**:
+  - **Description:**  comma-separated list of ignored system checks.
+    e.g. mysql.W002,models.W042
+  - **Type:** `string`
+  - **Default:** `None`
+
 The configuration of the database is also declared via environment variables.
 Storage Service looks up the `SS_DB_URL` environment string. If defined, its
 value is expected to follow the form described in the [dj-database-url docs],

--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -754,3 +754,5 @@ if PROMETHEUS_ENABLED:
     )
     INSTALLED_APPS = INSTALLED_APPS + ["django_prometheus"]
     LOGIN_EXEMPT_URLS.append(r"^metrics$")
+
+SILENCED_SYSTEM_CHECKS = environ.get("SS_SILENCED_SYSTEM_CHECKS", "[]")

--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -754,6 +754,3 @@ if PROMETHEUS_ENABLED:
     )
     INSTALLED_APPS = INSTALLED_APPS + ["django_prometheus"]
     LOGIN_EXEMPT_URLS.append(r"^metrics$")
-
-# Remove models.W042 warning
-DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -754,3 +754,6 @@ if PROMETHEUS_ENABLED:
     )
     INSTALLED_APPS = INSTALLED_APPS + ["django_prometheus"]
     LOGIN_EXEMPT_URLS.append(r"^metrics$")
+
+# Remove models.W042 warning
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/src/archivematica/storage_service/storage_service/settings/production.py
+++ b/src/archivematica/storage_service/storage_service/settings/production.py
@@ -79,3 +79,6 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"
 # Note: This key should only be used for development and testing.
 SECRET_KEY = get_env_variable("DJANGO_SECRET_KEY")
 # ######## END SECRET CONFIGURATION
+
+# Remove warning about autocreated primary keys.
+SILENCED_SYSTEM_CHECKS = ["models.W042"]

--- a/src/archivematica/storage_service/storage_service/settings/production.py
+++ b/src/archivematica/storage_service/storage_service/settings/production.py
@@ -79,6 +79,3 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"
 # Note: This key should only be used for development and testing.
 SECRET_KEY = get_env_variable("DJANGO_SECRET_KEY")
 # ######## END SECRET CONFIGURATION
-
-# Remove warning about autocreated primary keys.
-SILENCED_SYSTEM_CHECKS = ["models.W042"]


### PR DESCRIPTION
Removes models.W042 warning when running manage.py commands

Connected to https://github.com/archivematica/Issues/issues/1759