### PR TITLE
Add support for GnuPG v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN set -ex \
 		build-essential \
 		gcc \
 		gettext \
-		gnupg1 \
+		gnupg2 \
 		libffi-dev \
 		libldap2-dev \
 		libmysqlclient-dev \

--- a/src/archivematica/storage_service/administration/views.py
+++ b/src/archivematica/storage_service/administration/views.py
@@ -279,7 +279,7 @@ def key_import(request):
     armor in a form field. To get the ASCII armored private key with
     fingerprint ``fingerprint`` via Python GnuPG::
 
-        >>> gpg.export_keys(fingerprint, True)
+        >>> gpg.export_keys(fingerprint, True, expect_passphrase=False)
 
     From the shell::
 

--- a/src/archivematica/storage_service/common/gpgutils.py
+++ b/src/archivematica/storage_service/common/gpgutils.py
@@ -204,10 +204,22 @@ class GPGBinaryPathError(Exception):
     """Raised when the GnuPG binary could not be found in the system path."""
 
 
+def get_gpg_binary_path() -> str:
+    """Find and return the path of the preferred GnuPG binary."""
+    for item in GPG.PREFERRED_GNUPG_BINARIES:
+        ret = which(item)
+        if ret is not None:
+            return ret
+    raise GPGBinaryPathError(
+        "GnuPG binary not found in the system path."
+        " Preferred binary names: %s" % GPG.PREFERRED_GNUPG_BINARIES
+    )
+
+
 class GPG:
-    # List of binaries in order of preference. In distros like Ubuntu 18.04,
-    # GnuPG v1 is only available via ``gpg1`` (package ``gnupg1``).
-    PREFERRED_GNUPG_BINARIES = ["gpg1", "gpg"]
+    # List of binaries in order of preference. In newer distros, GnuPG v2 is
+    # provided by ``gpg`` (package ``gnupg2``), with ``gpg2`` as an alternative.
+    PREFERRED_GNUPG_BINARIES = ["gpg", "gpg2", "gpg1"]
 
     def __init__(self) -> None:
         self._gpg: GPGClient | None = None
@@ -231,15 +243,7 @@ class GPG:
         return gnupg_home_path
 
     def _get_gnupg_bin_path(self) -> str:
-        """Find and return the path of the preferred GnuPG binary."""
-        for item in self.PREFERRED_GNUPG_BINARIES:
-            ret = which(item)
-            if ret is not None:
-                return ret
-        raise GPGBinaryPathError(
-            "GnuPG binary not found in the system path."
-            " Preferred binary names: %s" % self.PREFERRED_GNUPG_BINARIES
-        )
+        return get_gpg_binary_path()
 
     @staticmethod
     def _ensure_gnupg_home_exists(gnupghome: str) -> None:
@@ -248,6 +252,63 @@ class GPG:
 
 
 gpg = GPG()
+
+
+_PASSPHRASE_STATUS_VALUES = {
+    "bad passphrase",
+    "missing passphrase",
+    "need passphrase",
+    "need passphrase pin",
+    "need symmetric passphrase",
+}
+
+_PASSPHRASE_STDERR_TOKENS = {
+    "BAD_PASSPHRASE",
+    "MISSING_PASSPHRASE",
+    "NEED_PASSPHRASE",
+    "NEED_PASSPHRASE_PIN",
+    "NEED_PASSPHRASE_SYM",
+}
+
+
+def _gpg_key_input_params(
+    *,
+    name_real: str,
+    name_email: str | None,
+    passphrase: str,
+) -> dict[str, str | int | bool]:
+    params: dict[str, str | int | bool] = {
+        "key_type": DFLT_KEY_TYPE,
+        "key_length": DFLT_KEY_LENGTH,
+        "name_real": name_real,
+    }
+    if name_email:
+        params["name_email"] = name_email
+    if passphrase:
+        params["passphrase"] = passphrase
+    else:
+        # GnuPG >= 2.1 requires explicit %no-protection for unprotected keys.
+        params["no_protection"] = True
+    return params
+
+
+def _decrypt_requires_passphrase(result: GPGCryptResult) -> bool:
+    status = (result.status or "").strip().lower()
+    if status in _PASSPHRASE_STATUS_VALUES:
+        return True
+    stderr = result.stderr.upper()
+    return _stderr_indicates_passphrase(stderr)
+
+
+def _stderr_indicates_passphrase(stderr: str) -> bool:
+    if _pinentry_requires_passphrase(stderr):
+        return True
+    return any(token in stderr for token in _PASSPHRASE_STDERR_TOKENS)
+
+
+def _pinentry_requires_passphrase(stderr: str) -> bool:
+    # Headless GnuPG can fail when it tries to prompt for a passphrase.
+    return "PINENTRY_LAUNCHED" in stderr and "INAPPROPRIATE IOCTL FOR DEVICE" in stderr
 
 
 def get_gpg_key(fingerprint: str) -> GPGKeyDict | None:
@@ -293,10 +354,11 @@ def generate_default_gpg_key() -> None:
     correctly configured, then GPG may take a long time to generate keys.
     """
     input_data = gpg().gen_key_input(
-        key_type=DFLT_KEY_TYPE,
-        key_length=DFLT_KEY_LENGTH,
-        name_real=DFLT_KEY_REAL_NAME,
-        passphrase=DFLT_KEY_PASSPHRASE,
+        **_gpg_key_input_params(
+            name_real=DFLT_KEY_REAL_NAME,
+            name_email=None,
+            passphrase=DFLT_KEY_PASSPHRASE,
+        )
     )
     LOGGER.info("Creating default AM SS key with name %s", DFLT_KEY_REAL_NAME)
     gpg().gen_key(input_data)
@@ -306,11 +368,11 @@ def generate_default_gpg_key() -> None:
 def generate_gpg_key(name_real: str, name_email: str) -> GPGKey:
     """Generate a GPG key."""
     input_data = gpg().gen_key_input(
-        key_type=DFLT_KEY_TYPE,
-        key_length=DFLT_KEY_LENGTH,
-        name_real=name_real,
-        name_email=name_email,
-        passphrase=DFLT_KEY_PASSPHRASE,
+        **_gpg_key_input_params(
+            name_real=name_real,
+            name_email=name_email,
+            passphrase=DFLT_KEY_PASSPHRASE,
+        )
     )
     key: GPGKey = gpg().gen_key(input_data)
     return key
@@ -358,26 +420,26 @@ def encryption_works(fingerprint: str) -> str:
     LOGGER.info("decrypt stderr: %s", decrypted_data.stderr)
     if decrypted_data.ok:
         return ENCR_WORKS
-    else:
-        # python-gnupg stopped reporting "need passphrase".
-        if (
-            decrypted_data.status == "need passphrase"
-            or "NEED_PASSPHRASE" in decrypted_data.stderr
-        ):
-            return PASSPHRASED
-        return ENCR_FAILS
+    if _decrypt_requires_passphrase(decrypted_data):
+        return PASSPHRASED
+    return ENCR_FAILS
 
 
 def export_gpg_key(fingerprint: str) -> tuple[str, str]:
     """Return the ASCII armor (string) representation of the private and public
     keys with fingerprint ``fingerprint``.
     """
-    return gpg().export_keys(fingerprint), gpg().export_keys(fingerprint, True)
+    return (
+        gpg().export_keys(fingerprint),
+        gpg().export_keys(fingerprint, secret=True, expect_passphrase=False),
+    )
 
 
 def delete_gpg_key(fingerprint: str) -> bool:
     """Delete the GPG key with fingerprint ``fingerprint``."""
-    result: GPGDeleteResult = gpg().delete_keys(fingerprint, True)
+    result: GPGDeleteResult = gpg().delete_keys(
+        fingerprint, secret=True, expect_passphrase=False
+    )
     try:
         assert str(result) == "ok"
         return True

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -16,6 +16,7 @@ import os
 import re
 import shutil
 import tarfile
+import tempfile
 import uuid
 from collections.abc import Iterable
 from collections.abc import Iterator
@@ -1478,10 +1479,10 @@ def _create_admin_gpg_key(
 
 
 def _generate_private_key_armor(
-    tmp_path: Path, *, passphrase: str | None, gpg_binary_path: str
+    tmp_dir: str, *, passphrase: str | None, gpg_binary_path: str
 ) -> tuple[str, str]:
-    source_home = tmp_path / f"gnupg-source-{uuid.uuid4().hex}"
-    source_home.mkdir(parents=True, exist_ok=True)
+    source_home = Path(tmp_dir)
+    source_home.chmod(0o700)
     gpg_source = gnupg.GPG(gnupghome=str(source_home), gpgbinary=gpg_binary_path)
     key_input = gpg_source.gen_key_input(
         key_type="RSA",
@@ -1537,13 +1538,13 @@ def test_admin_key_lifecycle(
 @pytest.mark.django_db
 def test_admin_key_imports_unpassphrased_key(
     admin_client: DjangoTestClient,
-    tmp_path: Path,
     gnupg_home: Path,
     gpg_binary_path: str,
 ) -> None:
-    fingerprint, private_armor = _generate_private_key_armor(
-        tmp_path, passphrase=None, gpg_binary_path=gpg_binary_path
-    )
+    with tempfile.TemporaryDirectory(dir="/tmp", prefix="gnupg-fixture-") as tmp_dir:
+        fingerprint, private_armor = _generate_private_key_armor(
+            tmp_dir, passphrase=None, gpg_binary_path=gpg_binary_path
+        )
     resp = admin_client.post(
         reverse("administration:key_import"),
         data={"ascii_armor": private_armor},
@@ -1563,13 +1564,13 @@ def test_admin_key_imports_unpassphrased_key(
 @pytest.mark.django_db
 def test_admin_key_import_rejects_passphrased_key(
     admin_client: DjangoTestClient,
-    tmp_path: Path,
     gnupg_home: Path,
     gpg_binary_path: str,
 ) -> None:
-    fingerprint, private_armor = _generate_private_key_armor(
-        tmp_path, passphrase="secret", gpg_binary_path=gpg_binary_path
-    )
+    with tempfile.TemporaryDirectory(dir="/tmp", prefix="gnupg-fixture-") as tmp_dir:
+        fingerprint, private_armor = _generate_private_key_armor(
+            tmp_dir, passphrase="secret", gpg_binary_path=gpg_binary_path
+        )
     resp = admin_client.post(
         reverse("administration:key_import"),
         data={"ascii_armor": private_armor},

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1405,6 +1405,8 @@ def test_aip_deletion(
 def gnupg_home(tmp_path: Path, settings: SettingsWrapper) -> Iterator[Path]:
     home = tmp_path / "gnupg"
     home.mkdir(parents=True, exist_ok=True)
+    # GnuPG expects 0700 on the homedir.
+    home.chmod(0o700)
     original_gnupg_home = settings.GNUPG_HOME_PATH
     # Reset the singleton to ensure GNUPG_HOME_PATH isolation for this test.
     original_gpg_client = gpgutils.gpg._gpg
@@ -1416,8 +1418,10 @@ def gnupg_home(tmp_path: Path, settings: SettingsWrapper) -> Iterator[Path]:
 
 
 @pytest.fixture(scope="session")
-def require_gpg() -> None:
-    if not shutil.which("gpg"):
+def gpg_binary_path() -> str:
+    try:
+        return gpgutils.get_gpg_binary_path()
+    except gpgutils.GPGBinaryPathError:
         pytest.skip("GnuPG not available")
 
 
@@ -1455,14 +1459,6 @@ class GPGStorageScenario(StorageScenario):
 _KEY_DETAIL_RE = re.compile(r"/keys/(?P<fingerprint>[^/]+)/detail")
 
 
-def _get_gpg_binary_path() -> str:
-    for candidate in ("gpg1", "gpg"):
-        path = shutil.which(candidate)
-        if path:
-            return path
-    raise RuntimeError("GnuPG binary not found in PATH.")
-
-
 def _extract_key_fingerprint(location: str) -> str:
     match = _KEY_DETAIL_RE.search(location)
     if not match:
@@ -1482,18 +1478,18 @@ def _create_admin_gpg_key(
 
 
 def _generate_private_key_armor(
-    tmp_path: Path, *, passphrase: str | None
+    tmp_path: Path, *, passphrase: str | None, gpg_binary_path: str
 ) -> tuple[str, str]:
-    gpg_binary = _get_gpg_binary_path()
     source_home = tmp_path / f"gnupg-source-{uuid.uuid4().hex}"
     source_home.mkdir(parents=True, exist_ok=True)
-    gpg_source = gnupg.GPG(gnupghome=str(source_home), gpgbinary=gpg_binary)
+    gpg_source = gnupg.GPG(gnupghome=str(source_home), gpgbinary=gpg_binary_path)
     key_input = gpg_source.gen_key_input(
         key_type="RSA",
         key_length=2048,
         name_real="Import Test Key",
         name_email="import-test@example.com",
         passphrase=passphrase or "",
+        no_protection=True,
     )
     key = gpg_source.gen_key(key_input)
     assert key
@@ -1507,7 +1503,7 @@ def test_admin_key_lifecycle(
     admin_client: DjangoTestClient,
     gnupg_home: Path,
     monkeypatch: pytest.MonkeyPatch,
-    require_gpg: None,
+    gpg_binary_path: str,
 ) -> None:
     # Reduce default key length to avoid slow key generation in low-entropy CI.
     monkeypatch.setattr(gpgutils, "DFLT_KEY_LENGTH", 2048)
@@ -1543,9 +1539,11 @@ def test_admin_key_imports_unpassphrased_key(
     admin_client: DjangoTestClient,
     tmp_path: Path,
     gnupg_home: Path,
-    require_gpg: None,
+    gpg_binary_path: str,
 ) -> None:
-    fingerprint, private_armor = _generate_private_key_armor(tmp_path, passphrase=None)
+    fingerprint, private_armor = _generate_private_key_armor(
+        tmp_path, passphrase=None, gpg_binary_path=gpg_binary_path
+    )
     resp = admin_client.post(
         reverse("administration:key_import"),
         data={"ascii_armor": private_armor},
@@ -1567,10 +1565,10 @@ def test_admin_key_import_rejects_passphrased_key(
     admin_client: DjangoTestClient,
     tmp_path: Path,
     gnupg_home: Path,
-    require_gpg: None,
+    gpg_binary_path: str,
 ) -> None:
     fingerprint, private_armor = _generate_private_key_armor(
-        tmp_path, passphrase="secret"
+        tmp_path, passphrase="secret", gpg_binary_path=gpg_binary_path
     )
     resp = admin_client.post(
         reverse("administration:key_import"),
@@ -1595,7 +1593,7 @@ def test_gpg_space_encrypts_and_decrypts_aip(
     working_directory_path: Path,
     tmp_path: Path,
     gnupg_home: Path,
-    require_gpg: None,
+    gpg_binary_path: str,
 ) -> None:
     fingerprint = _create_admin_gpg_key(
         admin_client,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1490,11 +1490,16 @@ def _generate_private_key_armor(
         name_real="Import Test Key",
         name_email="import-test@example.com",
         passphrase=passphrase or "",
-        no_protection=True,
+        no_protection=not passphrase,
     )
     key = gpg_source.gen_key(key_input)
     assert key
-    private_armor = gpg_source.export_keys(key.fingerprint, True)
+    export_kwargs: dict[str, bool | str] = {"secret": True}
+    if passphrase is None:
+        export_kwargs["expect_passphrase"] = False
+    else:
+        export_kwargs["passphrase"] = passphrase
+    private_armor = gpg_source.export_keys(key.fingerprint, **export_kwargs)
     assert "BEGIN PGP PRIVATE KEY BLOCK" in private_armor
     return key.fingerprint, private_armor
 


### PR DESCRIPTION
The [python-gnupg](https://docs.red-dove.com/python-gnupg/) dependency already supports both GnuPG versions, but
v2 requires explicit parameters for key generation, export, and
deletion. This change updates the `gpgutils.py` module to pass those
parameters so behavior stays consistent under GnuPG v2.

Connected to https://github.com/archivematica/Issues/issues/1781