### PR TITLE
Check rclone container existence more efficiently

### DIFF
--- a/src/archivematica/storage_service/locations/models/rclone.py
+++ b/src/archivematica/storage_service/locations/models/rclone.py
@@ -119,17 +119,25 @@ class RClone(models.Model):
         raise StorageException("rclone remote matching %s not found", self.remote_name)
 
     def _ensure_container_exists(self):
-        """Ensure that the S3 bucket or other container exists by asking it
-        something about itself. If we cannot retrieve metadata about it then
-        we attempt to create the bucket, else, we raise a StorageException.
+        """Ensure that the S3 bucket or other container exists by creating it if it doesn't.
+        If the creation attempt fails, we raise a StorageException.
         """
         LOGGER.debug("Test that container '%s' exists", self.container)
-        prefixed_container_name = f"{self.remote_prefix}{self.container}"
-        cmd = ["ls", prefixed_container_name]
+        remote_name = f"{self.remote_prefix}"
+        cmd = ["lsf", "--dirs-only", remote_name]
         try:
-            self._execute_rclone_subcommand(cmd)
+            containers_list = self._execute_rclone_subcommand(cmd).split("\n")
+            container_exists = False
+            for container in containers_list:
+                if container.rstrip("/") == self.container:
+                    container_exists = True
+            if not container_exists:
+                raise StorageException(
+                    "rclone container matching %s not found", self.container
+                )
         except StorageException:
             LOGGER.info("Creating container '%s'", self.container)
+            prefixed_container_name = f"{self.remote_prefix}{self.container}"
             create_container_cmd = ["mkdir", prefixed_container_name]
             try:
                 self._execute_rclone_subcommand(create_container_cmd)

--- a/tests/locations/test_rclone.py
+++ b/tests/locations/test_rclone.py
@@ -163,7 +163,9 @@ def test_rclone_ensure_container_exists(
     else:
         with pytest.raises(models.StorageException):
             rclone_space._ensure_container_exists()
-            subprocess.assert_called_with(["mkdir", "testremote:testcontainer"])
+
+    args, _ = subprocess.Popen.call_args
+    assert args[0] == ["rclone", "mkdir", "testremote:testcontainer"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In the rclone model's _ensure_container_exists method, rclone ls is used to check whether a container exists on an rclone remote. If not, rclone mkdir is used to create it. rclone ls is recursive by default, however, so this call can take minutes if the container is large. This commit replaces the rclone ls call with rclone lsf --dirs-only, which lists only root level directories and therefore runs much faster.