### PR TITLE
Fix: Preserve related_packages when PUT omits the field

### DIFF
--- a/src/archivematica/storage_service/locations/api/resources.py
+++ b/src/archivematica/storage_service/locations/api/resources.py
@@ -1175,6 +1175,10 @@ class PackageResource(ModelResource):
         """
         bundle_detail_data = self.get_bundle_detail_data(bundle) if bundle.obj else None
         arg_detail_data = kwargs.get(self._meta.detail_uri_name, None)
+        preserve_related_packages = (
+            bundle.request.method == "PUT" and "related_packages" not in bundle.data
+        )
+        original_related_packages = None
 
         if not bundle_detail_data or (
             arg_detail_data and bundle_detail_data != arg_detail_data
@@ -1194,10 +1198,15 @@ class PackageResource(ModelResource):
                         "A model instance matching the provided arguments could not be found."
                     )
                 )
+        if preserve_related_packages and bundle.obj is not None:
+            original_related_packages = list(bundle.obj.related_packages.all())
         bundle = self.full_hydrate(bundle)
         self.authorized_update_detail(self.get_object_list(bundle.request), bundle)
         bundle = self.obj_update_hook(bundle, **kwargs)
-        return self.save(bundle, skip_errors=skip_errors)
+        bundle = self.save(bundle, skip_errors=skip_errors)
+        if original_related_packages is not None:
+            bundle.obj.related_packages.set(original_related_packages)
+        return bundle
 
     def obj_update_hook(self, bundle, **kwargs):
         """

--- a/tests/locations/test_api.py
+++ b/tests/locations/test_api.py
@@ -711,8 +711,12 @@ class TestPackageAPI(TempDirMixin, TestCase):
         assert body["files"][0]["name"] == "test_sip/objects/file.txt"
 
     def test_put_preserves_related_packages_when_omitted(self):
-        package = models.Package.objects.get(uuid="0d4e739b-bf60-4b87-bc20-67a379b28cea")
-        related = models.Package.objects.get(uuid="6aebdb24-1b6b-41ab-b4a3-df9a73726a34")
+        package = models.Package.objects.get(
+            uuid="0d4e739b-bf60-4b87-bc20-67a379b28cea"
+        )
+        related = models.Package.objects.get(
+            uuid="6aebdb24-1b6b-41ab-b4a3-df9a73726a34"
+        )
         package.related_packages.add(related)
 
         response = self.client.get(f"/api/v2/file/{package.uuid}/")
@@ -733,9 +737,7 @@ class TestPackageAPI(TempDirMixin, TestCase):
         assert response.status_code == 200
 
         package.refresh_from_db()
-        related_uuids = set(
-            package.related_packages.values_list("uuid", flat=True)
-        )
+        related_uuids = set(package.related_packages.values_list("uuid", flat=True))
         assert related.uuid in related_uuids
 
     def test_adding_package_files_returns_400_with_empty_post_body(self):

--- a/tests/locations/test_api.py
+++ b/tests/locations/test_api.py
@@ -710,6 +710,34 @@ class TestPackageAPI(TempDirMixin, TestCase):
         assert len(body["files"]) == 1
         assert body["files"][0]["name"] == "test_sip/objects/file.txt"
 
+    def test_put_preserves_related_packages_when_omitted(self):
+        package = models.Package.objects.get(uuid="0d4e739b-bf60-4b87-bc20-67a379b28cea")
+        related = models.Package.objects.get(uuid="6aebdb24-1b6b-41ab-b4a3-df9a73726a34")
+        package.related_packages.add(related)
+
+        response = self.client.get(f"/api/v2/file/{package.uuid}/")
+        assert response.status_code == 200
+        body = json.loads(response.text)
+        body.pop("related_packages", None)
+        body.pop("resource_uri", None)
+        body.pop("replicas", None)
+        body.pop("replicated_package", None)
+        body.pop("current_full_path", None)
+        body.pop("encrypted", None)
+
+        response = self.client.put(
+            f"/api/v2/file/{package.uuid}/",
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+        package.refresh_from_db()
+        related_uuids = set(
+            package.related_packages.values_list("uuid", flat=True)
+        )
+        assert related.uuid in related_uuids
+
     def test_adding_package_files_returns_400_with_empty_post_body(self):
         response = self.client.put(
             "/api/v2/file/e0a41934-c1d7-45ba-9a95-a7531c063ed1/contents/",


### PR DESCRIPTION
Related issue: https://github.com/archivematica/Issues/issues/1774

## Summary

This PR prevents AIP↔DIP relationships from being unintentionally cleared during reingest. We observed that the DIP is stored with the correct `related_package_uuid`, but a later AIP update (PUT) wipes `related_packages` because the field is omitted. The fix preserves existing relationships on PUT when `related_packages` is not included.

### What we observed (logs)

- The DIP `storeaip_v0.0` task sends `related_package_uuid` correctly.
- The Storage Service response already contains `related_packages` pointing to the AIP.
- Conclusion: the relationship exists right after DIP storage; it is lost later.

### Normal ingest flow (works)

- AIP is stored first.
- DIP is stored later and includes `related_package_uuid` (pipeline `store_aip.py`).
- Storage Service adds the relationship (`self.related_packages.add(...)`).
- No later AIP update clears the relationship.

### Reingest flow (problematic)

- Reingest runs and produces a new AIP version.
- DIP is stored and the relationship is created (confirmed in logs).
- AIP is then updated via PUT in the Storage Service:
- `PackageResource.obj_update` → `obj_update_hook` → `finish_reingest`
- The PUT payload does **not** include `related_packages`.
- Tastypie full-hydrates the object and clears missing ManyToMany fields.
- Since `related_packages` is symmetric, the DIP loses the reverse link too.

### Fix implemented

In `PackageResource.obj_update`, if the request is PUT and `related_packages` is not present, we preserve the current relationships:
- Capture `related_packages` before `full_hydrate`.
- Restore them after save, this keeps the intended PUT behavior while avoiding unintended data loss.

### Alternatives considered
- Preserve `related_packages` only during reingest (inside `finish_reingest`).
- Recreate the relationship from the pipeline after reingest completes.
- Reorder the workflow so DIP storage happens after the final AIP PUT.
