### PR TITLE
Paginate S3 browse listings by prefix

### DIFF
--- a/src/archivematica/storage_service/locations/models/s3.py
+++ b/src/archivematica/storage_service/locations/models/s3.py
@@ -147,27 +147,33 @@ class S3(models.Model):
         if path != "":
             path = path.rstrip("/") + "/"
 
-        objects = self.resource.Bucket(self.bucket_name).objects.filter(Prefix=path)
-
         directories = set()
         entries = set()
         properties = {}
 
-        for objectSummary in objects:
-            relative_key = objectSummary.key.replace(path, "", 1).lstrip("/")
+        client = self.resource.meta.client
+        paginator = client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(
+            Bucket=self.bucket_name,
+            Prefix=path,
+            Delimiter="/",
+        ):
+            for obj in page.get("Contents", []):
+                relative_key = obj["Key"].replace(path, "", 1).lstrip("/")
+                if relative_key:
+                    entries.add(relative_key)
+                    properties[relative_key] = {
+                        "size": obj["Size"],
+                        "timestamp": obj["LastModified"],
+                        "e_tag": obj["ETag"],
+                    }
 
-            if "/" in relative_key:
+            for cp in page.get("CommonPrefixes", []):
+                relative_key = cp["Prefix"].replace(path, "", 1).lstrip("/")
                 directory_name = re.sub("/.*", "", relative_key)
                 if directory_name:
                     directories.add(directory_name)
                     entries.add(directory_name)
-            elif relative_key != "":
-                entries.add(relative_key)
-                properties[relative_key] = {
-                    "size": objectSummary.size,
-                    "timestamp": objectSummary.last_modified,
-                    "e_tag": objectSummary.e_tag,
-                }
 
         return {
             "directories": list(directories),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,160 @@
-import sys
+from collections.abc import Iterator
+from typing import Any
+from typing import Callable
+from typing import Optional
 
-# XXX delete?
-sys.path.append("/src/archivematica/storage_service")
+import boto3
+import pytest
+from boto3.resources.base import ServiceResource
+from boto3.resources.collection import ResourceCollection
+
+
+class KeyRecordingIterable:
+    """Proxy iterable that appends each yielded S3 key to the tracking list."""
+
+    def __init__(self, collection: Any, seen_keys: list[str]) -> None:
+        self._collection = collection
+        self._seen_keys = seen_keys
+
+    def __iter__(self) -> Iterator[Any]:
+        for obj in self._collection:
+            self._seen_keys.append(obj.key)
+            yield obj
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._collection, name)
+
+
+class KeyRecordingCollection:
+    """Proxy iterable that appends each yielded S3 key to the tracking list."""
+
+    def __init__(self, collection: ResourceCollection, seen_keys: list[str]) -> None:
+        self._collection = collection
+        self._seen_keys = seen_keys
+
+    def filter(self, *args: Any, **kwargs: Any) -> KeyRecordingIterable:
+        filtered = self._collection.filter(*args, **kwargs)
+        return KeyRecordingIterable(filtered, self._seen_keys)
+
+    def all(self) -> KeyRecordingIterable:
+        everything = self._collection.all()
+        return KeyRecordingIterable(everything, self._seen_keys)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._collection, name)
+
+
+class KeyRecordingPaginator:
+    """Wrap paginator so iterated pages append the keys they expose."""
+
+    def __init__(self, paginator: Any, seen_keys: list[str]) -> None:
+        self._paginator = paginator
+        self._seen_keys = seen_keys
+
+    def paginate(self, *args: Any, **kwargs: Any) -> Iterator[Any]:
+        for page in self._paginator.paginate(*args, **kwargs):
+            for obj in page.get("Contents", []):
+                key = obj.get("Key")
+                if key:
+                    self._seen_keys.append(key)
+            yield page
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._paginator, name)
+
+
+class KeyRecordingClient:
+    """Client wrapper that returns key-recording paginators."""
+
+    def __init__(self, client: Any, seen_keys: list[str]) -> None:
+        self._client = client
+        self._seen_keys = seen_keys
+
+    def get_paginator(self, name: str) -> KeyRecordingPaginator:
+        paginator = self._client.get_paginator(name)
+        return KeyRecordingPaginator(paginator, self._seen_keys)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client, name)
+
+
+class KeyRecordingMeta:
+    """Meta wrapper ensuring the client records keys."""
+
+    def __init__(self, meta: Any, seen_keys: list[str]) -> None:
+        self._meta = meta
+        self._seen_keys = seen_keys
+        self._client_wrapper: Optional[KeyRecordingClient] = None
+
+    @property
+    def client(self) -> KeyRecordingClient:
+        if self._client_wrapper is None:
+            self._client_wrapper = KeyRecordingClient(
+                self._meta.client, self._seen_keys
+            )
+        return self._client_wrapper
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._meta, name)
+
+
+class KeyRecordingBucket:
+    """Expose a bucket whose object collections add accessed keys to the log."""
+
+    def __init__(self, bucket: ServiceResource, seen_keys: list[str]) -> None:
+        self._bucket = bucket
+        self._seen_keys = seen_keys
+
+    @property
+    def objects(self) -> KeyRecordingCollection:
+        original_collection = self._bucket.objects
+        return KeyRecordingCollection(original_collection, self._seen_keys)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._bucket, name)
+
+
+class KeyRecordingResource:
+    """Resource wrapper that yields key-recording buckets."""
+
+    def __init__(self, resource: ServiceResource, seen_keys: list[str]) -> None:
+        self._resource = resource
+        self._seen_keys = seen_keys
+        self._meta_wrapper: Optional[KeyRecordingMeta] = None
+
+    def Bucket(self, name: str) -> KeyRecordingBucket:
+        bucket = self._resource.Bucket(name)
+        if not isinstance(bucket, ServiceResource):
+            raise TypeError("Expected ServiceResource bucket")
+        return KeyRecordingBucket(bucket, self._seen_keys)
+
+    @property
+    def meta(self) -> KeyRecordingMeta:
+        if self._meta_wrapper is None:
+            self._meta_wrapper = KeyRecordingMeta(self._resource.meta, self._seen_keys)
+        return self._meta_wrapper
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._resource, name)
+
+
+def make_key_recording_resource_factory(
+    recorded_keys: list[str], original_factory: Callable[..., ServiceResource]
+) -> Callable[..., KeyRecordingResource]:
+    def factory(*args: Any, **kwargs: Any) -> KeyRecordingResource:
+        resource = original_factory(*args, **kwargs)
+        return KeyRecordingResource(resource, recorded_keys)
+
+    return factory
+
+
+@pytest.fixture
+def s3_recorded_keys(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Override boto3.resource so each key bubbled through the wrappers lands in this list."""
+    recorded_keys: list[str] = []
+    original_boto3_resource = boto3.resource
+    tracking_factory = make_key_recording_resource_factory(
+        recorded_keys, original_boto3_resource
+    )
+    monkeypatch.setattr(boto3, "resource", tracking_factory)
+    return recorded_keys

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -75,6 +75,8 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+      minio-setup:
+        condition: service_completed_successfully
     links:
       - "minio"
       - "mysql"
@@ -90,6 +92,38 @@ services:
       MINIO_BROWSER: "off"
     expose:
       - "9000"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9000/minio/health/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+  minio-setup:
+    image: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+    entrypoint: []
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        set -e
+        until mc alias set minio http://minio:9000 minio minio123 >/dev/null 2>&1; do
+          sleep 1
+        done
+        #
+        # The resource name used in the statement of this policy file
+        # matches the bucket naming convention of the s3_browse_bucket fixture.
+        #
+        mc admin policy info minio ss-user >/dev/null 2>&1 || mc admin policy create minio ss-user /config/policies/user.json
+        if ! mc admin user info minio minio-user >/dev/null 2>&1; then
+          mc admin user add minio minio-user minio-password
+        fi
+        mc admin policy attach minio ss-user --user minio-user
+    depends_on:
+      minio:
+        condition: service_healthy
+    volumes:
+      - "./etc/minio:/config:ro"
 
   mysql:
     image: "percona/percona-server:8.4.6-6"

--- a/tests/integration/etc/minio/policies/user.json
+++ b/tests/integration/etc/minio/policies/user.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BrowseBuckets",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::storage-service-browse-*"
+      ]
+    }
+  ]
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -10,15 +10,22 @@ Missing: encryption, multiple replicators, packages generated with older version
 of Archivematica, etc...
 """
 
+import base64
 import json
 import os
 import shutil
 import tarfile
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
+from typing import Callable
 from typing import Union
 
+import boto3
 import pytest
+from boto3.resources.base import ServiceResource
+from boto3.resources.collection import ResourceCollection
 from django.http import HttpResponse
 from django.test import Client as TestClient
 from django.urls import reverse
@@ -102,6 +109,11 @@ class Client:
 
     def get_locations(self, data: dict[str, str]) -> HttpResponse:
         return self.admin_client.get("/api/v2/location/", data)
+
+    def browse_location(
+        self, location_id: uuid.UUID, data: dict[str, str]
+    ) -> HttpResponse:
+        return self.admin_client.get(f"/api/v2/location/{location_id}/browse/", data)
 
     def add_file(
         self,
@@ -846,3 +858,217 @@ def test_aip_recovery_handles_recovery_copy_setup_error(
     content = resp.content.decode()
     assert "AIP restore failed: error accessing restore files" in content
     assert "Please contact an administrator or see logs for details" in content
+
+
+class KeyRecordingIterable:
+    """Proxy iterable that appends each yielded S3 key to the tracking list."""
+
+    def __init__(self, collection: Any, seen_keys: list[str]) -> None:
+        self._collection = collection
+        self._seen_keys = seen_keys
+
+    def __iter__(self) -> Iterator[Any]:
+        for obj in self._collection:
+            self._seen_keys.append(obj.key)
+            yield obj
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._collection, name)
+
+
+class KeyRecordingCollection:
+    """Proxy iterable that appends each yielded S3 key to the tracking list."""
+
+    def __init__(self, collection: ResourceCollection, seen_keys: list[str]) -> None:
+        self._collection = collection
+        self._seen_keys = seen_keys
+
+    def filter(self, *args: Any, **kwargs: Any) -> KeyRecordingIterable:
+        filtered = self._collection.filter(*args, **kwargs)
+        return KeyRecordingIterable(filtered, self._seen_keys)
+
+    def all(self) -> KeyRecordingIterable:
+        everything = self._collection.all()
+        return KeyRecordingIterable(everything, self._seen_keys)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._collection, name)
+
+
+class KeyRecordingBucket:
+    """Expose a bucket whose object collections add accessed keys to the log."""
+
+    def __init__(self, bucket: ServiceResource, seen_keys: list[str]) -> None:
+        self._bucket = bucket
+        self._seen_keys = seen_keys
+
+    @property
+    def objects(self) -> KeyRecordingCollection:
+        original_collection = self._bucket.objects
+        return KeyRecordingCollection(original_collection, self._seen_keys)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._bucket, name)
+
+
+class KeyRecordingResource:
+    """Resource wrapper that yields key-recording buckets."""
+
+    def __init__(self, resource: ServiceResource, seen_keys: list[str]) -> None:
+        self._resource = resource
+        self._seen_keys = seen_keys
+
+    def Bucket(self, name: str) -> KeyRecordingBucket:
+        bucket = self._resource.Bucket(name)
+        if not isinstance(bucket, ServiceResource):
+            raise TypeError("Expected ServiceResource bucket")
+        return KeyRecordingBucket(bucket, self._seen_keys)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._resource, name)
+
+
+def make_key_recording_resource_factory(
+    recorded_keys: list[str], original_factory: Callable[..., ServiceResource]
+) -> Callable[..., KeyRecordingResource]:
+    def factory(*args: Any, **kwargs: Any) -> KeyRecordingResource:
+        resource = original_factory(*args, **kwargs)
+        return KeyRecordingResource(resource, recorded_keys)
+
+    return factory
+
+
+@pytest.fixture
+def s3_recorded_keys(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Override boto3.resource so each key bubbled through the wrappers lands in this list."""
+    recorded_keys: list[str] = []
+    original_boto3_resource = boto3.resource
+    tracking_factory = make_key_recording_resource_factory(
+        recorded_keys, original_boto3_resource
+    )
+    monkeypatch.setattr(boto3, "resource", tracking_factory)
+    return recorded_keys
+
+
+@pytest.fixture
+def s3_resource(s3_recorded_keys: list[str]) -> ServiceResource:
+    """Return a boto3 resource connected to the test MinIO instance."""
+    del s3_recorded_keys  # Ensure tracking fixture executes before resource creation.
+    return boto3.resource(
+        "s3",
+        endpoint_url="http://minio:9000",
+        aws_access_key_id="minio",
+        aws_secret_access_key="minio123",
+        region_name="planet-earth",
+    )
+
+
+@pytest.fixture
+def s3_browse_bucket(s3_resource: ServiceResource) -> Iterator[str]:
+    """Provision a bucket with a nested structure for browse tests."""
+    bucket_name = f"storage-service-browse-{uuid.uuid4().hex}"
+    s3_resource.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": "planet-earth"},
+    )
+
+    objects = [
+        "ts/file1.txt",
+        "ts/file2.txt",
+        "ts/dir1/file3.txt",
+        "ts/dir2/file4.txt",
+        "ts/dir2/file5.txt",
+        "ts/dir2/subdir1/file6.txt",
+        "ts/dir2/subdir2/file7.txt",
+        "ts/dir2/subdir2/subdir3/file8.txt",
+    ]
+    for key in objects:
+        s3_resource.Object(bucket_name, key).put(Body=b"content")
+
+    yield bucket_name
+
+    bucket = s3_resource.Bucket(bucket_name)
+    bucket.objects.all().delete()
+    bucket.delete()
+
+
+@pytest.mark.django_db
+def test_browsing_a_s3_transfer_source_location_loads_path_level_results_only(
+    admin_client: TestClient,
+    s3_resource: ServiceResource,
+    s3_browse_bucket: str,
+    s3_recorded_keys: list[str],
+    tmp_path: Path,
+) -> None:
+    client = Client(admin_client)
+    shared_directory = tmp_path / "var" / "archivematica" / "sharedDirectory"
+    shared_directory.mkdir(parents=True, exist_ok=True)
+
+    # Create pipeline.
+    resp = client.add_pipeline(
+        {
+            "uuid": str(uuid.uuid4()),
+            "description": "My pipeline",
+            "create_default_locations": False,
+            "shared_path": str(shared_directory),
+            "remote_name": "http://127.0.0.1:65534",
+            "api_username": "test",
+            "api_key": "test",
+        }
+    )
+    assert resp.status_code == 201
+    pipeline = json.loads(resp.content)
+
+    # Create space.
+    resp = client.add_space(
+        {
+            "access_protocol": Space.S3,
+            "path": "/",
+            "staging_path": "/var/archivematica/storage_service",
+            "endpoint_url": "http://minio:9000",
+            "access_key_id": "minio",
+            "secret_access_key": "minio123",
+            "region": "planet-earth",
+            "bucket": s3_browse_bucket,
+        }
+    )
+    assert resp.status_code == 201
+    space = json.loads(resp.content)
+
+    # Create transfer source location.
+    resp = client.add_location(
+        {
+            "relative_path": "ts",
+            "purpose": Location.TRANSFER_SOURCE,
+            "space": space["resource_uri"],
+            "pipeline": [pipeline["resource_uri"]],
+        }
+    )
+    assert resp.status_code == 201
+    location = json.loads(resp.content)
+
+    resp = client.browse_location(
+        uuid.UUID(location["uuid"]), {"path": base64.b64encode(b"/ts/dir2").decode()}
+    )
+    assert resp.status_code == 200
+    browse_result = json.loads(resp.content)
+
+    entries = {base64.b64decode(entry).decode() for entry in browse_result["entries"]}
+    directories = {
+        base64.b64decode(directory).decode()
+        for directory in browse_result["directories"]
+    }
+    assert entries == {"file4.txt", "file5.txt", "subdir1", "subdir2"}
+    assert directories == {"subdir1", "subdir2"}
+
+    # Verify the keys the browse API endpoint iterated through.
+    #
+    # Due to issue #1755 the API endpoint iterated the full nested layout even
+    # though the response only exposes the top-level entries.
+    assert set(s3_recorded_keys) == {
+        "ts/dir2/file4.txt",
+        "ts/dir2/file5.txt",
+        "ts/dir2/subdir1/file6.txt",
+        "ts/dir2/subdir2/file7.txt",
+        "ts/dir2/subdir2/subdir3/file8.txt",
+    }

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -18,15 +18,11 @@ import tarfile
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
-from typing import Callable
-from typing import Optional
 from typing import Union
 
 import boto3
 import pytest
 from boto3.resources.base import ServiceResource
-from boto3.resources.collection import ResourceCollection
 from django.http import HttpResponse
 from django.test import Client as TestClient
 from django.urls import reverse
@@ -861,157 +857,6 @@ def test_aip_recovery_handles_recovery_copy_setup_error(
     assert "Please contact an administrator or see logs for details" in content
 
 
-class KeyRecordingIterable:
-    """Proxy iterable that appends each yielded S3 key to the tracking list."""
-
-    def __init__(self, collection: Any, seen_keys: list[str]) -> None:
-        self._collection = collection
-        self._seen_keys = seen_keys
-
-    def __iter__(self) -> Iterator[Any]:
-        for obj in self._collection:
-            self._seen_keys.append(obj.key)
-            yield obj
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._collection, name)
-
-
-class KeyRecordingCollection:
-    """Proxy iterable that appends each yielded S3 key to the tracking list."""
-
-    def __init__(self, collection: ResourceCollection, seen_keys: list[str]) -> None:
-        self._collection = collection
-        self._seen_keys = seen_keys
-
-    def filter(self, *args: Any, **kwargs: Any) -> KeyRecordingIterable:
-        filtered = self._collection.filter(*args, **kwargs)
-        return KeyRecordingIterable(filtered, self._seen_keys)
-
-    def all(self) -> KeyRecordingIterable:
-        everything = self._collection.all()
-        return KeyRecordingIterable(everything, self._seen_keys)
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._collection, name)
-
-
-class KeyRecordingPaginator:
-    """Wrap paginator so iterated pages append the keys they expose."""
-
-    def __init__(self, paginator: Any, seen_keys: list[str]) -> None:
-        self._paginator = paginator
-        self._seen_keys = seen_keys
-
-    def paginate(self, *args: Any, **kwargs: Any) -> Iterator[Any]:
-        for page in self._paginator.paginate(*args, **kwargs):
-            for obj in page.get("Contents", []):
-                key = obj.get("Key")
-                if key:
-                    self._seen_keys.append(key)
-            yield page
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._paginator, name)
-
-
-class KeyRecordingClient:
-    """Client wrapper that returns key-recording paginators."""
-
-    def __init__(self, client: Any, seen_keys: list[str]) -> None:
-        self._client = client
-        self._seen_keys = seen_keys
-
-    def get_paginator(self, name: str) -> KeyRecordingPaginator:
-        paginator = self._client.get_paginator(name)
-        return KeyRecordingPaginator(paginator, self._seen_keys)
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._client, name)
-
-
-class KeyRecordingMeta:
-    """Meta wrapper ensuring the client records keys."""
-
-    def __init__(self, meta: Any, seen_keys: list[str]) -> None:
-        self._meta = meta
-        self._seen_keys = seen_keys
-        self._client_wrapper: Optional[KeyRecordingClient] = None
-
-    @property
-    def client(self) -> KeyRecordingClient:
-        if self._client_wrapper is None:
-            self._client_wrapper = KeyRecordingClient(
-                self._meta.client, self._seen_keys
-            )
-        return self._client_wrapper
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._meta, name)
-
-
-class KeyRecordingBucket:
-    """Expose a bucket whose object collections add accessed keys to the log."""
-
-    def __init__(self, bucket: ServiceResource, seen_keys: list[str]) -> None:
-        self._bucket = bucket
-        self._seen_keys = seen_keys
-
-    @property
-    def objects(self) -> KeyRecordingCollection:
-        original_collection = self._bucket.objects
-        return KeyRecordingCollection(original_collection, self._seen_keys)
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._bucket, name)
-
-
-class KeyRecordingResource:
-    """Resource wrapper that yields key-recording buckets."""
-
-    def __init__(self, resource: ServiceResource, seen_keys: list[str]) -> None:
-        self._resource = resource
-        self._seen_keys = seen_keys
-        self._meta_wrapper: Optional[KeyRecordingMeta] = None
-
-    def Bucket(self, name: str) -> KeyRecordingBucket:
-        bucket = self._resource.Bucket(name)
-        if not isinstance(bucket, ServiceResource):
-            raise TypeError("Expected ServiceResource bucket")
-        return KeyRecordingBucket(bucket, self._seen_keys)
-
-    @property
-    def meta(self) -> KeyRecordingMeta:
-        if self._meta_wrapper is None:
-            self._meta_wrapper = KeyRecordingMeta(self._resource.meta, self._seen_keys)
-        return self._meta_wrapper
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._resource, name)
-
-
-def make_key_recording_resource_factory(
-    recorded_keys: list[str], original_factory: Callable[..., ServiceResource]
-) -> Callable[..., KeyRecordingResource]:
-    def factory(*args: Any, **kwargs: Any) -> KeyRecordingResource:
-        resource = original_factory(*args, **kwargs)
-        return KeyRecordingResource(resource, recorded_keys)
-
-    return factory
-
-
-@pytest.fixture
-def s3_recorded_keys(monkeypatch: pytest.MonkeyPatch) -> list[str]:
-    """Override boto3.resource so each key bubbled through the wrappers lands in this list."""
-    recorded_keys: list[str] = []
-    original_boto3_resource = boto3.resource
-    tracking_factory = make_key_recording_resource_factory(
-        recorded_keys, original_boto3_resource
-    )
-    monkeypatch.setattr(boto3, "resource", tracking_factory)
-    return recorded_keys
-
-
 @pytest.fixture
 def s3_resource(s3_recorded_keys: list[str]) -> ServiceResource:
     """Return a boto3 resource connected to the test MinIO instance."""
@@ -1057,7 +902,6 @@ def s3_browse_bucket(s3_resource: ServiceResource) -> Iterator[str]:
 @pytest.mark.django_db
 def test_browsing_a_s3_transfer_source_location_loads_path_level_results_only(
     admin_client: TestClient,
-    s3_resource: ServiceResource,
     s3_browse_bucket: str,
     s3_recorded_keys: list[str],
     tmp_path: Path,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1124,13 +1124,7 @@ def test_browsing_a_s3_transfer_source_location_loads_path_level_results_only(
     assert directories == {"subdir1", "subdir2"}
 
     # Verify the keys the browse API endpoint iterated through.
-    #
-    # Due to issue #1755 the API endpoint iterated the full nested layout even
-    # though the response only exposes the top-level entries.
     assert set(s3_recorded_keys) == {
         "ts/dir2/file4.txt",
         "ts/dir2/file5.txt",
-        "ts/dir2/subdir1/file6.txt",
-        "ts/dir2/subdir2/file7.txt",
-        "ts/dir2/subdir2/subdir3/file8.txt",
     }

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -20,6 +20,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from typing import Callable
+from typing import Optional
 from typing import Union
 
 import boto3
@@ -895,6 +896,60 @@ class KeyRecordingCollection:
         return getattr(self._collection, name)
 
 
+class KeyRecordingPaginator:
+    """Wrap paginator so iterated pages append the keys they expose."""
+
+    def __init__(self, paginator: Any, seen_keys: list[str]) -> None:
+        self._paginator = paginator
+        self._seen_keys = seen_keys
+
+    def paginate(self, *args: Any, **kwargs: Any) -> Iterator[Any]:
+        for page in self._paginator.paginate(*args, **kwargs):
+            for obj in page.get("Contents", []):
+                key = obj.get("Key")
+                if key:
+                    self._seen_keys.append(key)
+            yield page
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._paginator, name)
+
+
+class KeyRecordingClient:
+    """Client wrapper that returns key-recording paginators."""
+
+    def __init__(self, client: Any, seen_keys: list[str]) -> None:
+        self._client = client
+        self._seen_keys = seen_keys
+
+    def get_paginator(self, name: str) -> KeyRecordingPaginator:
+        paginator = self._client.get_paginator(name)
+        return KeyRecordingPaginator(paginator, self._seen_keys)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client, name)
+
+
+class KeyRecordingMeta:
+    """Meta wrapper ensuring the client records keys."""
+
+    def __init__(self, meta: Any, seen_keys: list[str]) -> None:
+        self._meta = meta
+        self._seen_keys = seen_keys
+        self._client_wrapper: Optional[KeyRecordingClient] = None
+
+    @property
+    def client(self) -> KeyRecordingClient:
+        if self._client_wrapper is None:
+            self._client_wrapper = KeyRecordingClient(
+                self._meta.client, self._seen_keys
+            )
+        return self._client_wrapper
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._meta, name)
+
+
 class KeyRecordingBucket:
     """Expose a bucket whose object collections add accessed keys to the log."""
 
@@ -917,12 +972,19 @@ class KeyRecordingResource:
     def __init__(self, resource: ServiceResource, seen_keys: list[str]) -> None:
         self._resource = resource
         self._seen_keys = seen_keys
+        self._meta_wrapper: Optional[KeyRecordingMeta] = None
 
     def Bucket(self, name: str) -> KeyRecordingBucket:
         bucket = self._resource.Bucket(name)
         if not isinstance(bucket, ServiceResource):
             raise TypeError("Expected ServiceResource bucket")
         return KeyRecordingBucket(bucket, self._seen_keys)
+
+    @property
+    def meta(self) -> KeyRecordingMeta:
+        if self._meta_wrapper is None:
+            self._meta_wrapper = KeyRecordingMeta(self._resource.meta, self._seen_keys)
+        return self._meta_wrapper
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._resource, name)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -96,7 +96,7 @@ class Client:
         )
 
     def set_location(
-        self, location_id: uuid.UUID, data: dict[str, str]
+        self, location_id: uuid.UUID, data: dict[str, Union[str, list[dict[str, str]]]]
     ) -> HttpResponse:
         return self.admin_client.post(
             f"/api/v2/location/{location_id}/",
@@ -932,8 +932,8 @@ def test_browsing_a_s3_transfer_source_location_loads_path_level_results_only(
             "path": "/",
             "staging_path": "/var/archivematica/storage_service",
             "endpoint_url": "http://minio:9000",
-            "access_key_id": "minio",
-            "secret_access_key": "minio123",
+            "access_key_id": "minio-user",
+            "secret_access_key": "minio-password",
             "region": "planet-earth",
             "bucket": s3_browse_bucket,
         }
@@ -972,3 +972,141 @@ def test_browsing_a_s3_transfer_source_location_loads_path_level_results_only(
         "ts/dir2/file4.txt",
         "ts/dir2/file5.txt",
     }
+
+
+@pytest.mark.django_db
+def test_browsing_an_rclone_transfer_source_location_works_with_limited_permissions(
+    admin_client: TestClient,
+    s3_browse_bucket: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RCLONE_CONFIG_MYS3_ACCESS_KEY_ID", "minio-user")
+    monkeypatch.setenv("RCLONE_CONFIG_MYS3_SECRET_ACCESS_KEY", "minio-password")
+
+    client = Client(admin_client)
+    shared_directory = tmp_path / "var" / "archivematica" / "sharedDirectory"
+    shared_directory.mkdir(parents=True, exist_ok=True)
+
+    # Create pipeline.
+    resp = client.add_pipeline(
+        {
+            "uuid": str(uuid.uuid4()),
+            "description": "My pipeline",
+            "create_default_locations": False,
+            "shared_path": str(shared_directory),
+            "remote_name": "http://127.0.0.1:65534",
+            "api_username": "test",
+            "api_key": "test",
+        }
+    )
+    assert resp.status_code == 201
+    pipeline = json.loads(resp.content)
+
+    # Create space.
+    resp = client.add_space(
+        {
+            "access_protocol": Space.RCLONE,
+            "path": "/",
+            "staging_path": "/var/archivematica/storage_service",
+            "remote_name": "mys3",
+            "container": s3_browse_bucket,
+        }
+    )
+    assert resp.status_code == 201
+    space = json.loads(resp.content)
+
+    # Create transfer source location.
+    resp = client.add_location(
+        {
+            "relative_path": "ts",
+            "purpose": Location.TRANSFER_SOURCE,
+            "space": space["resource_uri"],
+            "pipeline": [pipeline["resource_uri"]],
+        }
+    )
+    assert resp.status_code == 201
+    location = json.loads(resp.content)
+
+    resp = client.browse_location(
+        uuid.UUID(location["uuid"]), {"path": base64.b64encode(b"/ts/dir2").decode()}
+    )
+    assert resp.status_code == 200
+    browse_result = json.loads(resp.content)
+
+    entries = {base64.b64decode(entry).decode() for entry in browse_result["entries"]}
+    directories = {
+        base64.b64decode(directory).decode()
+        for directory in browse_result["directories"]
+    }
+    assert entries == {"file4.txt", "file5.txt", "subdir1", "subdir2"}
+    assert directories == {"subdir1", "subdir2"}
+
+    # The rest simulates the start of the Archivematica transfer process, where
+    # the pipeline requests the Storage Service to copy files from the transfer
+    # source location to the currently processing location directory.
+
+    # Create a local file system space.
+    fs_space_path = shared_directory / "tmp" / "local_fs"
+    fs_space_staging_path = shared_directory / "tmp" / "local_fs_staging_path"
+    fs_space_path.mkdir(parents=True)
+    fs_space_staging_path.mkdir(parents=True)
+    resp = client.add_space(
+        {
+            "access_protocol": Space.LOCAL_FILESYSTEM,
+            "path": str(fs_space_path),
+            "staging_path": str(fs_space_staging_path),
+        }
+    )
+    assert resp.status_code == 201
+    fs_space = json.loads(resp.content)
+
+    # Add a currently processing location.
+    resp = client.add_location(
+        {
+            "relative_path": "currentlyProcessing",
+            "purpose": Location.CURRENTLY_PROCESSING,
+            "space": fs_space["resource_uri"],
+            "pipeline": [pipeline["resource_uri"]],
+        }
+    )
+    assert resp.status_code == 201
+    fs_location = json.loads(resp.content)
+    fs_location_path = Path(fs_location["path"])
+    fs_location_path.mkdir(parents=True)
+
+    # Copy one file from the transfer source location to the currently
+    # processing location using the API.
+    source_file_name = "file1.txt"
+    transfer_name = "my-transfer"
+    transfer_dir = fs_location_path / transfer_name
+    transfer_dir.mkdir()
+    resp = client.set_location(
+        uuid.UUID(fs_location["uuid"]),
+        {
+            "origin_location": location["resource_uri"],
+            "pipeline": pipeline["resource_uri"],
+            "files": [{"source": source_file_name, "destination": transfer_name}],
+        },
+    )
+    assert resp.status_code == 200
+
+    # Browse the processing location and ensure the file was copied.
+    resp = client.browse_location(
+        uuid.UUID(fs_location["uuid"]),
+        {"path": base64.b64encode(transfer_name.encode()).decode()},
+    )
+    assert resp.status_code == 200
+    fs_browse_result = json.loads(resp.content)
+
+    entries = {
+        base64.b64decode(entry).decode() for entry in fs_browse_result["entries"]
+    }
+    directories = {
+        base64.b64decode(directory).decode()
+        for directory in fs_browse_result["directories"]
+    }
+    assert entries == {source_file_name}
+    assert directories == set()
+    # File content is set in the s3_browse_bucket fixture.
+    assert (transfer_dir / source_file_name).read_text() == "content"

--- a/tests/locations/test_s3.py
+++ b/tests/locations/test_s3.py
@@ -215,20 +215,48 @@ def test_ensure_bucket_exists_works_with_any_region(resource, s3_space):
     "boto3.resource",
     return_value=mock.Mock(
         **{
-            "Bucket.return_value.objects.filter.return_value": [
-                mock.Mock(
-                    key="/aips/myaips/myaip.7z",
-                    size=1024,
-                    last_modified="2024-01-01 00:00:00",
-                    e_tag="2b5fbc705df14fd1c4fb022acfb4b3ca",
-                ),
-                mock.Mock(
-                    key="/aips/other/other.7z",
-                    size=512,
-                    last_modified="2023-01-01 00:00:00",
-                    e_tag="9f11c93c2583100d80612e46db1c3bd5",
-                ),
-            ]
+            "meta.client.get_paginator.return_value": mock.Mock(
+                **{
+                    "paginate.side_effect": [
+                        [{"Contents": [], "CommonPrefixes": [{"Prefix": "aips/"}]}],
+                        [
+                            {
+                                "Contents": [],
+                                "CommonPrefixes": [
+                                    {"Prefix": "aips/myaips/"},
+                                    {"Prefix": "aips/other/"},
+                                ],
+                            }
+                        ],
+                        [
+                            {
+                                "Contents": [
+                                    {
+                                        "Key": "aips/myaips/myaip.7z",
+                                        "Size": 1024,
+                                        "LastModified": "2024-01-01 00:00:00",
+                                        "ETag": "2b5fbc705df14fd1c4fb022acfb4b3ca",
+                                    }
+                                ],
+                                "CommonPrefixes": [{"Prefix": "aips/myaips/aips/"}],
+                            }
+                        ],
+                        [
+                            {
+                                "Contents": [
+                                    {
+                                        "Key": "aips/other/other.7z",
+                                        "Size": 512,
+                                        "LastModified": "2023-01-01 00:00:00",
+                                        "ETag": "9f11c93c2583100d80612e46db1c3bd5",
+                                    }
+                                ],
+                                "CommonPrefixes": [{"Prefix": "aips/other/aips/"}],
+                            }
+                        ],
+                    ]
+                }
+            )
         }
     ),
 )


### PR DESCRIPTION
This updates the S3 Space browse implementation to use a boto3
paginator with a delimiter so only the current prefix is inspected.

The new integration test records S3 keys and asserts that the browse
location API endpoint returns only the requested level's directories
and files.

Connected to https://github.com/archivematica/Issues/issues/1755