### PR TITLE
Migrate directives in CSP settings file

### DIFF
--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -736,6 +736,7 @@ INSECURE_SKIP_VERIFY = is_true(environ.get("SS_INSECURE_SKIP_VERIFY", ""))
 
 CSP_ENABLED = is_true(environ.get("SS_CSP_ENABLED", ""))
 if CSP_ENABLED:
+    INSTALLED_APPS.append("csp")
     MIDDLEWARE.insert(0, "csp.middleware.CSPMiddleware")
 
     from archivematica.storage_service.storage_service.settings.components.csp import *

--- a/src/archivematica/storage_service/storage_service/settings/components/csp.py
+++ b/src/archivematica/storage_service/storage_service/settings/components/csp.py
@@ -1,7 +1,15 @@
-CSP_DEFAULT_SRC = ["'none'"]
-CSP_SCRIPT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
-CSP_STYLE_SRC = ["'self'", "'unsafe-inline'"]
-CSP_IMG_SRC = ["'self'"]
+from csp.constants import NONE
+from csp.constants import SELF
+from csp.constants import UNSAFE_EVAL
+from csp.constants import UNSAFE_INLINE
 
-# for the create space form
-CSP_CONNECT_SRC = ["'self'"]
+CONTENT_SECURITY_POLICY = {
+    "DIRECTIVES": {
+        "default-src": [NONE],
+        "script-src": [SELF, UNSAFE_INLINE, UNSAFE_EVAL],
+        "style-src": [SELF, UNSAFE_INLINE],
+        "img-src": [SELF],
+        # for the create space form
+        "connect-src": [SELF],
+    }
+}


### PR DESCRIPTION
This follows the `django-csp` [4.0 migration guide](https://django-csp.readthedocs.io/en/latest/migration-guide.html) to update the directives in the CSP settings file.