### PR TITLE
Add integration test for AIP deletion

### DIFF
--- a/src/archivematica/storage_service/locations/models/package.py
+++ b/src/archivematica/storage_service/locations/models/package.py
@@ -553,53 +553,53 @@ class Package(models.Model):
             temp_aip.delete()
             return (success, failures, message)
 
-        origin_space = temp_aip.current_location.space
-        destination_space = self.current_location.space
+        storage_space = self.current_location.space
+        recovery_space = origin_location.space
 
-        # Copy corrupt files to storage service staging
+        # Copy corrupt files to recovery backup directory via recovery staging.
         source_path = os.path.join(
             self.current_location.relative_path, self.current_path
         )
-        destination_path = os.path.join(origin_location.relative_path, "backup")
+        backup_destination_path = os.path.join(origin_location.relative_path, "backup")
 
-        origin_space.move_to_storage_service(
+        storage_space.move_to_storage_service(
             source_path=source_path,
-            destination_path=destination_path,
-            destination_space=destination_space,
+            destination_path=backup_destination_path,
+            destination_space=recovery_space,
         )
-        origin_space.post_move_to_storage_service()
+        storage_space.post_move_to_storage_service()
 
-        # Copy corrupt files from staging to backup directory
-        destination_space.move_from_storage_service(
-            source_path=destination_path,
-            destination_path=destination_path,
+        recovery_space.move_from_storage_service(
+            source_path=backup_destination_path,
+            destination_path=backup_destination_path,
             package=self,
         )
-        destination_space.post_move_from_storage_service(
-            staging_path=None, destination_path=None
+        recovery_space.post_move_from_storage_service(
+            staging_path=None, destination_path=None, package=self
         )
 
-        # Copy recovery files to storage service staging
-        source_path = os.path.join(temp_aip.current_location.relative_path, origin_path)
-        destination_path = os.path.join(
+        # Copy recovery files to storage space via storage staging.
+        recovery_source_path = os.path.join(
+            temp_aip.current_location.relative_path, origin_path
+        )
+        storage_destination_path = os.path.join(
             self.current_location.relative_path, os.path.dirname(self.current_path), ""
         )
 
-        origin_space.move_to_storage_service(
-            source_path=source_path,
-            destination_path=destination_path,
-            destination_space=destination_space,
+        recovery_space.move_to_storage_service(
+            source_path=recovery_source_path,
+            destination_path=storage_destination_path,
+            destination_space=storage_space,
         )
-        origin_space.post_move_to_storage_service()
+        recovery_space.post_move_to_storage_service()
 
-        # Copy recovery files from staging to AIP store
-        destination_space.move_from_storage_service(
-            source_path=destination_path,
-            destination_path=destination_path,
+        storage_space.move_from_storage_service(
+            source_path=storage_destination_path,
+            destination_path=storage_destination_path,
             package=self,
         )
-        destination_space.post_move_from_storage_service(
-            staging_path=None, destination_path=None
+        storage_space.post_move_from_storage_service(
+            staging_path=None, destination_path=None, package=self
         )
 
         temp_aip.delete()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import tarfile
 import uuid
+from collections.abc import Iterable
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Optional
@@ -26,6 +27,7 @@ from typing import Union
 import boto3
 import pytest
 from boto3.resources.base import ServiceResource
+from botocore.exceptions import ClientError
 from django.http import StreamingHttpResponse
 from django.test import Client as TestClient
 from django.urls import reverse
@@ -303,12 +305,21 @@ class StorageScenario:
             f"foobar-{self.PACKAGE_UUID}{''.join(pkg.suffixes) if compressed else ''}"
         )
         self.compressed = compressed
+        self._object_storage_bucket_name: Optional[str] = None
 
-    def init(self, admin_client: TestClient, working_directory_path: Path) -> None:
+    def init(
+        self,
+        admin_client: TestClient,
+        working_directory_path: Path,
+        *,
+        s3_bucket: Optional[str] = None,
+    ) -> None:
         self.client = Client(admin_client)
         self.shared_directory_path = (
             working_directory_path / "var" / "archivematica" / "sharedDirectory"
         )
+        if s3_bucket is not None:
+            self._object_storage_bucket_name = s3_bucket
         self.register_pipeline()
         self.register_aip_storage_location()
         if self.replication_protocol:
@@ -332,25 +343,23 @@ class StorageScenario:
     def _adjust_space_data(
         self, data: dict[str, Union[str, bool]]
     ) -> dict[str, Union[str, bool]]:
+        adjusted = data.copy()
         for attr in ["path", "staging_path"]:
-            if (
-                (value := data.get(attr) is not None)
-                and isinstance(value, str)
-                and value.startswith("/var/archivematica/sharedDirectory")
+            value = adjusted.get(attr)
+            if isinstance(value, str) and value.startswith(
+                "/var/archivematica/sharedDirectory"
             ):
-                data[attr] = value.replace(
+                adjusted[attr] = value.replace(
                     "/var/archivematica/sharedDirectory",
                     str(self.shared_directory_path),
                 )
-        return data
+        return adjusted
 
     def register_aip_storage_location(self) -> None:
         """Register AIP Storage location."""
 
         # Add space.
-        resp = self.client.add_space(
-            self._adjust_space_data(self.SPACES[self.storage_protocol])
-        )
+        resp = self.client.add_space(self._space_definition(self.storage_protocol))
         assert resp.status_code == 201
         space = json.loads(resp.content)
 
@@ -421,9 +430,7 @@ class StorageScenario:
         """Register AIP Storage replicator."""
 
         # 1. Add space.
-        resp = self.client.add_space(
-            self._adjust_space_data(self.SPACES[self.replication_protocol])
-        )
+        resp = self.client.add_space(self._space_definition(self.replication_protocol))
         assert resp.status_code == 201
         space = json.loads(resp.content)
 
@@ -471,6 +478,9 @@ class StorageScenario:
         assert self.aip_storage_location_attrs is not None
         as_location = self.aip_storage_location_attrs
 
+        aip_id = self.PACKAGE_UUID.hex
+        aip_id_chunks = [aip_id[i : i + 4] for i in range(0, len(aip_id), 4)]
+
         resp = self.client.add_file(
             self.PACKAGE_UUID,
             {
@@ -490,12 +500,7 @@ class StorageScenario:
         assert resp.status_code == 201
 
         aip = json.loads(resp.content)
-        aip_id = self.PACKAGE_UUID.hex
-        aip_path_parts = (
-            [as_location["path"]]
-            + [aip_id[i : i + 4] for i in range(0, len(aip_id), 4)]
-            + [self.pkg_name]
-        )
+        aip_path_parts = [as_location["path"], *aip_id_chunks, self.pkg_name]
         aip_path = Path(*aip_path_parts)
         assert aip["uuid"] == str(self.PACKAGE_UUID)
         assert aip["current_full_path"] == str(aip_path)
@@ -504,6 +509,26 @@ class StorageScenario:
             assert stored_size == get_size(self.pkg)
         else:
             assert get_size(aip_path) > 1
+
+    def _space_definition(self, protocol: str) -> dict[str, Union[str, bool]]:
+        data = self._adjust_space_data(self.SPACES[protocol])
+        bucket_key = self._object_storage_bucket_key(protocol)
+        if bucket_key:
+            bucket_name = self._object_storage_bucket_name
+            if not bucket_name:
+                raise RuntimeError(
+                    "Object storage spaces require the s3_browse_bucket fixture to be "
+                    "passed into StorageScenario.init()."
+                )
+            data[bucket_key] = bucket_name
+        return data
+
+    def _object_storage_bucket_key(self, protocol: str) -> str:
+        if protocol == Space.S3:
+            return "bucket"
+        if protocol == Space.RCLONE:
+            return "container"
+        return ""
 
     def assert_stored(self) -> None:
         if self.replication_protocol:
@@ -686,8 +711,13 @@ def test_main(
     storage_scenario: StorageScenario,
     admin_client: TestClient,
     working_directory_path: Path,
+    s3_browse_bucket: str,
 ) -> None:
-    storage_scenario.init(admin_client, working_directory_path)
+    storage_scenario.init(
+        admin_client,
+        working_directory_path,
+        s3_bucket=s3_browse_bucket,
+    )
     storage_scenario.store_aip()
     storage_scenario.assert_stored()
 
@@ -843,9 +873,14 @@ def test_aip_recovery(
     corrupt_package: bool,
     admin_client: TestClient,
     working_directory_path: Path,
+    s3_browse_bucket: str,
     tmp_path: Path,
 ) -> None:
-    scenario.init(admin_client, working_directory_path)
+    scenario.init(
+        admin_client,
+        working_directory_path,
+        s3_bucket=s3_browse_bucket,
+    )
     scenario.store_aip()
     scenario.assert_stored()
     if corrupt_package:
@@ -860,6 +895,7 @@ def test_aip_recovery_handles_recovery_copy_setup_error(
     startup: None,
     admin_client: TestClient,
     working_directory_path: Path,
+    s3_browse_bucket: str,
 ) -> None:
     # This represents an scenario where the user does not place the recovery
     # copy in the recovery location directory, creates the recovery request
@@ -867,7 +903,11 @@ def test_aip_recovery_handles_recovery_copy_setup_error(
     scenario = AIPRecoveryScenario(
         storage_protocol=Space.NFS, pkg=COMPRESSED_PACKAGE, compressed=True
     )
-    scenario.init(admin_client, working_directory_path)
+    scenario.init(
+        admin_client,
+        working_directory_path,
+        s3_bucket=s3_browse_bucket,
+    )
     scenario.store_aip()
     scenario.assert_stored()
     scenario.corrupt_package()
@@ -913,27 +953,46 @@ def s3_resource(s3_recorded_keys: list[str]) -> ServiceResource:
     )
 
 
-@pytest.fixture
-def s3_browse_bucket(s3_resource: ServiceResource) -> Iterator[str]:
-    """Provision a bucket with a nested structure for browse tests."""
-    bucket_name = f"storage-service-browse-{uuid.uuid4().hex}"
-    s3_resource.create_bucket(
-        Bucket=bucket_name,
-        CreateBucketConfiguration={"LocationConstraint": "planet-earth"},
-    )
+def _provision_s3_bucket(
+    s3_resource: ServiceResource,
+    *,
+    region: str,
+    name_prefix: str,
+    object_keys: Optional[Iterable[str]] = None,
+) -> str:
+    bucket_name = f"{name_prefix}{uuid.uuid4().hex}"
+    try:
+        if region.lower() == "us-east-1":
+            s3_resource.create_bucket(Bucket=bucket_name)
+        else:
+            s3_resource.create_bucket(
+                Bucket=bucket_name,
+                CreateBucketConfiguration={"LocationConstraint": region},
+            )
+    except ClientError as exc:
+        error_code = (exc.response.get("Error") or {}).get("Code")
+        if error_code not in {"BucketAlreadyOwnedByYou", "BucketAlreadyExists"}:
+            raise
 
-    objects = [
-        "ts/file1.txt",
-        "ts/file2.txt",
-        "ts/dir1/file3.txt",
-        "ts/dir2/file4.txt",
-        "ts/dir2/file5.txt",
-        "ts/dir2/subdir1/file6.txt",
-        "ts/dir2/subdir2/file7.txt",
-        "ts/dir2/subdir2/subdir3/file8.txt",
-    ]
-    for key in objects:
-        s3_resource.Object(bucket_name, key).put(Body=b"content")
+    if object_keys:
+        for key in object_keys:
+            s3_resource.Object(bucket_name, key).put(Body=b"content")
+
+    return bucket_name
+
+
+@pytest.fixture
+def s3_browse_bucket(
+    request: pytest.FixtureRequest, s3_resource: ServiceResource
+) -> Iterator[str]:
+    """Provision a bucket backed by the MinIO test service."""
+    object_keys = getattr(request, "param", None)
+    bucket_name = _provision_s3_bucket(
+        s3_resource,
+        region="planet-earth",
+        name_prefix="storage-service-browse-",
+        object_keys=object_keys,
+    )
 
     yield bucket_name
 
@@ -942,7 +1001,24 @@ def s3_browse_bucket(s3_resource: ServiceResource) -> Iterator[str]:
     bucket.delete()
 
 
+_BROWSE_BUCKET_OBJECTS = [
+    "ts/file1.txt",
+    "ts/file2.txt",
+    "ts/dir1/file3.txt",
+    "ts/dir2/file4.txt",
+    "ts/dir2/file5.txt",
+    "ts/dir2/subdir1/file6.txt",
+    "ts/dir2/subdir2/file7.txt",
+    "ts/dir2/subdir2/subdir3/file8.txt",
+]
+
+
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "s3_browse_bucket",
+    [_BROWSE_BUCKET_OBJECTS],
+    indirect=True,
+)
 def test_browsing_a_s3_transfer_source_location_loads_path_level_results_only(
     admin_client: TestClient,
     s3_browse_bucket: str,
@@ -1018,6 +1094,11 @@ def test_browsing_a_s3_transfer_source_location_loads_path_level_results_only(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "s3_browse_bucket",
+    [_BROWSE_BUCKET_OBJECTS],
+    indirect=True,
+)
 def test_browsing_an_rclone_transfer_source_location_works_with_limited_permissions(
     admin_client: TestClient,
     s3_browse_bucket: str,
@@ -1225,10 +1306,7 @@ class AIPDeletionScenario(StorageScenario):
 
         if self.storage_protocol in self.OBJECT_STORAGE_PROTOCOLS:
             assert s3_resource is not None
-            if self.storage_protocol == Space.S3:
-                bucket_name = self.SPACES[self.storage_protocol].get("bucket")
-            else:
-                bucket_name = self.SPACES[self.storage_protocol].get("container")
+            bucket_name = self._object_storage_bucket_name
             assert bucket_name
             prefix = package_full_path.lstrip(os.sep)
             bucket = s3_resource.Bucket(bucket_name)
@@ -1288,9 +1366,14 @@ def test_aip_deletion(
     scenario: AIPDeletionScenario,
     admin_client: TestClient,
     working_directory_path: Path,
+    s3_browse_bucket: str,
     s3_resource: ServiceResource,
 ) -> None:
-    scenario.init(admin_client, working_directory_path)
+    scenario.init(
+        admin_client,
+        working_directory_path,
+        s3_bucket=s3_browse_bucket,
+    )
     scenario.store_aip()
     scenario.assert_stored()
     package_full_path = scenario.delete_aip()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -18,7 +18,9 @@ import tarfile
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Optional
 from typing import Protocol
+from typing import TypedDict
 from typing import Union
 
 import boto3
@@ -61,6 +63,21 @@ PremisEvent = tuple[
     tuple[TagName, tuple[TagName, Element]],
     tuple[TagName, Element, Element],
 ]
+
+
+class LocationResponseResult(TypedDict):
+    description: Optional[str]
+    enabled: bool
+    path: str
+    pipeline: list[str]
+    purpose: str
+    quota: Optional[int]
+    relative_path: str
+    resource_uri: str
+    space: str
+    used: int
+    uuid: str
+
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -155,6 +172,23 @@ class Client:
             follow=True,
         )
 
+    def request_aip_deletion(
+        self, file_id: uuid.UUID, data: dict[str, Union[str, int]]
+    ) -> HttpResponse:
+        return self.admin_client.post(
+            f"/api/v2/file/{file_id}/delete_aip/",
+            json.dumps(data),
+            content_type="application/json",
+        )
+
+    def approve_aip_deletion_request(self, event_id: int) -> HttpResponse:
+        # Not possible via API.
+        return self.admin_client.post(
+            reverse("locations:package_delete_request"),
+            {"approve": "Approve", f"{event_id}-status_reason": "Approved!"},
+            follow=True,
+        )
+
     def download_file(self, file_id: uuid.UUID) -> HttpResponse:
         return self.admin_client.get(f"/api/v2/file/{file_id}/download/")
 
@@ -217,6 +251,7 @@ class StorageScenario:
 
     PIPELINE_UUID = uuid.UUID("00000b87-1655-4b7e-bbf8-344b317da334")
     PACKAGE_UUID = uuid.UUID("5658e603-277b-4292-9b58-20bf261c8f88")
+    OBJECT_STORAGE_PROTOCOLS = {Space.S3, Space.RCLONE}
 
     SPACES: dict[str, dict[str, Union[str, bool]]] = {
         Space.S3: {
@@ -261,6 +296,7 @@ class StorageScenario:
         compressed: bool,
     ) -> None:
         self.storage_protocol = storage_protocol
+        self.aip_storage_location_attrs: Optional[LocationResponseResult] = None
         self.replication_protocol = replication_protocol
         self.pkg = pkg
         self.pkg_name = (
@@ -329,6 +365,7 @@ class StorageScenario:
             }
         )
         assert resp.status_code == 201
+        self.aip_storage_location_attrs = json.loads(resp.content)
 
     def get_compression_event(self) -> PremisEvent:
         return (
@@ -404,12 +441,9 @@ class StorageScenario:
         rp_location = json.loads(resp.content)
 
         # 3. Install replicator (not possible via API).
-        resp = self.client.get_locations(
-            {"pipeline_uuid": str(self.PIPELINE_UUID), "purpose": Location.AIP_STORAGE}
-        )
-        as_location = json.loads(resp.content)["objects"][0]
         rp_location = Location.objects.get(uuid=rp_location["uuid"])
-        as_location = Location.objects.get(uuid=as_location["uuid"])
+        assert self.aip_storage_location_attrs is not None
+        as_location = Location.objects.get(uuid=self.aip_storage_location_attrs["uuid"])
         as_location.replicators.add(rp_location)
         assert (
             Location.objects.get(uuid=as_location.uuid).replicators.all().count() == 1
@@ -434,17 +468,15 @@ class StorageScenario:
         )
         cp_location = json.loads(resp.content)["objects"][0]
 
-        resp = self.client.get_locations(
-            {"pipeline_uuid": str(self.PIPELINE_UUID), "purpose": Location.AIP_STORAGE}
-        )
-        as_location = json.loads(resp.content)["objects"][0]
+        assert self.aip_storage_location_attrs is not None
+        as_location = self.aip_storage_location_attrs
 
         resp = self.client.add_file(
             self.PACKAGE_UUID,
             {
                 "uuid": str(self.PACKAGE_UUID),
                 "origin_location": cp_location["resource_uri"],
-                "origin_path": self.pkg_name,
+                "origin_path": f"{self.pkg_name}{'/' if not self.compressed else ''}",
                 "current_location": as_location["resource_uri"],
                 "current_path": self.pkg_name,
                 "size": get_size(self.pkg),
@@ -467,7 +499,11 @@ class StorageScenario:
         aip_path = Path(*aip_path_parts)
         assert aip["uuid"] == str(self.PACKAGE_UUID)
         assert aip["current_full_path"] == str(aip_path)
-        assert get_size(aip_path) > 1
+        if self.storage_protocol in self.OBJECT_STORAGE_PROTOCOLS:
+            stored_size = Package.objects.get(uuid=self.PACKAGE_UUID).size
+            assert stored_size == get_size(self.pkg)
+        else:
+            assert get_size(aip_path) > 1
 
     def assert_stored(self) -> None:
         if self.replication_protocol:
@@ -1117,3 +1153,150 @@ def test_browsing_an_rclone_transfer_source_location_works_with_limited_permissi
     assert directories == set()
     # File content is set in the s3_browse_bucket fixture.
     assert (transfer_dir / source_file_name).read_text() == "content"
+
+
+class AIPDeletionScenario(StorageScenario):
+    def request_aip_deletion(self, data: dict[str, Union[str, int]]) -> HttpResponse:
+        return self.client.request_aip_deletion(self.PACKAGE_UUID, data)
+
+    def approve_aip_deletion_request(self, event_id: int) -> HttpResponse:
+        return self.client.approve_aip_deletion_request(event_id)
+
+    def delete_aip(self) -> str:
+        data: dict[str, Union[str, int]] = {
+            "event_reason": "Delete please!",
+            "pipeline": str(self.PIPELINE_UUID),
+            "user_id": 1,
+            "user_email": "user@example.com",
+        }
+        resp = self.request_aip_deletion(data)
+        assert resp.status_code == 202
+
+        assert Event.objects.count() == 1
+
+        event = Event.objects.get(
+            package=Package.objects.get(uuid=self.PACKAGE_UUID),
+            event_type=Event.DELETE,
+            status=Event.SUBMITTED,
+            event_reason=data["event_reason"],
+            pipeline_id=data["pipeline"],
+            user_id=data["user_id"],
+            user_email=data["user_email"],
+        )
+
+        package = Package.objects.get(uuid=self.PACKAGE_UUID)
+        assert package.current_location.space.access_protocol == self.storage_protocol
+        package_full_path = str(package.full_path)
+
+        if self.storage_protocol not in self.OBJECT_STORAGE_PROTOCOLS:
+            assert Path(package_full_path).exists()
+
+        resp = self.approve_aip_deletion_request(event.id)
+        assert resp.status_code == 200
+        content = resp.content.decode()
+        assert "Request approved: Package deleted successfully." in content
+
+        assert Event.objects.count() == 1
+        assert (
+            Event.objects.filter(
+                package=Package.objects.get(uuid=self.PACKAGE_UUID),
+                event_type=Event.DELETE,
+                status=Event.APPROVED,
+                event_reason=data["event_reason"],
+                pipeline_id=data["pipeline"],
+                user_id=data["user_id"],
+                user_email=data["user_email"],
+            ).count()
+            == 1
+        )
+
+        package.refresh_from_db()
+        assert package.status == Package.DELETED
+
+        return package_full_path
+
+    def assert_deleted(
+        self,
+        package_full_path: str,
+        s3_resource: Optional[ServiceResource],
+    ) -> None:
+        package = Package.objects.get(uuid=self.PACKAGE_UUID)
+        assert package.status == Package.DELETED
+
+        if self.storage_protocol in self.OBJECT_STORAGE_PROTOCOLS:
+            assert s3_resource is not None
+            if self.storage_protocol == Space.S3:
+                bucket_name = self.SPACES[self.storage_protocol].get("bucket")
+            else:
+                bucket_name = self.SPACES[self.storage_protocol].get("container")
+            assert bucket_name
+            prefix = package_full_path.lstrip(os.sep)
+            bucket = s3_resource.Bucket(bucket_name)
+            remaining = list(bucket.objects.filter(Prefix=prefix))
+            assert not remaining
+        else:
+            path = Path(package_full_path)
+            assert not path.exists()
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        AIPDeletionScenario(
+            storage_protocol=Space.S3, pkg=COMPRESSED_PACKAGE, compressed=True
+        ),
+        AIPDeletionScenario(
+            storage_protocol=Space.S3, pkg=UNCOMPRESSED_PACKAGE, compressed=False
+        ),
+        AIPDeletionScenario(
+            storage_protocol=Space.RCLONE, pkg=COMPRESSED_PACKAGE, compressed=True
+        ),
+        AIPDeletionScenario(
+            storage_protocol=Space.RCLONE, pkg=UNCOMPRESSED_PACKAGE, compressed=False
+        ),
+        AIPDeletionScenario(
+            storage_protocol=Space.NFS, pkg=COMPRESSED_PACKAGE, compressed=True
+        ),
+        AIPDeletionScenario(
+            storage_protocol=Space.NFS, pkg=UNCOMPRESSED_PACKAGE, compressed=False
+        ),
+        AIPDeletionScenario(
+            storage_protocol=Space.LOCAL_FILESYSTEM,
+            pkg=COMPRESSED_PACKAGE,
+            compressed=True,
+        ),
+        AIPDeletionScenario(
+            storage_protocol=Space.LOCAL_FILESYSTEM,
+            pkg=UNCOMPRESSED_PACKAGE,
+            compressed=False,
+        ),
+    ],
+    ids=[
+        "s3_compressed",
+        "s3_uncompressed",
+        "rclone_compressed",
+        "rclone_uncompressed",
+        "nfs_compressed",
+        "nfs_uncompressed",
+        "local_fs_compressed",
+        "local_fs_uncompressed",
+    ],
+)
+@pytest.mark.django_db
+def test_aip_deletion(
+    startup: None,
+    scenario: AIPDeletionScenario,
+    admin_client: TestClient,
+    working_directory_path: Path,
+    s3_resource: ServiceResource,
+) -> None:
+    scenario.init(admin_client, working_directory_path)
+    scenario.store_aip()
+    scenario.assert_stored()
+    package_full_path = scenario.delete_aip()
+    scenario.assert_deleted(
+        package_full_path,
+        s3_resource
+        if scenario.storage_protocol in scenario.OBJECT_STORAGE_PROTOCOLS
+        else None,
+    )


### PR DESCRIPTION
This updates the integration tests to cover the end-to-end delete AIP flow for compressed and uncompressed packages in S3, RClone, NFS, and local spaces, including the admin approval path and cleanup assertions.

It also changes the storage scenario setup to cache the created AIP storage location so the tests reuse the precise location while avoiding collisions with the default locations created during startup and pipeline provisioning.

Connected to https://github.com/archivematica/Issues/issues/1696