### PR TITLE
Add API endpoint for reviewing AIP deletion requests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
     - python-gnupg
     - python-swiftclient
     - sword2 @ git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4
+    - types-requests
 - repo: https://github.com/tcort/markdown-link-check
   rev: v3.14.1
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ ignore_errors = true
 module = [
     "archivematica.storage_service.administration.roles",
     "archivematica.storage_service.common.helpers",
+    "archivematica.storage_service.locations.package_request",
     "tests.administration.test_users",
     "tests.integration.*",
     "tests.storage_service.test_helpers",

--- a/src/archivematica/storage_service/common/utils.py
+++ b/src/archivematica/storage_service/common/utils.py
@@ -104,7 +104,7 @@ def get_all_settings():
     return settings
 
 
-def get_setting(setting, default=None):
+def get_setting(setting: str, default: Any = None) -> Any:
     """Returns the value of 'setting' from models.Settings, 'default' if not found."""
     try:
         setting = models.Settings.objects.get(name=setting)

--- a/src/archivematica/storage_service/locations/api/resources.py
+++ b/src/archivematica/storage_service/locations/api/resources.py
@@ -3,12 +3,12 @@
 import json
 import logging
 import os
-import pprint
 import re
 import shutil
 import urllib.parse
 import uuid
 from pathlib import Path
+from typing import Any
 
 import bagit
 import tastypie.exceptions
@@ -16,6 +16,8 @@ from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned
 from django.core.exceptions import ObjectDoesNotExist
 from django.forms.models import model_to_dict
+from django.http import HttpRequest
+from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.urls import re_path
 from django.urls import reverse
@@ -27,6 +29,7 @@ from tastypie.authentication import BasicAuthentication
 from tastypie.authentication import MultiAuthentication
 from tastypie.authentication import SessionAuthentication
 from tastypie.authorization import DjangoAuthorization
+from tastypie.bundle import Bundle
 from tastypie.resources import ALL
 from tastypie.resources import ALL_WITH_RELATIONS
 from tastypie.resources import ModelResource
@@ -35,6 +38,7 @@ from tastypie.validation import CleanedDataFormValidation
 
 from archivematica.storage_service.administration.models import Settings
 from archivematica.storage_service.common import utils
+from archivematica.storage_service.locations import package_request
 from archivematica.storage_service.locations import signals
 from archivematica.storage_service.locations.api.sword import views as sword_views
 from archivematica.storage_service.locations.constants import PROTOCOL
@@ -813,6 +817,16 @@ class PackageResource(ModelResource):
                 name="recover_aip_request",
             ),
             re_path(
+                r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/review_aip_deletion%s$"
+                % (
+                    self._meta.resource_name,
+                    self._meta.detail_uri_name,
+                    trailing_slash(),
+                ),
+                self.wrap_view("review_aip_deletion_request"),
+                name="review_aip_deletion_request",
+            ),
+            re_path(
                 r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/extract_file%s$"
                 % (
                     self._meta.resource_name,
@@ -1246,8 +1260,9 @@ class PackageResource(ModelResource):
                 response_json, content_type="application/json"
             )
 
+        config = package_request.PackageDeletionRequestHandlerConfig()
         (status_code, response) = self._attempt_package_request_event(
-            package, request_info, Event.DELETE, Package.DEL_REQ
+            package, request_info, config
         )
 
         if status_code == 202:
@@ -1284,14 +1299,122 @@ class PackageResource(ModelResource):
                 response_json, content_type="application/json"
             )
 
+        config = package_request.PackageRecoveryRequestHandlerConfig()
         (status_code, response) = self._attempt_package_request_event(
-            package, request_info, Event.RECOVER, Package.RECOVER_REQ
+            package, request_info, config
         )
 
         self.log_throttled_access(request)
         response_json = json.dumps(response)
         return http.HttpResponse(
             status=status_code, content=response_json, content_type="application/json"
+        )
+
+    @_custom_endpoint(
+        expected_methods=["post"], required_fields=("event_id", "decision", "reason")
+    )
+    def review_aip_deletion_request(
+        self, request: HttpRequest, bundle: Bundle, **kwargs: Any
+    ) -> HttpResponse:
+        config = package_request.PackageDeletionRequestHandlerConfig()
+
+        return self._review_package_request(
+            request=request,
+            bundle=bundle,
+            config=config,
+            required_permission="locations.approve_package_deletion",
+        )
+
+    def _review_package_request(
+        self,
+        *,
+        request: HttpRequest,
+        bundle: Bundle,
+        config: package_request.PackageRequestHandlerConfig,
+        required_permission: str,
+    ) -> HttpResponse:
+        user = getattr(request, "user", None)
+        if not user or not user.has_perm(required_permission):
+            return http.HttpForbidden()
+
+        package: Package = bundle.obj
+        data = bundle.data
+
+        event_id_value: Any = data.get("event_id")
+        if event_id_value is None:
+            return self._bad_request_response(_("An event id must be provided."))
+
+        try:
+            event_id = int(event_id_value)
+        except (TypeError, ValueError):
+            return self._bad_request_response(_("Event id must be an integer."))
+        if event_id < 1:
+            return self._bad_request_response(_("Event id must be a positive integer."))
+
+        try:
+            decision_value, reason = package_request.parse_decision_and_reason(
+                data.get("decision"), data.get("reason")
+            )
+        except package_request.PackageRequestValidationError as error:
+            return self._bad_request_response(error.message)
+
+        event_type = config.event_type
+        if event_type is None:
+            raise ValueError("Package request event type is not configured.")
+
+        try:
+            event = Event.objects.select_related("package").get(
+                id=event_id,
+                package=package,
+                event_type=event_type,
+            )
+        except Event.DoesNotExist:
+            response_data = {
+                "error_message": _(
+                    "No pending request matches this package and event id."
+                )
+            }
+
+            return http.HttpNotFound(
+                json.dumps(response_data), content_type="application/json"
+            )
+
+        if event.status != Event.SUBMITTED:
+            return self._bad_request_response(_("This request is not pending review."))
+
+        result = package_request.process_package_request_decision(
+            config,
+            event,
+            decision_value,
+            reason=reason,
+            admin=user,
+        )
+
+        status_code = 200
+        message = str(result.message.content)
+        if result.message.level == "error":
+            response_payload = {"error_message": message}
+        else:
+            response_payload = {"message": message}
+
+        if result.message.detail:
+            # The response surfaces the successful deletion warning details (for
+            # example from LOCKSS) alongside the primary message.
+            response_payload["detail"] = str(result.message.detail)
+
+        self.log_throttled_access(request)
+
+        return http.HttpResponse(
+            json.dumps(response_payload),
+            content_type="application/json",
+            status=status_code,
+        )
+
+    def _bad_request_response(self, message: Any) -> HttpResponse:
+        response_data = {"error_message": str(message)}
+
+        return http.HttpBadRequest(
+            json.dumps(response_data), content_type="application/json"
         )
 
     @_custom_endpoint(expected_methods=["get", "head"])
@@ -1757,46 +1880,24 @@ class PackageResource(ModelResource):
         return sword_views.deposit_state(request, package or kwargs["uuid"])
 
     def _attempt_package_request_event(
-        self, package, request_info, event_type, event_status
-    ):
-        """Generic package request handler, e.g. package recovery: RECOVER_REQ,
-        or package deletion: DEL_REQ.
-        """
-        LOGGER.info(
-            f"Package event: '{event_type}' requested, with package status: '{event_status}'"
+        self,
+        package: Package,
+        request_info: dict[str, Any],
+        config: package_request.PackageRequestHandlerConfig,
+    ) -> tuple[int, dict[str, Any]]:
+        """Generic package request handler (e.g. recover or delete)."""
+
+        submission_result = package_request.submit_package_request_event(
+            config, package, request_info=request_info
         )
-        LOGGER.debug(pprint.pformat(request_info))
 
-        pipeline = Pipeline.objects.get(uuid=request_info["pipeline"])
-        request_description = event_type.replace("_", " ").lower()
-
-        # See if an event already exists
-        existing_requests = Event.objects.filter(
-            package=package, event_type=event_type, status=Event.SUBMITTED
-        ).count()
-        if existing_requests < 1:
-            request_event = Event(
-                package=package,
-                event_type=event_type,
-                status=Event.SUBMITTED,
-                event_reason=request_info["event_reason"],
-                pipeline=pipeline,
-                user_id=request_info["user_id"],
-                user_email=request_info["user_email"],
-                store_data=package.status,
-            )
-
-            # Update package status
-            package.status = event_status
-            package.save()
-
-            request_event.save()
+        request_description = config.request_description
+        if submission_result.created and submission_result.event is not None:
             response = {
                 "message": _("%(event_type)s request created successfully.")
                 % {"event_type": request_description.title()},
-                "id": request_event.id,
+                "id": submission_result.event.id,
             }
-
             status_code = 202
         else:
             response = {

--- a/src/archivematica/storage_service/locations/models/package.py
+++ b/src/archivematica/storage_service/locations/models/package.py
@@ -10,6 +10,8 @@ import subprocess
 import tempfile
 from collections import namedtuple
 from pathlib import Path
+from typing import Any
+from typing import Optional
 from uuid import uuid4
 
 import bagit
@@ -20,6 +22,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+from django_stubs_ext import StrOrPromise
 from lxml import etree
 from metsrw.plugins import premisrw
 
@@ -528,7 +531,9 @@ class Package(models.Model):
         self.current_location.space.update_package_status(self)
         self._update_existing_ptr_loc_info()
 
-    def recover_aip(self, origin_location, origin_path):
+    def recover_aip(
+        self, origin_location, origin_path
+    ) -> tuple[Optional[bool], list[Any], StrOrPromise]:
         """Recovers an AIP using files at a given location.
 
         Creates a temporary package associated with recovery AIP files within
@@ -1915,8 +1920,11 @@ class Package(models.Model):
         self.save()
 
     def check_fixity(
-        self, force_local=False, delete_after=True, verify_correct_package=True
-    ):
+        self,
+        force_local: bool = False,
+        delete_after: bool = True,
+        verify_correct_package: bool = True,
+    ) -> tuple[Optional[bool], list[Any], StrOrPromise, Optional[str]]:
         """Scans the package to verify its checksums.
 
         This will check if the Space can run a fixity and use that. If not, it will run fixity locally.
@@ -2087,19 +2095,19 @@ class Package(models.Model):
         return report, response
 
     @staticmethod
-    def _if_lockss_notify(space, uuid, attributes):
+    def _if_lockss_notify(space, package):
         """Notify lOM that files will be deleted."""
         if not space.access_protocol == Space.LOM:
             return
-        NUM_FILES = "num_files"
-        if NUM_FILES not in attributes:
+        num_files = package.misc_attributes.get("num_files")
+        if num_files is None:
             return
         lom = space.get_child_space()
         lom.update_service_document()
         delete_lom_ids = [
-            lom._download_url(uuid, idx + 1) for idx in range(attributes[NUM_FILES])
+            lom._download_url(package.uuid, idx + 1) for idx in range(num_files)
         ]
-        return lom._delete_update_lom(delete_lom_ids)
+        return lom._delete_update_lom(package, delete_lom_ids)
 
     @staticmethod
     def _delete_pointer_file(
@@ -2155,7 +2163,7 @@ class Package(models.Model):
                     replica_error,
                 )
 
-    def delete_from_storage(self):
+    def delete_from_storage(self) -> tuple[bool, Optional[StrOrPromise]]:
         """Deletes the package from filesystem and updates metadata.
         Returns (True, None) on success, and (False, error_msg) on failure.
         """
@@ -2165,16 +2173,16 @@ class Package(models.Model):
             True if self.replicated_package else False,
         )
 
-        error = None
+        error: Optional[StrOrPromise] = None
         location = self.current_location
         space = location.space
 
-        error = self._if_lockss_notify(space, self.uuid, self.misc_attributes)
+        error = self._if_lockss_notify(space, self)
 
         try:
             space.delete_path(self.full_path)
         except (StorageException, NotImplementedError, ValueError) as err:
-            return False, err
+            return False, str(err)
 
         self._delete_pointer_file(
             self.uuid,

--- a/src/archivematica/storage_service/locations/package_request.py
+++ b/src/archivematica/storage_service/locations/package_request.py
@@ -1,0 +1,399 @@
+"""Helpers that encapsulate the package request workflow.
+
+This module defines configuration classes and helper functions that manage
+package request events (such as delete and recover operations) in the Storage
+Service. Views and API endpoints rely on these helpers to validate requests,
+persist workflow state, execute package operations, and send remote
+notifications to external systems.
+"""
+
+import json
+import logging
+import os
+import pprint
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+from typing import Literal
+from typing import Optional
+from typing import Union
+
+import requests
+from django.utils.translation import gettext as _
+from django_stubs_ext import StrOrPromise
+
+from archivematica.storage_service.common import utils
+from archivematica.storage_service.locations.models import Event
+from archivematica.storage_service.locations.models import Package
+from archivematica.storage_service.locations.models import Pipeline
+from archivematica.storage_service.locations.models import StorageException
+from archivematica.storage_service.locations.models.location import Location
+from archivematica.storage_service.locations.models.location import LocationPipeline
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PackageRequestHandlerConfig:
+    event_type: Optional[str] = None  # Event type being handled.
+    pending_status: Optional[str] = (
+        None  # Package status while request is pending review.
+    )
+    approved_status: Optional[str] = None  # Package status after approval.
+    reject_message: Union[StrOrPromise, str] = ""  # Message returned if not approved.
+    execution_success_message: Union[StrOrPromise, str] = (
+        ""  # Message returned if execution succeeds.
+    )
+    execution_fail_message: Union[StrOrPromise, str] = (
+        ""  # Message returned if execution fails.
+    )
+
+    def execution_logic(self, package: Package) -> tuple[bool, StrOrPromise]:
+        raise NotImplementedError("Implement in subclasses")
+
+    @property
+    def request_description(self) -> str:
+        """Human-readable description of the configured event type."""
+
+        if self.event_type is None:
+            raise ValueError("Package request event type is not configured.")
+        return self.event_type.replace("_", " ").lower()
+
+
+class PackageDeletionRequestHandlerConfig(PackageRequestHandlerConfig):
+    event_type = Event.DELETE
+    pending_status = Package.DEL_REQ
+    approved_status = Package.DELETED
+    reject_message = _("Request rejected, package still stored.")
+    execution_success_message = _("Package deleted successfully.")
+    execution_fail_message = _("Package was not deleted from disk correctly")
+
+    def execution_logic(self, package: Package) -> tuple[bool, StrOrPromise]:
+        success, error = package.delete_from_storage()
+
+        return success, str(error) if error is not None else ""
+
+
+class PackageRecoveryRequestHandlerConfig(PackageRequestHandlerConfig):
+    event_type = Event.RECOVER
+    pending_status = Package.RECOVER_REQ
+    approved_status = Package.UPLOADED
+    reject_message = _("AIP restore rejected.")
+    execution_success_message = _("AIP restored.")
+    execution_fail_message = _("AIP restore failed")
+
+    def execution_logic(self, aip: Package) -> tuple[bool, StrOrPromise]:
+        recover_location = LocationPipeline.objects.get(
+            pipeline=aip.origin_pipeline, location__purpose=Location.AIP_RECOVERY
+        ).location
+
+        try:
+            (success, failures, message) = aip.recover_aip(
+                recover_location, os.path.basename(aip.current_path)
+            )
+        except StorageException:
+            recover_path = os.path.join(
+                recover_location.full_path, os.path.basename(aip.full_path)
+            )
+            message = _("error accessing restore files at %(path)s") % {
+                "path": recover_path
+            }
+            success = False
+
+        return (bool(success), message)
+
+
+class PackageRequestDecision(str, Enum):
+    APPROVE = "approve"
+    REJECT = "reject"
+
+    @classmethod
+    def from_value(cls, value: Any) -> "PackageRequestDecision":
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, str):
+            try:
+                return cls(value.strip().lower())
+            except ValueError as error:
+                raise ValueError(f"Unsupported decision '{value}'.") from error
+        raise ValueError(f"Unsupported decision '{value}'.")
+
+
+# Level tags are used with Django's messages framework.
+PackageRequestMessageLevel = Literal["success", "error"]
+
+
+@dataclass
+class PackageRequestMessage:
+    level: PackageRequestMessageLevel
+    content: StrOrPromise
+    detail: Optional[StrOrPromise] = None
+
+
+@dataclass
+class PackageRequestProcessingResult:
+    event: Event
+    decision: PackageRequestDecision
+    message: PackageRequestMessage
+
+
+@dataclass
+class PackageRequestSubmissionResult:
+    event: Optional[Event]
+    created: bool
+
+
+class PackageRequestValidationError(ValueError):
+    """Raised when package request input cannot be validated."""
+
+    def __init__(self, message: StrOrPromise):
+        super().__init__(str(message))
+        self.message: StrOrPromise = message
+
+
+def parse_decision_and_reason(
+    decision_value: Any,
+    reason_value: Any,
+) -> tuple[PackageRequestDecision, str]:
+    """Return a validated decision and non-empty reason string.
+
+    The decision must be one of the supported values. The reason must be a
+    non-empty string after trimming whitespace.
+    """
+
+    try:
+        decision = PackageRequestDecision.from_value(decision_value)
+    except ValueError as error:
+        raise PackageRequestValidationError(
+            _("Decision must be either '%(approve)s' or '%(reject)s'.")
+            % {
+                "approve": PackageRequestDecision.APPROVE.value,
+                "reject": PackageRequestDecision.REJECT.value,
+            }
+        ) from error
+
+    reason_required_message = _("A reason is required.")
+
+    if not isinstance(reason_value, str) or not (reason := reason_value.strip()):
+        raise PackageRequestValidationError(reason_required_message)
+
+    return decision, reason
+
+
+def submit_package_request_event(
+    config: PackageRequestHandlerConfig,
+    package: Package,
+    *,
+    request_info: Mapping[str, Any],
+) -> PackageRequestSubmissionResult:
+    """Create a pending package request event if one does not exist already."""
+
+    LOGGER.info(
+        "Package event: '%s' requested, with package status: '%s'",
+        config.event_type,
+        config.pending_status,
+    )
+    LOGGER.debug(pprint.pformat(dict(request_info)))
+
+    if config.event_type is None:
+        raise ValueError("Package request event type is not configured.")
+
+    existing_request_exists = Event.objects.filter(
+        package=package, event_type=config.event_type, status=Event.SUBMITTED
+    ).exists()
+    if existing_request_exists:
+        return PackageRequestSubmissionResult(event=None, created=False)
+
+    original_status = package.status if config.pending_status is not None else None
+
+    pipeline_value = request_info["pipeline"]
+    if isinstance(pipeline_value, Pipeline):
+        pipeline = pipeline_value
+    else:
+        pipeline = Pipeline.objects.get(uuid=pipeline_value)
+
+    request_event = Event(
+        package=package,
+        event_type=config.event_type,
+        status=Event.SUBMITTED,
+        event_reason=request_info["event_reason"],
+        pipeline=pipeline,
+        user_id=request_info["user_id"],
+        user_email=request_info["user_email"],
+        store_data=original_status,
+    )
+
+    if config.pending_status is not None:
+        package.status = config.pending_status
+        package.save(update_fields=["status"])
+
+    request_event.save()
+
+    return PackageRequestSubmissionResult(event=request_event, created=True)
+
+
+def handle_remote_result_notification(
+    config: PackageRequestHandlerConfig, event: Event, success: bool
+) -> str:
+    if config.event_type is None:
+        raise ValueError("Package request event type is not configured.")
+
+    response_message = ""
+
+    # The setting name is determined using the event type.
+    setting_prefix = f"{config.event_type.lower()}_request_notification"
+    request_notification_url = utils.get_setting(f"{setting_prefix}_url")
+
+    # If a notification is configured, attempt to send it.
+    if request_notification_url is not None:
+        headers = {"Content-type": "application/json"}
+
+        # The reported status may be approved even if the execution failed.
+        if success:
+            status_to_report = event.status
+        else:
+            if event.status == Event.REJECTED:
+                status_to_report = event.status
+            else:
+                # Report a failed approval as "APPROVE (failed)" so downstream
+                # consumers see the same status text while the event remains in
+                # SUBMIT.
+                status_to_report = f"{Event.APPROVED} (failed)"
+
+        # Serialize the payload.
+        payload = json.dumps(
+            {
+                "event_id": event.id,
+                "message": f"{status_to_report}: {event.status_reason}",
+                "success": success,
+            }
+        )
+
+        # Specify basic authentication if it is configured.
+        request_notification_auth_username = utils.get_setting(
+            f"{setting_prefix}_auth_username"
+        )
+        request_notification_auth_password = utils.get_setting(
+            f"{setting_prefix}_auth_password"
+        )
+
+        if request_notification_auth_username is not None:
+            auth = requests.auth.HTTPBasicAuth(
+                request_notification_auth_username, request_notification_auth_password
+            )
+        else:
+            auth = None
+
+        # Make the request and capture any message returned by the notification
+        # service.
+        try:
+            notification_response = requests.post(
+                request_notification_url, auth=auth, data=payload, headers=headers
+            )
+        except requests.RequestException as exc:
+            LOGGER.exception(
+                "Notification request for event %s (%s) to %s failed.",
+                event.id,
+                config.event_type,
+                request_notification_url,
+            )
+            return _("Notification request failed: %(error)s") % {"error": exc}
+
+        try:
+            response_data = json.loads(notification_response.content)
+        except ValueError:
+            return response_message
+
+        message = response_data.get("message")
+        if message:
+            response_message = str(message)
+
+    return response_message
+
+
+def process_package_request_decision(
+    config: PackageRequestHandlerConfig,
+    event: Event,
+    decision: PackageRequestDecision,
+    *,
+    reason: Optional[StrOrPromise] = None,
+    admin: Optional[Any] = None,
+) -> PackageRequestProcessingResult:
+    """Apply an approval or rejection decision to a package request event.
+
+    This helper centralizes the workflow previously embedded in the view so the
+    same business logic can be leveraged programmatically outside of Django's
+    request/response cycle.
+    """
+
+    decision_value = PackageRequestDecision.from_value(decision)
+
+    result_message: Optional[PackageRequestMessage] = None
+    execution_succeeded: Optional[bool] = None
+
+    status_reason = str(reason) if reason is not None else None
+
+    event.status_reason = status_reason
+    if admin is not None:
+        event.admin_id = admin
+
+    if decision_value is PackageRequestDecision.REJECT:
+        event.status = Event.REJECTED
+        # The request is rejected, so the package status is reset to the stored
+        # value.
+        stored_status = event.store_data
+        if stored_status is not None:
+            event.package.status = stored_status
+        notification_message = handle_remote_result_notification(config, event, False)
+        reject_message = config.reject_message
+        if notification_message:
+            reject_message = f"{reject_message} {notification_message}"
+        result_message = PackageRequestMessage(level="success", content=reject_message)
+    else:
+        execution_succeeded, err_msg = config.execution_logic(event.package)
+        if not execution_succeeded:
+            error_message = "{}: {}. {}".format(
+                config.execution_fail_message,
+                err_msg,
+                _("Please contact an administrator or see logs for details."),
+            )
+            notification_message = handle_remote_result_notification(
+                config, event, False
+            )
+            if notification_message:
+                error_message = f"{error_message} {notification_message}"
+            result_message = PackageRequestMessage(level="error", content=error_message)
+        else:
+            # The package execution succeeded, so update the status per the
+            # event configuration.
+            event.status = Event.APPROVED
+            if config.approved_status is not None:
+                event.package.status = config.approved_status
+            approval_message = _("Request approved: %(message)s") % {
+                "message": config.execution_success_message
+            }
+            detail_message: Optional[StrOrPromise] = None
+            if err_msg:
+                err_text = str(err_msg).strip()
+                if err_text:
+                    # The deletion succeeded, but the storage backend also
+                    # returned a warning (for example from LOCKSS).
+                    detail_message = err_text
+            notification_message = handle_remote_result_notification(
+                config, event, True
+            )
+            if notification_message:
+                approval_message = f"{approval_message} {notification_message}"
+            result_message = PackageRequestMessage(
+                level="success", content=approval_message, detail=detail_message
+            )
+
+    event.save()
+    event.package.save()
+
+    if result_message is None:
+        raise ValueError("Package request processing did not produce a message.")
+
+    return PackageRequestProcessingResult(
+        event=event, decision=decision_value, message=result_message
+    )

--- a/src/archivematica/storage_service/locations/views.py
+++ b/src/archivematica/storage_service/locations/views.py
@@ -1,14 +1,12 @@
 import json
 import logging
-import os
 
-import requests
-from django.contrib import auth
 from django.contrib import messages
 from django.contrib.auth.context_processors import PermWrapper
 from django.contrib.auth.decorators import permission_required
 from django.db.models import Q
 from django.forms.models import model_to_dict
+from django.http import HttpRequest
 from django.http import HttpResponse
 from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404
@@ -25,6 +23,7 @@ from archivematica.storage_service.common import gpgutils
 from archivematica.storage_service.common import utils
 from archivematica.storage_service.locations import datatable_utils
 from archivematica.storage_service.locations import forms
+from archivematica.storage_service.locations import package_request
 from archivematica.storage_service.locations.constants import PROTOCOL
 from archivematica.storage_service.locations.models import GPG
 from archivematica.storage_service.locations.models import Callback
@@ -35,7 +34,6 @@ from archivematica.storage_service.locations.models import LocationPipeline
 from archivematica.storage_service.locations.models import Package
 from archivematica.storage_service.locations.models import Pipeline
 from archivematica.storage_service.locations.models import Space
-from archivematica.storage_service.locations.models import StorageException
 
 LOGGER = logging.getLogger(__name__)
 
@@ -148,48 +146,11 @@ def fixity_logs_ajax(request):
     )
 
 
-class PackageRequestHandlerConfig:
-    event_type = ""  # Event type being handled
-    approved_status = ""  # Event status, if approved
-    reject_message = ""  # Message returned if not approved
-    execution_success_message = ""  # Message returned if execution success
-    execution_fail_message = ""  # Message returned if execution failed
-
-    def execution_logic(package):  # Logic performed on package if approved
-        pass
-
-
 @permission_required("locations.change_package", raise_exception=True)
 def aip_recover_request(request):
     """Lists existing AIP recover requests."""
 
-    def execution_logic(aip):
-        recover_location = LocationPipeline.objects.get(
-            pipeline=aip.origin_pipeline, location__purpose=Location.AIP_RECOVERY
-        ).location
-
-        try:
-            (success, failures, message) = aip.recover_aip(
-                recover_location, os.path.basename(aip.current_path)
-            )
-        except StorageException:
-            recover_path = os.path.join(
-                recover_location.full_path, os.path.basename(aip.full_path)
-            )
-            message = _("error accessing restore files at %(path)s") % {
-                "path": recover_path
-            }
-            success = False
-
-        return (success, message)
-
-    config = PackageRequestHandlerConfig()
-    config.event_type = Event.RECOVER
-    config.approved_status = Package.UPLOADED
-    config.reject_message = _("AIP restore rejected.")
-    config.execution_success_message = _("AIP restored.")
-    config.execution_fail_message = _("AIP restore failed")
-    config.execution_logic = execution_logic
+    config = package_request.PackageRecoveryRequestHandlerConfig()
 
     return _handle_package_request(request, config, "locations:aip_recover_request")
 
@@ -238,21 +199,16 @@ def package_delete(request, uuid):
 
 @permission_required("locations.approve_package_deletion", raise_exception=True)
 def package_delete_request(request):
-    def execution_logic(package):
-        return package.delete_from_storage()
-
-    config = PackageRequestHandlerConfig()
-    config.event_type = Event.DELETE
-    config.approved_status = Package.DELETED
-    config.reject_message = _("Request rejected, package still stored.")
-    config.execution_success_message = _("Package deleted successfully.")
-    config.execution_fail_message = _("Package was not deleted from disk correctly")
-    config.execution_logic = execution_logic
+    config = package_request.PackageDeletionRequestHandlerConfig()
 
     return _handle_package_request(request, config, "locations:package_delete_request")
 
 
-def _handle_package_request(request, config, view_name):
+def _handle_package_request(
+    request: HttpRequest,
+    config: package_request.PackageRequestHandlerConfig,
+    view_name: str,
+) -> HttpResponse:
     request_events = Event.objects.filter(status=Event.SUBMITTED).filter(
         event_type=config.event_type
     )
@@ -265,61 +221,40 @@ def _handle_package_request(request, config, view_name):
                 request.POST, prefix=str(req.id), instance=req
             )
             if req.form.is_valid():
-                event = req.form.save()
-                event.status_reason = req.form.cleaned_data["status_reason"]
-                event.admin_id = auth.get_user(request)
-                # Handle administrator decision and optionally notify remote REST endpoint
-                if "reject" in request.POST:
-                    event.status = Event.REJECTED
-                    # Request is rejected so the package status set back to
-                    # what it was stored as previously.
-                    event.package.status = event.store_data
-                    notification_message = (
-                        _handle_package_request_remote_result_notification(
-                            config, event, False
+                event = req.form.save(commit=False)
+                decision_value = request.POST.get("decision")
+
+                if decision_value is None:
+                    if "approve" in request.POST:
+                        decision_value = (
+                            package_request.PackageRequestDecision.APPROVE.value
                         )
-                    )
-                    if notification_message:
-                        config.reject_message += " " + notification_message
-                    messages.success(request, config.reject_message)
-                elif "approve" in request.POST:
-                    event.status = Event.APPROVED
-                    success, err_msg = config.execution_logic(event.package)
-                    if not success:
-                        error_message = "{}: {}. {}".format(
-                            config.execution_fail_message,
-                            err_msg,
-                            _(
-                                "Please contact an administrator or see logs for details."
-                            ),
+                    elif "reject" in request.POST:
+                        decision_value = (
+                            package_request.PackageRequestDecision.REJECT.value
                         )
-                        notification_message = (
-                            _handle_package_request_remote_result_notification(
-                                config, event, False
-                            )
-                        )
-                        if notification_message:
-                            error_message += " " + notification_message
-                        messages.error(request, error_message)
                     else:
-                        # Package deletion was a success so update the package
-                        # status per the event.
-                        event.package.status = config.approved_status
-                        approval_message = _("Request approved: %(message)s") % {
-                            "message": config.execution_success_message
-                        }
-                        notification_message = (
-                            _handle_package_request_remote_result_notification(
-                                config, event, True
-                            )
-                        )
-                        if notification_message:
-                            approval_message += " " + notification_message
-                        messages.success(request, approval_message)
-                        if err_msg:
-                            messages.info(request, err_msg)
-                event.save()
-                event.package.save()
+                        continue
+
+                try:
+                    decision, reason = package_request.parse_decision_and_reason(
+                        decision_value, req.form.cleaned_data["status_reason"]
+                    )
+                except package_request.PackageRequestValidationError as error:
+                    messages.error(request, str(error.message))
+                    continue
+
+                result = package_request.process_package_request_decision(
+                    config, event, decision, reason=reason, admin=request.user
+                )
+
+                message_payload = result.message
+                message_method = getattr(messages, message_payload.level, None)
+                if message_method is not None:
+                    message_method(request, message_payload.content)
+                if result.message.detail:
+                    messages.info(request, result.message.detail)
+
                 return redirect(view_name)
     else:
         for req in request_events:
@@ -330,59 +265,6 @@ def _handle_package_request(request, config, view_name):
     )
 
     return render(request, "locations/package_request.html", locals())
-
-
-def _handle_package_request_remote_result_notification(config, event, success):
-    response_message = None
-
-    # Setting name is determined using event type
-    setting_prefix = f"{config.event_type.lower()}_request_notification"
-    request_notification_url = utils.get_setting(f"{setting_prefix}_url")
-
-    # If notification is configured, attempt
-    if request_notification_url is not None:
-        headers = {"Content-type": "application/json"}
-
-        # Status reported may be approved, yet failed during execution
-        status_to_report = event.status
-        if event.status == Event.APPROVED and not success:
-            status_to_report += " (failed)"
-
-        # Serialize payload
-        payload = json.dumps(
-            {
-                "event_id": event.id,
-                "message": f"{status_to_report}: {event.status_reason}",
-                "success": success,
-            }
-        )
-
-        # Specify basic authentication, if configured
-        request_notification_auth_username = utils.get_setting(
-            f"{setting_prefix}_auth_username"
-        )
-        request_notification_auth_password = utils.get_setting(
-            f"{setting_prefix}_auth_password"
-        )
-
-        if request_notification_auth_username is not None:
-            auth = requests.auth.HTTPBasicAuth(
-                request_notification_auth_username, request_notification_auth_password
-            )
-        else:
-            auth = None
-
-        # Make request and set response message, if included in notification request response body
-        notification_response = requests.post(
-            request_notification_url, auth=auth, data=payload, headers=headers
-        )
-        try:
-            responseData = json.loads(notification_response.content)
-            response_message = responseData["message"]
-        except ValueError:
-            pass
-
-    return response_message
 
 
 @permission_required("locations.change_package", raise_exception=True)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -34,6 +34,7 @@ from django.urls import reverse
 from metsrw.plugins import premisrw
 
 from archivematica.storage_service.common import utils
+from archivematica.storage_service.locations import package_request
 from archivematica.storage_service.locations.models import Event
 from archivematica.storage_service.locations.models import Location
 from archivematica.storage_service.locations.models import Package
@@ -183,12 +184,13 @@ class Client:
             content_type="application/json",
         )
 
-    def approve_aip_deletion_request(self, event_id: int) -> HttpResponse:
-        # Not possible via API.
+    def review_aip_deletion(
+        self, file_id: uuid.UUID, data: dict[str, Union[str, int]]
+    ) -> HttpResponse:
         return self.admin_client.post(
-            reverse("locations:package_delete_request"),
-            {"approve": "Approve", f"{event_id}-status_reason": "Approved!"},
-            follow=True,
+            f"/api/v2/file/{file_id}/review_aip_deletion/",
+            json.dumps(data),
+            content_type="application/json",
         )
 
     def download_file(self, file_id: uuid.UUID) -> HttpResponse:
@@ -1240,8 +1242,10 @@ class AIPDeletionScenario(StorageScenario):
     def request_aip_deletion(self, data: dict[str, Union[str, int]]) -> HttpResponse:
         return self.client.request_aip_deletion(self.PACKAGE_UUID, data)
 
-    def approve_aip_deletion_request(self, event_id: int) -> HttpResponse:
-        return self.client.approve_aip_deletion_request(event_id)
+    def review_aip_deletion(
+        self, file_uuid: uuid.UUID, data: dict[str, Union[str, int]]
+    ) -> HttpResponse:
+        return self.client.review_aip_deletion(file_uuid, data)
 
     def delete_aip(self) -> str:
         data: dict[str, Union[str, int]] = {
@@ -1272,10 +1276,20 @@ class AIPDeletionScenario(StorageScenario):
         if self.storage_protocol not in self.OBJECT_STORAGE_PROTOCOLS:
             assert Path(package_full_path).exists()
 
-        resp = self.approve_aip_deletion_request(event.id)
+        reason = "Deleting!"
+        resp = self.review_aip_deletion(
+            self.PACKAGE_UUID,
+            {
+                "reason": reason,
+                "decision": package_request.PackageRequestDecision.APPROVE,
+                "event_id": event.id,
+            },
+        )
         assert resp.status_code == 200
-        content = resp.content.decode()
-        assert "Request approved: Package deleted successfully." in content
+        response_payload = json.loads(resp.content)
+        assert response_payload == {
+            "message": "Request approved: Package deleted successfully.",
+        }
 
         assert Event.objects.count() == 1
         assert (

--- a/tests/locations/test_api.py
+++ b/tests/locations/test_api.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 
 from archivematica.storage_service.administration import roles
 from archivematica.storage_service.locations import models
+from archivematica.storage_service.locations import package_request
 from archivematica.storage_service.locations.api.sword.views import (
     _parse_name_and_content_urls_from_mets_file,
 )
@@ -1261,7 +1262,7 @@ def test_move_request_fails_if_package_is_in_unexpected_state(
     )
 
     assert response.status_code == 400
-    assert json.loads(response.content.decode()) == {
+    assert json.loads(response.content) == {
         "error": True,
         "message": f"The file must be in an {models.Package.UPLOADED} state to be moved. Current state: {package.status}",
     }
@@ -1300,7 +1301,7 @@ def test_move_request_fails_if_target_location_does_not_exist(
     )
 
     assert response.status_code == 400
-    assert json.loads(response.content.decode()) == {
+    assert json.loads(response.content) == {
         "error": True,
         "message": f"Location UUID {location_uuid} failed to return a location",
     }
@@ -1319,7 +1320,7 @@ def test_move_request_fails_if_target_location_is_origin_location(
     )
 
     assert response.status_code == 400
-    assert json.loads(response.content.decode()) == {
+    assert json.loads(response.content) == {
         "error": True,
         "message": "New location must be different to the current location",
     }
@@ -1343,7 +1344,7 @@ def test_move_request_fails_if_target_location_purpose_does_not_match(
     )
 
     assert response.status_code == 400
-    assert json.loads(response.content.decode()) == {
+    assert json.loads(response.content) == {
         "error": True,
         "message": f"New location must have the same purpose as the current location - {package.current_location.purpose}",
     }
@@ -1366,7 +1367,7 @@ def test_move_request_fails_if_updating_package_status_fails(
     )
 
     assert response.status_code == 400
-    assert json.loads(response.content.decode()) == {
+    assert json.loads(response.content) == {
         "error": True,
         "message": f"The package must be in an {models.Package.UPLOADED} state to be moved. Current state: {package.status}",
     }
@@ -1400,3 +1401,410 @@ def test_move_request_returns_asyncronous_task_url_in_response_headers(
         "api_dispatch_detail",
         kwargs={"api_name": "v2", "resource_name": "async", "id": task_id},
     )
+
+
+@pytest.mark.django_db
+def test_review_aip_deletion_requires_permission(
+    client: Client, django_user_model: type[User], package: models.Package
+) -> None:
+    user = django_user_model.objects.create_user(
+        username="limited",
+        password="test-password",
+        email="limited@example.com",
+    )
+    client.force_login(user)
+    pipeline = models.Pipeline.objects.create(description="Pipeline")
+    event = models.Event.objects.create(
+        package=package,
+        event_type=models.Event.DELETE,
+        event_reason="Deletion requested",
+        pipeline=pipeline,
+        user_id=1,
+        user_email="requester@example.com",
+        status=models.Event.SUBMITTED,
+        store_data=package.status,
+    )
+    url = reverse(
+        "review_aip_deletion_request",
+        kwargs={"api_name": "v2", "resource_name": "file", "uuid": package.uuid},
+    )
+    data = {
+        "decision": package_request.PackageRequestDecision.APPROVE.value,
+        "reason": "ok",
+        "event_id": event.id,
+    }
+
+    resp = client.post(url, data=json.dumps(data), content_type="application/json")
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("decision", "reason", "expected_status", "expected_message", "expect_delete_call"),
+    [
+        (
+            package_request.PackageRequestDecision.APPROVE.value,
+            "Approved for deletion",
+            models.Event.APPROVED,
+            "Request approved: Package deleted successfully.",
+            True,
+        ),
+        (
+            package_request.PackageRequestDecision.REJECT.value,
+            "Not this time",
+            models.Event.REJECTED,
+            "Request rejected, package still stored.",
+            False,
+        ),
+    ],
+    ids=["approve decision removes package", "reject decision leaves package stored"],
+)
+def test_review_aip_deletion_request(
+    admin_client: Client,
+    package: models.Package,
+    decision: str,
+    reason: str,
+    expected_status: str,
+    expected_message: str,
+    expect_delete_call: bool,
+) -> None:
+    pipeline = models.Pipeline.objects.create(description="Pipeline")
+    original_package_status = package.status
+    event = models.Event.objects.create(
+        package=package,
+        event_type=models.Event.DELETE,
+        event_reason="Deletion requested",
+        pipeline=pipeline,
+        user_id=1,
+        user_email="requester@example.com",
+        status=models.Event.SUBMITTED,
+        store_data=original_package_status,
+    )
+    package.status = models.Package.DEL_REQ
+    package.save()
+    url = reverse(
+        "review_aip_deletion_request",
+        kwargs={"api_name": "v2", "resource_name": "file", "uuid": package.uuid},
+    )
+
+    with mock.patch.object(
+        models.Package, "delete_from_storage", return_value=(True, None)
+    ) as delete_from_storage:
+        resp = admin_client.post(
+            url,
+            data=json.dumps(
+                {"decision": decision, "reason": reason, "event_id": event.id}
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert json.loads(resp.content) == {"message": expected_message}
+
+        if expect_delete_call:
+            delete_from_storage.assert_called_once()
+        else:
+            delete_from_storage.assert_not_called()
+
+        event.refresh_from_db()
+        package.refresh_from_db()
+        assert event.status == expected_status
+        assert event.status_reason == reason
+
+        if expect_delete_call:
+            assert package.status == models.Package.DELETED
+        else:
+            assert package.status == original_package_status
+
+
+@pytest.mark.django_db
+def test_review_aip_deletion_request_reports_success_with_warning(
+    admin_client: Client, package: models.Package
+) -> None:
+    pipeline = models.Pipeline.objects.create(description="Pipeline")
+    original_package_status = package.status
+    event = models.Event.objects.create(
+        package=package,
+        event_type=models.Event.DELETE,
+        event_reason="Deletion requested",
+        pipeline=pipeline,
+        user_id=1,
+        user_email="requester@example.com",
+        status=models.Event.SUBMITTED,
+        store_data=original_package_status,
+    )
+    package.status = models.Package.DEL_REQ
+    package.save()
+    url = reverse(
+        "review_aip_deletion_request",
+        kwargs={"api_name": "v2", "resource_name": "file", "uuid": package.uuid},
+    )
+    data = {
+        "decision": package_request.PackageRequestDecision.APPROVE.value,
+        "reason": "Proceed with deletion",
+        "event_id": event.id,
+    }
+
+    with mock.patch.object(
+        models.Package, "delete_from_storage", return_value=(True, "LOCKSS warning")
+    ) as delete_from_storage:
+        resp = admin_client.post(
+            url, data=json.dumps(data), content_type="application/json"
+        )
+
+    assert resp.status_code == 200
+    assert json.loads(resp.content) == {
+        "message": "Request approved: Package deleted successfully.",
+        "detail": "LOCKSS warning",
+    }
+
+    delete_from_storage.assert_called_once()
+
+    event.refresh_from_db()
+    package.refresh_from_db()
+    assert event.status == models.Event.APPROVED
+    assert event.status_reason == data["reason"]
+    assert package.status == models.Package.DELETED
+
+
+@pytest.mark.django_db
+def test_review_aip_deletion_request_reports_failure(
+    admin_client: Client, package: models.Package
+) -> None:
+    pipeline = models.Pipeline.objects.create(description="Pipeline")
+    original_package_status = package.status
+    event = models.Event.objects.create(
+        package=package,
+        event_type=models.Event.DELETE,
+        event_reason="Deletion requested",
+        pipeline=pipeline,
+        user_id=1,
+        user_email="requester@example.com",
+        status=models.Event.SUBMITTED,
+        store_data=original_package_status,
+    )
+    package.status = models.Package.DEL_REQ
+    package.save()
+    url = reverse(
+        "review_aip_deletion_request",
+        kwargs={"api_name": "v2", "resource_name": "file", "uuid": package.uuid},
+    )
+    data = {
+        "decision": package_request.PackageRequestDecision.APPROVE.value,
+        "reason": "Understood. Deleting!",
+        "event_id": event.id,
+    }
+
+    with mock.patch.object(
+        models.Package, "delete_from_storage", return_value=(False, "Disk error")
+    ) as delete_from_storage:
+        resp = admin_client.post(
+            url, data=json.dumps(data), content_type="application/json"
+        )
+        assert resp.status_code == 200
+        assert json.loads(resp.content) == {
+            "error_message": "Package was not deleted from disk correctly: Disk error. Please contact an administrator or see logs for details."
+        }
+
+        delete_from_storage.assert_called_once()
+
+        # Event and package statuses remain unchanged because of the error.
+        # The reason and administrator have been recorded.
+        event.refresh_from_db()
+        package.refresh_from_db()
+        assert event.status == models.Event.SUBMITTED
+        assert package.status == models.Package.DEL_REQ
+        assert event.status_reason == data["reason"]
+        assert event.admin_id is not None
+
+
+@pytest.mark.django_db
+def test_review_aip_deletion_request_allows_retry_after_failure(
+    admin_client: Client, package: models.Package
+) -> None:
+    pipeline = models.Pipeline.objects.create(description="Pipeline")
+    original_package_status = package.status
+    event = models.Event.objects.create(
+        package=package,
+        event_type=models.Event.DELETE,
+        event_reason="Deletion requested",
+        pipeline=pipeline,
+        user_id=1,
+        user_email="requester@example.com",
+        status=models.Event.SUBMITTED,
+        store_data=original_package_status,
+    )
+    package.status = models.Package.DEL_REQ
+    package.save()
+    url = reverse(
+        "review_aip_deletion_request",
+        kwargs={"api_name": "v2", "resource_name": "file", "uuid": package.uuid},
+    )
+    data = {
+        "decision": package_request.PackageRequestDecision.APPROVE.value,
+        "reason": "Sure! Deleting...",
+        "event_id": event.id,
+    }
+
+    with mock.patch.object(
+        models.Package,
+        "delete_from_storage",
+        side_effect=[(False, "Disk error"), (True, None)],
+    ) as delete_from_storage:
+        # This is the first attempt at approving the deletion request.
+        resp = admin_client.post(
+            url, data=json.dumps(data), content_type="application/json"
+        )
+        assert resp.status_code == 200
+        assert json.loads(resp.content) == {
+            "error_message": "Package was not deleted from disk correctly: Disk error. Please contact an administrator or see logs for details."
+        }
+
+        # Event and package statuses remain unchanged because of the error.
+        # The reason and administrator have been recorded.
+        event.refresh_from_db()
+        package.refresh_from_db()
+        assert event.status == models.Event.SUBMITTED
+        assert package.status == models.Package.DEL_REQ
+        assert event.status_reason == data["reason"]
+        assert event.admin_id is not None
+
+        # Try the approval again.
+        second_response = admin_client.post(
+            url,
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+        assert second_response.status_code == 200
+        assert json.loads(second_response.content) == {
+            "message": "Request approved: Package deleted successfully.",
+        }
+
+        # The event and package statuses have been updated.
+        event.refresh_from_db()
+        package.refresh_from_db()
+        assert event.status == models.Event.APPROVED
+        assert event.status_reason == data["reason"]
+        assert package.status == models.Package.DELETED
+
+        # Ensure that the execution logic was called twice.
+        delete_from_storage.assert_called()
+        assert delete_from_storage.call_count == 2
+
+
+@pytest.mark.django_db
+def test_review_aip_deletion_request_retry_success_includes_warning(
+    admin_client: Client, package: models.Package
+) -> None:
+    pipeline = models.Pipeline.objects.create(description="Pipeline")
+    original_package_status = package.status
+    event = models.Event.objects.create(
+        package=package,
+        event_type=models.Event.DELETE,
+        event_reason="Deletion requested",
+        pipeline=pipeline,
+        user_id=1,
+        user_email="requester@example.com",
+        status=models.Event.SUBMITTED,
+        store_data=original_package_status,
+    )
+    package.status = models.Package.DEL_REQ
+    package.save()
+    url = reverse(
+        "review_aip_deletion_request",
+        kwargs={"api_name": "v2", "resource_name": "file", "uuid": package.uuid},
+    )
+    data = {
+        "decision": package_request.PackageRequestDecision.APPROVE.value,
+        "reason": "Retry deletion",
+        "event_id": event.id,
+    }
+
+    with mock.patch.object(
+        models.Package,
+        "delete_from_storage",
+        side_effect=[(False, "Disk error"), (True, "LOCKSS warning")],
+    ) as delete_from_storage:
+        # The first attempt fails.
+        resp = admin_client.post(
+            url, data=json.dumps(data), content_type="application/json"
+        )
+        assert resp.status_code == 200
+        assert json.loads(resp.content) == {
+            "error_message": "Package was not deleted from disk correctly: Disk error. Please contact an administrator or see logs for details."
+        }
+
+        event.refresh_from_db()
+        package.refresh_from_db()
+        assert event.status == models.Event.SUBMITTED
+        assert package.status == models.Package.DEL_REQ
+        assert event.status_reason == data["reason"]
+
+        # The retry succeeds and returns the warning detail.
+        second_resp = admin_client.post(
+            url, data=json.dumps(data), content_type="application/json"
+        )
+        assert second_resp.status_code == 200
+        assert json.loads(second_resp.content) == {
+            "message": "Request approved: Package deleted successfully.",
+            "detail": "LOCKSS warning",
+        }
+
+        delete_from_storage.assert_called()
+        assert delete_from_storage.call_count == 2
+
+        event.refresh_from_db()
+        package.refresh_from_db()
+        assert event.status == models.Event.APPROVED
+        assert event.status_reason == data["reason"]
+        assert package.status == models.Package.DELETED
+
+
+@pytest.mark.django_db
+def test_review_aip_deletion_request_cannot_be_reviewed_twice(
+    admin_client: Client, package: models.Package
+) -> None:
+    pipeline = models.Pipeline.objects.create(description="Pipeline")
+    original_package_status = package.status
+    event = models.Event.objects.create(
+        package=package,
+        event_type=models.Event.DELETE,
+        event_reason="Deletion requested",
+        pipeline=pipeline,
+        user_id=1,
+        user_email="requester@example.com",
+        status=models.Event.SUBMITTED,
+        store_data=original_package_status,
+    )
+    url = reverse(
+        "review_aip_deletion_request",
+        kwargs={"api_name": "v2", "resource_name": "file", "uuid": package.uuid},
+    )
+    data = {
+        "decision": package_request.PackageRequestDecision.REJECT.value,
+        "reason": "We cannot delete it. Sorry",
+        "event_id": event.id,
+    }
+
+    # The deletion request is rejected.
+    resp = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+    assert resp.status_code == 200
+    assert json.loads(resp.content) == {
+        "message": "Request rejected, package still stored."
+    }
+
+    # The event status has been updated, but the package status is unchanged.
+    event.refresh_from_db()
+    package.refresh_from_db()
+    assert event.status == models.Event.REJECTED
+    assert package.status == original_package_status
+
+    # Attempt to reject the request again.
+    resp = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+    assert resp.status_code == 400
+    assert json.loads(resp.content) == {
+        "error_message": "This request is not pending review."
+    }

--- a/tests/locations/test_replica_staging.py
+++ b/tests/locations/test_replica_staging.py
@@ -38,7 +38,7 @@ class TestOfflineReplicaStaging(TempDirMixin, TestCase):
         """Test that package in Space isn't deleted."""
         success, err = self.replica.delete_from_storage()
         assert success is False
-        assert isinstance(err, NotImplementedError)
+        assert err == "Write-Only Offline Staging does not implement deletion"
 
     def test_check_fixity(self):
         """Test that fixity check raises NotImplementedError."""


### PR DESCRIPTION
This change refactors the package request handling logic by extracting it from the views and API resources modules within the locations package into a dedicated module, enabling it to be shared across views, API endpoints, and management commands.

Additionally, it introduces a new API endpoint in the package resource that allows authorized users to approve or reject package deletion requests. Access to this endpoint is restricted by the same permission used in the “View delete requests” page of the user interface.

The API documentation has been updated in https://github.com/artefactual/archivematica-docs/pull/489

**Note**: while returning `message` on success and `error_message` on failure isn’t an ideal REST practice, this endpoint follows the convention already used by other Storage Service API endpoints to keep responses consistent.

Connected to https://github.com/archivematica/Issues/issues/1696