### PR TITLE
Fix clean up staging directory after DuraCloud AIP upload

### DIFF
--- a/src/archivematica/storage_service/locations/models/duracloud.py
+++ b/src/archivematica/storage_service/locations/models/duracloud.py
@@ -525,3 +525,25 @@ class Duracloud(models.Model):
             raise StorageException(
                 _("%(path)s is not a file or directory.") % {"path": source_path}
             )
+
+    def post_move_from_storage_service(
+        self, staging_path, destination_path, package=None
+    ):
+        """
+        Delete staging files after successful upload to DuraCloud.
+
+        DuraCloud uploads files to remote object storage rather than moving them
+        locally, so the staging copy needs to be explicitly removed after upload.
+        """
+        if staging_path and os.path.exists(staging_path):
+            try:
+                if os.path.isdir(staging_path):
+                    shutil.rmtree(staging_path)
+                    LOGGER.info("Deleted staging directory: %s", staging_path)
+                elif os.path.isfile(staging_path):
+                    os.remove(staging_path)
+                    LOGGER.info("Deleted staging file: %s", staging_path)
+            except OSError:
+                LOGGER.warning(
+                    "Unable to remove staging path %s", staging_path, exc_info=True
+                )

--- a/tests/locations/test_duracloud.py
+++ b/tests/locations/test_duracloud.py
@@ -699,3 +699,60 @@ def test_move_from_storage_service_fails_if_source_file_cannot_be_determined(
 
     with pytest.raises(StorageException, match=f"{f} is not a file or directory."):
         d.move_from_storage_service(f.as_posix(), "some/file.txt")
+
+
+@pytest.mark.django_db
+def test_post_move_from_storage_service_deletes_staging_file(space, tmp_path):
+    d = Duracloud.objects.create(space=space, host="duracloud.org", duraspace="myspace")
+    staging_file = tmp_path / "staging_file.txt"
+    staging_file.write_text("staged content")
+
+    assert staging_file.exists()
+
+    d.post_move_from_storage_service(
+        staging_path=staging_file.as_posix(), destination_path="some/file.txt"
+    )
+
+    assert not staging_file.exists()
+
+
+@pytest.mark.django_db
+def test_post_move_from_storage_service_deletes_staging_directory(space, tmp_path):
+    d = Duracloud.objects.create(space=space, host="duracloud.org", duraspace="myspace")
+    staging_dir = tmp_path / "staging_dir"
+    staging_dir.mkdir()
+    (staging_dir / "file1.txt").write_text("content 1")
+    (staging_dir / "file2.txt").write_text("content 2")
+    subdir = staging_dir / "subdir"
+    subdir.mkdir()
+    (subdir / "file3.txt").write_text("content 3")
+
+    assert staging_dir.exists()
+    assert (staging_dir / "file1.txt").exists()
+
+    d.post_move_from_storage_service(
+        staging_path=staging_dir.as_posix(), destination_path="some/folder/"
+    )
+
+    assert not staging_dir.exists()
+
+
+@pytest.mark.django_db
+def test_post_move_from_storage_service_handles_missing_staging_path(space, tmp_path):
+    d = Duracloud.objects.create(space=space, host="duracloud.org", duraspace="myspace")
+    nonexistent = tmp_path / "nonexistent"
+
+    # Should not raise an exception
+    d.post_move_from_storage_service(
+        staging_path=nonexistent.as_posix(), destination_path="some/file.txt"
+    )
+
+
+@pytest.mark.django_db
+def test_post_move_from_storage_service_handles_none_staging_path(space):
+    d = Duracloud.objects.create(space=space, host="duracloud.org", duraspace="myspace")
+
+    # Should not raise an exception
+    d.post_move_from_storage_service(
+        staging_path=None, destination_path="some/file.txt"
+    )


### PR DESCRIPTION
Fixes an issue where temporary directories were not being deleted after DuraCloud uploads, causing disk space to be consumed by accumulated staging files.

The DuraCloud storage model was missing the `post_move_from_storage_service` hook that other storage backends implement. This hook is called after successful uploads to clean up staging directories.

## Changes

- Added `post_move_from_storage_service()` method to the `Duracloud` class
- Method explicitly deletes staging directories/files after successful upload

The issue can be found here: https://github.com/archivematica/Issues/issues/1768

