### PR TITLE
Update GPG key label in space forms and views

### DIFF
--- a/src/archivematica/storage_service/locations/forms.py
+++ b/src/archivematica/storage_service/locations/forms.py
@@ -193,7 +193,9 @@ class GPGForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         system_key = gpgutils.get_default_gpg_key(gpgutils.get_gpg_key_list())
         self.fields["key"] = forms.ChoiceField(
-            choices=get_gpg_key_choices(), initial=system_key["fingerprint"]
+            choices=get_gpg_key_choices(),
+            initial=system_key["fingerprint"],
+            label=_("Keyid"),
         )
 
     class Meta:

--- a/src/archivematica/storage_service/locations/views.py
+++ b/src/archivematica/storage_service/locations/views.py
@@ -629,12 +629,7 @@ def space_list(request):
         child_dict_raw = model_to_dict(
             child, PROTOCOL[space.access_protocol]["fields"] or [""]
         )
-        child_dict = {
-            child._meta.get_field(field).verbose_name: get_child_space_value(
-                value, field, child
-            )
-            for field, value in child_dict_raw.items()
-        }
+        child_dict = get_child_space_dict(child, child_dict_raw)
         space.child = child_dict
 
     list(map(add_child, spaces))
@@ -652,15 +647,23 @@ def space_detail(request, uuid):
     child_dict_raw = model_to_dict(
         child, PROTOCOL[space.access_protocol]["fields"] or [""]
     )
-    child_dict = {
-        child._meta.get_field(field).verbose_name: get_child_space_value(
-            value, field, child
-        )
-        for field, value in child_dict_raw.items()
-    }
+    child_dict = get_child_space_dict(child, child_dict_raw)
     space.child = child_dict
     locations = Location.objects.filter(space=space)
     return render(request, "locations/space_detail.html", locals())
+
+
+def get_child_space_dict(child, child_dict_raw):
+    return {
+        get_child_space_label(child, field): get_child_space_value(value, field, child)
+        for field, value in child_dict_raw.items()
+    }
+
+
+def get_child_space_label(child, field):
+    if field == "key" and isinstance(child, GPG):
+        return _("Keyid")
+    return child._meta.get_field(field).verbose_name
 
 
 def get_child_space_value(value, field, child):

--- a/src/archivematica/storage_service/locations/views.py
+++ b/src/archivematica/storage_service/locations/views.py
@@ -667,9 +667,10 @@ def get_child_space_label(child, field):
 
 
 def get_child_space_value(value, field, child):
+    """Show shorter Key ID instead of full fingerprint for GPG keys."""
     if field == "key" and isinstance(child, GPG):
         key = gpgutils.get_gpg_key(value)
-        return key["keyid"] if key is not None else _("Keyid not found")
+        return (key or {}).get("keyid", _("Keyid not found"))
     return value
 
 

--- a/src/archivematica/storage_service/locations/views.py
+++ b/src/archivematica/storage_service/locations/views.py
@@ -667,13 +667,9 @@ def get_child_space_label(child, field):
 
 
 def get_child_space_value(value, field, child):
-    """If the child space ``child`` is a GPG instance, and the field is key, we
-    return a human-readable representation of the GPG key instead of its
-    fingerprint: the name of the first user in its uids list.
-    """
     if field == "key" and isinstance(child, GPG):
         key = gpgutils.get_gpg_key(value)
-        return key["keyid"]
+        return key["keyid"] if key is not None else _("Keyid not found")
     return value
 
 


### PR DESCRIPTION
This change updates the `GPG.key` field to use the Keyid label in space forms and views, aligning it with the label used in the encryption key views.

Connected to https://github.com/archivematica/Issues/issues/1737