### PR TITLE
Add dependabot.yml config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "docker-compose"
+    directory: "/tests/integration"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+    groups:
+      docker-compose-tests:
+        patterns:
+          - "*"

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "9000"
 
   mysql:
-    image: "percona:8.0"
+    image: "percona/percona-server:8.0.43-34"
     environment:
       MYSQL_ROOT_PASSWORD: "root"
       # These are used in the storage_service.settings.testmysql module
@@ -107,7 +107,7 @@ services:
       start_period: 15s
 
   keycloak:
-    image: "quay.io/keycloak/keycloak:latest"
+    image: "quay.io/keycloak/keycloak:26.3.3-0"
     command: ["start-dev", "--import-realm"]
     restart: "unless-stopped"
     environment:


### PR DESCRIPTION
Relates to https://github.com/artefactual/archivematica/pull/2102.

For now this is still being evaluated, so the focus is only on image versions listed in `/tests/integration/docker-compose.yml`.