### PR TITLE
Fix Log out link

### DIFF
--- a/src/archivematica/storage_service/static/css/project.css
+++ b/src/archivematica/storage_service/static/css/project.css
@@ -92,3 +92,27 @@ button.link:active {
 .callback-extended-description {
   margin-bottom: 20px;
 }
+
+.nav > li > form {
+  margin: 0;
+}
+
+.nav li > form > button {
+  background: none !important;
+  border: 0;
+  color: #999;
+  cursor: pointer;
+  font: inherit;
+  padding: 10px 15px 10px;
+  text-decoration: none;
+  text-shadow: 0 -1px 0 rgba(0,0,0,0.25);
+}
+
+.nav li > form > button:hover,
+.nav li > form > button:focus {
+  color: #fff;
+}
+
+.nav li > form > button:focus {
+  outline: none;
+}

--- a/src/archivematica/storage_service/storage_service/views.py
+++ b/src/archivematica/storage_service/storage_service/views.py
@@ -72,7 +72,7 @@ class CustomOIDCLogoutView(OIDCLogoutView):
     Provide OpenID Logout capability
     """
 
-    def get(self, request):
+    def post(self, request):
         self.request = request
 
         if "oidc_id_token" in request.session:

--- a/src/archivematica/storage_service/templates/base.html
+++ b/src/archivematica/storage_service/templates/base.html
@@ -1,6 +1,7 @@
 {% load static %}
 {% load i18n %}
 {% load user %}
+{% logout_link as logout_url %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -54,7 +55,12 @@
               <li {% if '/package' in request.path %}class="active"{% endif %}><a href="{% url 'locations:package_list' %}">{% trans "Packages" %}</a></li>
               <li {% if '/administration' in request.path or '/callbacks' in request.path %}class="active"{% endif %}><a href="{% url 'administration:index' %}">{% trans "Administration" %}</a></li>
               {% if user.is_authenticated %}
-              <li><a href="{% logout_link %}">{% trans "Log out" %}</a></li>
+              <li>
+                <form method="post" action="{{ logout_url }}">
+                  {% csrf_token %}
+                  <button type="submit">{% trans "Log out" %}</button>
+                </form>
+              </li>
               {% endif %}
             </ul>
           </div><!--/.nav-collapse -->

--- a/tests/integration/test_oidc_auth.py
+++ b/tests/integration/test_oidc_auth.py
@@ -2,13 +2,14 @@ import os
 from collections.abc import Generator
 
 import pytest
+from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.models import Group
-from django.contrib.auth.models import User
 from django.urls import reverse
 from playwright.sync_api import Page
 from pytest_django.fixtures import SettingsWrapper
 from pytest_django.live_server_helper import LiveServer
 from pytest_django.plugin import DjangoDbBlocker
+from tastypie.models import ApiKey
 
 if "RUN_INTEGRATION_TESTS" not in os.environ:
     pytest.skip("Skipping integration tests", allow_module_level=True)
@@ -32,7 +33,7 @@ def recreate_user_groups(
 
 
 @pytest.fixture
-def user(django_user_model: type[User]) -> User:
+def user(django_user_model: type[AbstractUser]) -> AbstractUser:
     user = django_user_model.objects.create(
         username="foobar",
         email="foobar@example.com",
@@ -45,11 +46,16 @@ def user(django_user_model: type[User]) -> User:
     return user
 
 
+@pytest.fixture
+def user_apikey(user: AbstractUser) -> ApiKey:
+    return ApiKey.objects.create(user=user)
+
+
 @pytest.mark.django_db
 def test_oidc_backend_creates_local_user(
     page: Page,
     live_server: LiveServer,
-    django_user_model: type[User],
+    django_user_model: type[AbstractUser],
 ) -> None:
     page.goto(live_server.url)
 
@@ -85,7 +91,7 @@ def test_oidc_backend_creates_local_user(
 
 @pytest.mark.django_db
 def test_local_authentication_backend_authenticates_existing_user(
-    page: Page, live_server: LiveServer, user: User
+    page: Page, live_server: LiveServer, user: AbstractUser
 ) -> None:
     page.goto(live_server.url)
 
@@ -118,7 +124,7 @@ def test_local_authentication_backend_authenticates_existing_user(
 def test_removing_model_authentication_backend_disables_local_authentication(
     page: Page,
     live_server: LiveServer,
-    user: User,
+    user: AbstractUser,
     settings: SettingsWrapper,
 ) -> None:
     disabled_backends = ["django.contrib.auth.backends.ModelBackend"]
@@ -143,7 +149,7 @@ def test_removing_model_authentication_backend_disables_local_authentication(
 def test_setting_login_url_redirects_to_oidc_login_page(
     page: Page,
     live_server: LiveServer,
-    user: User,
+    user: AbstractUser,
     settings: SettingsWrapper,
 ) -> None:
     page.goto(live_server.url)
@@ -296,3 +302,22 @@ def test_logging_out_logs_out_user_from_secondary_provider_admin_role(
     assert page.url.startswith(
         settings.OIDC_PROVIDERS["SECONDARY"]["OIDC_OP_AUTHORIZATION_ENDPOINT"]
     )
+
+
+@pytest.mark.xfail(reason="Django 5.2 requires logout requests to be POST not GET.")
+@pytest.mark.django_db
+def test_logout_link_logs_out_user(
+    page: Page, live_server: LiveServer, user: AbstractUser, user_apikey: ApiKey
+) -> None:
+    page.goto(live_server.url)
+    assert page.url == f"{live_server.url}{reverse('login')}?next=/"
+
+    page.get_by_label("Username").fill("foobar")
+    page.get_by_label("Password").fill("foobar1A,")
+    page.get_by_text("Log in", exact=True).click()
+
+    assert page.url == f"{live_server.url}/"
+
+    page.get_by_role("link", name="Log out").click()
+
+    assert page.url == f"{live_server.url}{reverse('login')}"

--- a/tests/integration/test_oidc_auth.py
+++ b/tests/integration/test_oidc_auth.py
@@ -178,7 +178,7 @@ def test_logging_out_logs_out_user_from_both_systems(
     assert page.url == f"{live_server.url}/"
 
     # Logging out redirects the user to the login url.
-    page.get_by_role("link", name="Log out").click()
+    page.get_by_role("button", name="Log out").click()
     assert page.url == f"{live_server.url}{reverse('login')}?next=/"
 
     # Logging in through the OIDC provider requires to authenticate again.
@@ -236,7 +236,7 @@ def test_logging_out_logs_out_user_from_secondary_provider_reader_role(
     assert page.url == f"{live_server.url}/"
 
     # Logging out redirects the user to the login url.
-    page.get_by_role("link", name="Log out").click()
+    page.get_by_role("button", name="Log out").click()
     assert page.url == f"{live_server.url}{reverse('login')}?next=/"
 
     # Logging in through the OIDC provider requires to authenticate again.
@@ -291,7 +291,7 @@ def test_logging_out_logs_out_user_from_secondary_provider_admin_role(
     assert page.url == f"{live_server.url}/"
 
     # Logging out redirects the user to the login url.
-    page.get_by_role("link", name="Log out").click()
+    page.get_by_role("button", name="Log out").click()
     assert page.url == f"{live_server.url}{reverse('login')}?next=/"
 
     # Logging in through the OIDC provider requires to authenticate again.
@@ -304,7 +304,6 @@ def test_logging_out_logs_out_user_from_secondary_provider_admin_role(
     )
 
 
-@pytest.mark.xfail(reason="Django 5.2 requires logout requests to be POST not GET.")
 @pytest.mark.django_db
 def test_logout_link_logs_out_user(
     page: Page, live_server: LiveServer, user: AbstractUser, user_apikey: ApiKey
@@ -318,6 +317,6 @@ def test_logout_link_logs_out_user(
 
     assert page.url == f"{live_server.url}/"
 
-    page.get_by_role("link", name="Log out").click()
+    page.get_by_role("button", name="Log out").click()
 
     assert page.url == f"{live_server.url}{reverse('login')}"


### PR DESCRIPTION
[Django 5.0](https://docs.djangoproject.com/en/5.2/releases/5.0/#features-removed-in-5-0) requires the logout requests to be POST not GET:

> Support for logging out via `GET` requests in the `django.contrib.auth.views.LogoutView` and `django.contrib.auth.views.logout_then_login()` is removed.

This replaces the `Log out` link in the navigation bar with a form and submit button.

Connected to https://github.com/archivematica/Issues/issues/1773