### PR TITLE
Add variable to toggle transfer threading in S3 space

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -223,6 +223,14 @@ of these settings or provide values to mandatory fields.
   - **Type:** `integer`
   - **Default:** `900`
 
+- **`SS_S3_USE_THREADS`**:
+  - **Description:** enable boto3 S3 managed transfer threads for uploads and
+    downloads. Set to `false` if your environment has constrained CPU/memory,
+    unstable networking, backend throttling, or S3-compatible endpoints that
+    behave poorly under concurrent transfers.
+  - **Type:** `boolean`
+  - **Default:** `true`
+
 The configuration of the database is also declared via environment variables.
 Storage Service looks up the `SS_DB_URL` environment string. If defined, its
 value is expected to follow the form described in the [dj-database-url docs],

--- a/src/archivematica/storage_service/locations/models/s3.py
+++ b/src/archivematica/storage_service/locations/models/s3.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 import boto3
 import botocore
+from boto3.s3.transfer import TransferConfig
 from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -90,6 +91,12 @@ class S3(models.Model):
 
     def _is_global_endpoint(self, url):
         return urlparse(url).netloc == "s3.amazonaws.com"
+
+    @property
+    def transfer_config(self):
+        if not hasattr(self, "_transfer_config"):
+            self._transfer_config = TransferConfig(use_threads=settings.S3_USE_THREADS)
+        return self._transfer_config
 
     @boto_exception
     def _ensure_bucket_exists(self):
@@ -222,7 +229,9 @@ class S3(models.Model):
             dest_file = objectSummary.key.replace(src_path, dest_path, 1)
             self.space.create_local_directory(dest_file)
             if not os.path.isdir(dest_file):
-                bucket.download_file(objectSummary.key, dest_file)
+                bucket.download_file(
+                    objectSummary.key, dest_file, Config=self.transfer_config
+                )
 
     def move_from_storage_service(self, src_path, dest_path, package=None):
         self._ensure_bucket_exists()
@@ -262,4 +271,6 @@ class S3(models.Model):
             extra_args["ContentType"] = mtype
 
         with open(data, "rb") as d:
-            bucket.upload_fileobj(d, path, ExtraArgs=extra_args)
+            bucket.upload_fileobj(
+                d, path, ExtraArgs=extra_args, Config=self.transfer_config
+            )

--- a/src/archivematica/storage_service/storage_service/settings/components/s3.py
+++ b/src/archivematica/storage_service/storage_service/settings/components/s3.py
@@ -7,6 +7,8 @@ from os import environ
 
 from django.core.exceptions import ImproperlyConfigured
 
+from archivematica.storage_service.common.helpers import is_true
+
 # Read and connect timeouts for S3. Ideally these will match the
 # defaults recommended by your S3 implementation.
 S3_TIMEOUTS = 900
@@ -15,3 +17,6 @@ try:
 except ValueError:
     err_msg = "S3 timeout value configured incorrectly in the environment - please check the 'S3_TIMEOUTS' variable"
     raise ImproperlyConfigured(err_msg)
+
+# Enable/disable managed transfer threading for boto3 S3 transfers.
+S3_USE_THREADS = is_true(environ.get("SS_S3_USE_THREADS", "true"))

--- a/tests/locations/test_api.py
+++ b/tests/locations/test_api.py
@@ -1141,7 +1141,7 @@ def compressed_bag_fixture_path():
 def s3_resource(compressed_bag_fixture_path, aip_storage_location):
     """Mock the S3 bucket interactions in S3.move_to_storage_service."""
 
-    def download_file(_key, dest_file):
+    def download_file(_key, dest_file, Config=None):
         shutil.copy(compressed_bag_fixture_path, dest_file)
 
     return mock.Mock(

--- a/tests/locations/test_s3.py
+++ b/tests/locations/test_s3.py
@@ -1,7 +1,9 @@
+from pathlib import Path
 from unittest import mock
 
 import botocore
 import pytest
+from pytest_django.fixtures import SettingsWrapper
 
 from archivematica.storage_service.locations import models
 
@@ -344,3 +346,73 @@ def test_delete_path_deletes_package(resource, s3_space, caplog):
         "S3 response when attempting to delete:",
         "{'success': True}",
     ]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("use_threads", [True, False])
+def test_transfer_config_uses_settings_value(
+    s3_space: models.S3,
+    settings: SettingsWrapper,
+    use_threads: bool,
+) -> None:
+    settings.S3_USE_THREADS = use_threads
+
+    assert s3_space.transfer_config.use_threads is use_threads
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("use_threads", [True, False])
+def test_upload_object_passes_transfer_config_to_boto3(
+    s3_space: models.S3,
+    settings: SettingsWrapper,
+    tmp_path: Path,
+    use_threads: bool,
+) -> None:
+    settings.S3_USE_THREADS = use_threads
+    payload = tmp_path / "payload.txt"
+    payload.write_text("hello")
+    bucket = mock.Mock()
+
+    s3_space.upload_object(bucket, "aips/payload.txt", str(payload))
+
+    upload_fileobj = bucket.upload_fileobj
+    upload_fileobj.assert_called_once()
+    config = upload_fileobj.call_args.kwargs["Config"]
+
+    assert config is s3_space.transfer_config
+    assert config.use_threads is use_threads
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("use_threads", [True, False])
+@mock.patch("boto3.resource")
+def test_move_to_storage_service_passes_transfer_config_to_boto3(
+    resource: mock.Mock,
+    s3_space: models.S3,
+    settings: SettingsWrapper,
+    tmp_path: Path,
+    use_threads: bool,
+) -> None:
+    resource.return_value = mock.Mock(
+        **{
+            "meta.client.get_bucket_location.return_value": {
+                "LocationConstraint": "us-east-1",
+                "ResponseMetadata": {},
+            },
+            "Bucket.return_value.objects.filter.return_value": [
+                mock.Mock(key="aips/payload.txt")
+            ],
+        }
+    )
+
+    settings.S3_USE_THREADS = use_threads
+    destination = tmp_path / "downloads"
+
+    s3_space.move_to_storage_service("/aips", str(destination), None)
+
+    download_file = resource.return_value.Bucket.return_value.download_file
+    download_file.assert_called_once()
+    config = download_file.call_args.kwargs["Config"]
+
+    assert config is s3_space.transfer_config
+    assert config.use_threads is use_threads


### PR DESCRIPTION
This makes boto3 threading configurable via an application-specific environment variable that allows operators to disable managed transfer threads when concurrency causes instability, throttling, or resource pressure in constrained deployments and S3-compatible backends.