### PR TITLE
Fix clipboard-field flaky tests

### DIFF
--- a/src/archivematica/storage_service/frontend/lib/core/features/clipboard-field/index.spec.ts
+++ b/src/archivematica/storage_service/frontend/lib/core/features/clipboard-field/index.spec.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AmClipboardFieldElement, defineAmClipboardField } from './index'
 
-vi.mock('@/shared/i18n', () => ({
-  initI18n: vi.fn().mockResolvedValue(undefined),
-}))
-
 vi.mock('@/shared/i18n/plain', () => ({
   translate: (value: string) =>
     (

--- a/src/archivematica/storage_service/frontend/lib/core/features/clipboard-field/init.spec.ts
+++ b/src/archivematica/storage_service/frontend/lib/core/features/clipboard-field/init.spec.ts
@@ -22,10 +22,18 @@ const createDeferred = (): Deferred => {
   return { promise, resolve, reject }
 }
 
-const mockTranslateModule = (): void => {
-  vi.doMock('@/shared/i18n/plain', () => ({
-    translate: (value: string) =>
-      LABELS[value as keyof typeof LABELS] ?? value,
+const mockI18nModule = (
+  initI18n: () => Promise<void>,
+  isLocaleReady: () => boolean = () => true,
+): void => {
+  vi.doMock('@/shared/i18n', () => ({
+    i18n: {
+      global: {
+        te: (key: string) => isLocaleReady() && key in LABELS,
+        t: (key: string) => LABELS[key as keyof typeof LABELS] ?? key,
+      },
+    },
+    initI18n,
   }))
 }
 
@@ -38,15 +46,13 @@ describe('clipboard-field init', () => {
 
   afterEach(() => {
     vi.doUnmock('@/shared/i18n')
-    vi.doUnmock('@/shared/i18n/plain')
   })
 
   it('defines the element even if i18n init rejects', async () => {
     const initI18n = vi.fn().mockRejectedValue(new Error('boom'))
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 
-    vi.doMock('@/shared/i18n', () => ({ initI18n }))
-    mockTranslateModule()
+    mockI18nModule(initI18n)
 
     const defineSpy = vi.spyOn(customElements, 'define').mockImplementation(() => undefined)
     vi.spyOn(customElements, 'get').mockReturnValue(undefined)
@@ -68,24 +74,17 @@ describe('clipboard-field init', () => {
     const deferred = createDeferred()
     let localeReady = false
 
-    vi.doMock('@/shared/i18n', () => ({
-      initI18n: vi.fn(async () => {
+    mockI18nModule(
+      vi.fn(async () => {
         await deferred.promise
         localeReady = true
       }),
-    }))
-
-    vi.doMock('@/shared/i18n/plain', () => ({
-      translate: (value: string) => {
-        if (!localeReady) return value
-        return LABELS[value as keyof typeof LABELS] ?? value
-      },
-    }))
+      () => localeReady,
+    )
 
     const { init } = await import('./index')
     const initPromise = init()
 
-    await Promise.resolve()
     expect(customElements.get('am-clipboard-field')).toBeUndefined()
 
     deferred.resolve()


### PR DESCRIPTION
This change removes the unsafe split mocking between @/shared/i18n and @/shared/i18n/plain in the clipboard-field tests and replaces it with a single coherent i18n mock where needed.

It also drops an unnecessary i18n mock from the element-behavior spec and uses the deferred initI18n() promise itself as the synchronization point.

For context see this run https://github.com/artefactual/archivematica-storage-service/actions/runs/23053934500/job/66962053757

<details>
<summary>job log</summary>

```
2026-03-13T13:51:04.4899534Z Current runner version: '2.332.0'
2026-03-13T13:51:04.4926880Z ##[group]Runner Image Provisioner
2026-03-13T13:51:04.4927875Z Hosted Compute Agent
2026-03-13T13:51:04.4928418Z Version: 20260213.493
2026-03-13T13:51:04.4929017Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
2026-03-13T13:51:04.4929772Z Build Date: 2026-02-13T00:28:41Z
2026-03-13T13:51:04.4930478Z Worker ID: {738cbf06-ad40-4c32-94dc-6025b5366a83}
2026-03-13T13:51:04.4931140Z Azure Region: westus
2026-03-13T13:51:04.4931762Z ##[endgroup]
2026-03-13T13:51:04.4933183Z ##[group]Operating System
2026-03-13T13:51:04.4933815Z Ubuntu
2026-03-13T13:51:04.4934333Z 24.04.3
2026-03-13T13:51:04.4934880Z LTS
2026-03-13T13:51:04.4935366Z ##[endgroup]
2026-03-13T13:51:04.4935889Z ##[group]Runner Image
2026-03-13T13:51:04.4936487Z Image: ubuntu-24.04
2026-03-13T13:51:04.4937169Z Version: 20260309.50.1
2026-03-13T13:51:04.4938553Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260309.50/images/ubuntu/Ubuntu2404-Readme.md
2026-03-13T13:51:04.4940060Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260309.50
2026-03-13T13:51:04.4941052Z ##[endgroup]
2026-03-13T13:51:04.4943615Z ##[group]GITHUB_TOKEN Permissions
2026-03-13T13:51:04.4945748Z Actions: write
2026-03-13T13:51:04.4946354Z ArtifactMetadata: write
2026-03-13T13:51:04.4947119Z Attestations: write
2026-03-13T13:51:04.4947601Z Checks: write
2026-03-13T13:51:04.4948203Z Contents: write
2026-03-13T13:51:04.4948689Z Deployments: write
2026-03-13T13:51:04.4949212Z Discussions: write
2026-03-13T13:51:04.4949834Z Issues: write
2026-03-13T13:51:04.4950352Z Metadata: read
2026-03-13T13:51:04.4950855Z Models: read
2026-03-13T13:51:04.4951411Z Packages: write
2026-03-13T13:51:04.4951929Z Pages: write
2026-03-13T13:51:04.4952508Z PullRequests: write
2026-03-13T13:51:04.4953215Z RepositoryProjects: write
2026-03-13T13:51:04.4953774Z SecurityEvents: write
2026-03-13T13:51:04.4954330Z Statuses: write
2026-03-13T13:51:04.4955375Z ##[endgroup]
2026-03-13T13:51:04.4958206Z Secret source: Actions
2026-03-13T13:51:04.4959212Z Prepare workflow directory
2026-03-13T13:51:04.5422127Z Prepare all required actions
2026-03-13T13:51:04.5467392Z Getting action download info
2026-03-13T13:51:05.0054372Z Download action repository 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' (SHA:de0fac2e4500dabe0009e67214ff5f5447ce83dd)
2026-03-13T13:51:05.1749535Z Download action repository 'actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f' (SHA:53b83947a5a98c8d113130e565377fae1a50d02f)
2026-03-13T13:51:05.9825994Z Complete job name: Test frontend
2026-03-13T13:51:06.0753901Z ##[group]Run actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
2026-03-13T13:51:06.0755764Z with:
2026-03-13T13:51:06.0756941Z   repository: artefactual/archivematica-storage-service
2026-03-13T13:51:06.0758515Z   token: ***
2026-03-13T13:51:06.0759202Z   ssh-strict: true
2026-03-13T13:51:06.0759931Z   ssh-user: git
2026-03-13T13:51:06.0760670Z   persist-credentials: true
2026-03-13T13:51:06.0761539Z   clean: true
2026-03-13T13:51:06.0762274Z   sparse-checkout-cone-mode: true
2026-03-13T13:51:06.0763189Z   fetch-depth: 1
2026-03-13T13:51:06.0763907Z   fetch-tags: false
2026-03-13T13:51:06.0764656Z   show-progress: true
2026-03-13T13:51:06.0765407Z   lfs: false
2026-03-13T13:51:06.0766109Z   submodules: false
2026-03-13T13:51:06.0767004Z   set-safe-directory: true
2026-03-13T13:51:06.0768138Z ##[endgroup]
2026-03-13T13:51:06.1813186Z Syncing repository: artefactual/archivematica-storage-service
2026-03-13T13:51:06.1816047Z ##[group]Getting Git version info
2026-03-13T13:51:06.1818357Z Working directory is '/home/runner/work/archivematica-storage-service/archivematica-storage-service'
2026-03-13T13:51:06.1820837Z [command]/usr/bin/git version
2026-03-13T13:51:06.2054698Z git version 2.53.0
2026-03-13T13:51:06.2081156Z ##[endgroup]
2026-03-13T13:51:06.2097440Z Temporarily overriding HOME='/home/runner/work/_temp/dc3113d5-973f-414e-b60c-b5f2234745db' before making global git config changes
2026-03-13T13:51:06.2101108Z Adding repository directory to the temporary git global config as a safe directory
2026-03-13T13:51:06.2104386Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/archivematica-storage-service/archivematica-storage-service
2026-03-13T13:51:06.2152231Z Deleting the contents of '/home/runner/work/archivematica-storage-service/archivematica-storage-service'
2026-03-13T13:51:06.2155363Z ##[group]Initializing the repository
2026-03-13T13:51:06.2161402Z [command]/usr/bin/git init /home/runner/work/archivematica-storage-service/archivematica-storage-service
2026-03-13T13:51:06.2330418Z hint: Using 'master' as the name for the initial branch. This default branch name
2026-03-13T13:51:06.2334227Z hint: will change to "main" in Git 3.0. To configure the initial branch name
2026-03-13T13:51:06.2337528Z hint: to use in all of your new repositories, which will suppress this warning,
2026-03-13T13:51:06.2339741Z hint: call:
2026-03-13T13:51:06.2340596Z hint:
2026-03-13T13:51:06.2341784Z hint: 	git config --global init.defaultBranch <name>
2026-03-13T13:51:06.2343248Z hint:
2026-03-13T13:51:06.2345240Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
2026-03-13T13:51:06.2347299Z hint: 'development'. The just-created branch can be renamed via this command:
2026-03-13T13:51:06.2348675Z hint:
2026-03-13T13:51:06.2349321Z hint: 	git branch -m <name>
2026-03-13T13:51:06.2350104Z hint:
2026-03-13T13:51:06.2351175Z hint: Disable this message with "git config set advice.defaultBranchName false"
2026-03-13T13:51:06.2353894Z Initialized empty Git repository in /home/runner/work/archivematica-storage-service/archivematica-storage-service/.git/
2026-03-13T13:51:06.2358040Z [command]/usr/bin/git remote add origin https://github.com/artefactual/archivematica-storage-service
2026-03-13T13:51:06.2392193Z ##[endgroup]
2026-03-13T13:51:06.2394271Z ##[group]Disabling automatic garbage collection
2026-03-13T13:51:06.2396360Z [command]/usr/bin/git config --local gc.auto 0
2026-03-13T13:51:06.2432085Z ##[endgroup]
2026-03-13T13:51:06.2434299Z ##[group]Setting up auth
2026-03-13T13:51:06.2435821Z Removing SSH command configuration
2026-03-13T13:51:06.2441507Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2026-03-13T13:51:06.2480757Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2026-03-13T13:51:06.3026384Z Removing HTTP extra header
2026-03-13T13:51:06.3034191Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2026-03-13T13:51:06.3071943Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2026-03-13T13:51:06.3318077Z Removing includeIf entries pointing to credentials config files
2026-03-13T13:51:06.3324097Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
2026-03-13T13:51:06.3360099Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
2026-03-13T13:51:06.3668823Z [command]/usr/bin/git config --file /home/runner/work/_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
2026-03-13T13:51:06.3678707Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/archivematica-storage-service/archivematica-storage-service/.git.path /home/runner/work/_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:06.3711140Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/archivematica-storage-service/archivematica-storage-service/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:06.3752283Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:06.3792271Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:06.3823182Z ##[endgroup]
2026-03-13T13:51:06.3824451Z ##[group]Fetching the repository
2026-03-13T13:51:06.3833844Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +c7f32b1c3e22830b298219418ebf2dcb15dbe3c6:refs/remotes/origin/qa/0.x
2026-03-13T13:51:06.9519976Z From https://github.com/artefactual/archivematica-storage-service
2026-03-13T13:51:06.9523478Z  * [new ref]         c7f32b1c3e22830b298219418ebf2dcb15dbe3c6 -> origin/qa/0.x
2026-03-13T13:51:06.9563088Z [command]/usr/bin/git branch --list --remote origin/qa/0.x
2026-03-13T13:51:06.9590283Z   origin/qa/0.x
2026-03-13T13:51:06.9599887Z [command]/usr/bin/git rev-parse refs/remotes/origin/qa/0.x
2026-03-13T13:51:06.9631703Z c7f32b1c3e22830b298219418ebf2dcb15dbe3c6
2026-03-13T13:51:06.9637168Z ##[endgroup]
2026-03-13T13:51:06.9638844Z ##[group]Determining the checkout info
2026-03-13T13:51:06.9640296Z ##[endgroup]
2026-03-13T13:51:06.9642614Z [command]/usr/bin/git sparse-checkout disable
2026-03-13T13:51:06.9687452Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
2026-03-13T13:51:06.9717083Z ##[group]Checking out the ref
2026-03-13T13:51:06.9720509Z [command]/usr/bin/git checkout --progress --force -B qa/0.x refs/remotes/origin/qa/0.x
2026-03-13T13:51:07.0091193Z Switched to a new branch 'qa/0.x'
2026-03-13T13:51:07.0093393Z branch 'qa/0.x' set up to track 'origin/qa/0.x'.
2026-03-13T13:51:07.0101238Z ##[endgroup]
2026-03-13T13:51:07.0151171Z [command]/usr/bin/git log -1 --format=%H
2026-03-13T13:51:07.0179751Z c7f32b1c3e22830b298219418ebf2dcb15dbe3c6
2026-03-13T13:51:07.0503668Z ##[group]Run actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
2026-03-13T13:51:07.0505214Z with:
2026-03-13T13:51:07.0505987Z   node-version: 24
2026-03-13T13:51:07.0506927Z   cache: npm
2026-03-13T13:51:07.0508317Z   cache-dependency-path: src/archivematica/storage_service/frontend/package-lock.json

2026-03-13T13:51:07.0510011Z   check-latest: false
2026-03-13T13:51:07.0511140Z   token: ***
2026-03-13T13:51:07.0511970Z   package-manager-cache: true
2026-03-13T13:51:07.0512926Z ##[endgroup]
2026-03-13T13:51:07.2408957Z Found in cache @ /opt/hostedtoolcache/node/24.14.0/x64
2026-03-13T13:51:07.2412823Z ##[group]Environment details
2026-03-13T13:51:09.5934805Z node: v24.14.0
2026-03-13T13:51:09.5935530Z npm: 11.9.0
2026-03-13T13:51:09.5935954Z yarn: 1.22.22
2026-03-13T13:51:09.5937935Z ##[endgroup]
2026-03-13T13:51:09.5959862Z [command]/opt/hostedtoolcache/node/24.14.0/x64/bin/npm config get cache
2026-03-13T13:51:09.8848983Z /home/runner/.npm
2026-03-13T13:51:10.1559767Z npm cache is not found
2026-03-13T13:51:10.1707689Z ##[group]Run npm clean-install
2026-03-13T13:51:10.1708065Z [36;1mnpm clean-install[0m
2026-03-13T13:51:10.1772758Z shell: /usr/bin/bash -e {0}
2026-03-13T13:51:10.1773069Z ##[endgroup]
2026-03-13T13:51:13.7795682Z npm warn gitignore-fallback No .npmignore file found, using .gitignore for file exclusion. Consider creating a .npmignore file to explicitly control published files.
2026-03-13T13:51:14.8478223Z npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
2026-03-13T13:51:16.8498290Z 
2026-03-13T13:51:16.8499006Z > storage-service-frontend@0.0.0 prepare
2026-03-13T13:51:16.8499671Z > npm run build
2026-03-13T13:51:16.8499879Z 
2026-03-13T13:51:16.9576854Z 
2026-03-13T13:51:16.9577747Z > storage-service-frontend@0.0.0 build
2026-03-13T13:51:16.9578725Z > run-p type-check "build-only {@}" --
2026-03-13T13:51:16.9579436Z 
2026-03-13T13:51:17.1243384Z 
2026-03-13T13:51:17.1244698Z > storage-service-frontend@0.0.0 type-check
2026-03-13T13:51:17.1260376Z > vue-tsc --build
2026-03-13T13:51:17.1260984Z 
2026-03-13T13:51:17.1261375Z 
2026-03-13T13:51:17.1261990Z > storage-service-frontend@0.0.0 build-only
2026-03-13T13:51:17.1262766Z > vite build
2026-03-13T13:51:17.1263206Z 
2026-03-13T13:51:17.5976228Z [36mvite v8.0.0 [32mbuilding client environment for production...[36m[39m
2026-03-13T13:51:17.6722299Z [2K
2026-03-13T13:51:18.4098339Z transforming...✓ 661 modules transformed.
2026-03-13T13:51:18.4538473Z rendering chunks...
2026-03-13T13:51:18.6029286Z computing gzip size...
2026-03-13T13:51:18.6478825Z dist/manifest.json                                        5.94 kB │ gzip:   0.97 kB
2026-03-13T13:51:18.6481708Z dist/storage-service-frontend.css                     1,505.53 kB │ gzip: 690.02 kB
2026-03-13T13:51:18.6484545Z dist/_plugin-vue_export-helper-BGPkDkcu.js                0.16 kB │ gzip:   0.15 kB
2026-03-13T13:51:18.6490980Z dist/plain-Cv5odNRG.js                                    0.28 kB │ gzip:   0.22 kB
2026-03-13T13:51:18.6498410Z dist/core-feature-location-replicators-D1mqnwYA.js        0.45 kB │ gzip:   0.29 kB
2026-03-13T13:51:18.6499800Z dist/core-feature-space-protocol-QS45JDwF.js              0.87 kB │ gzip:   0.51 kB
2026-03-13T13:51:18.6501037Z dist/rolldown-runtime-CYMK-g2i.js                         0.91 kB │ gzip:   0.51 kB
2026-03-13T13:51:18.6502192Z dist/locale-sv-B4FlGTmA.js                                1.49 kB │ gzip:   0.73 kB
2026-03-13T13:51:18.6503285Z dist/locale-no-SQxxUv-M.js                                1.49 kB │ gzip:   0.71 kB
2026-03-13T13:51:18.6504331Z dist/en-CghTo7OT.js                                       1.52 kB │ gzip:   0.72 kB
2026-03-13T13:51:18.6505509Z dist/core-feature-package-request-delete-BzRWxEAv.js      1.53 kB │ gzip:   0.83 kB
2026-03-13T13:51:18.6507018Z dist/core.js                                              1.55 kB │ gzip:   0.74 kB
2026-03-13T13:51:18.6508225Z dist/locale-es-DGJmMgxR.js                                1.57 kB │ gzip:   0.74 kB
2026-03-13T13:51:18.6509634Z dist/locale-pt-XcHW8yd_.js                                1.59 kB │ gzip:   0.75 kB
2026-03-13T13:51:18.6510693Z dist/locale-pt-br-DYaVaETC.js                             1.59 kB │ gzip:   0.76 kB
2026-03-13T13:51:18.6511916Z dist/locale-fr-CQasTmUj.js                                1.62 kB │ gzip:   0.79 kB
2026-03-13T13:51:18.6512856Z dist/locale-ja-Cg6ntgQz.js                                1.67 kB │ gzip:   0.91 kB
2026-03-13T13:51:18.6514095Z dist/core-feature-nav-collapse-Dd55kDoU.js                1.80 kB │ gzip:   0.80 kB
2026-03-13T13:51:18.6515243Z dist/i18n-1qHvaiSC.js                                     1.95 kB │ gzip:   0.97 kB
2026-03-13T13:51:18.6516114Z dist/core-feature-callback-headers-lKGZnq26.js            2.45 kB │ gzip:   1.00 kB
2026-03-13T13:51:18.6551052Z dist/client-1Ry_RQXB.js                                   2.68 kB │ gzip:   1.28 kB
2026-03-13T13:51:18.6552367Z dist/core-feature-modal-BEviwfZ6.js                       3.24 kB │ gzip:   1.33 kB
2026-03-13T13:51:18.6553666Z dist/core-feature-clipboard-field-DKk3XgeF.js             5.03 kB │ gzip:   1.61 kB
2026-03-13T13:51:18.6554913Z dist/location-directory-picker.js                        10.21 kB │ gzip:   3.79 kB
2026-03-13T13:51:18.6556057Z dist/treeview-DSwiAxIv.js                                39.24 kB │ gzip:  11.17 kB
2026-03-13T13:51:18.6557326Z dist/tables.js                                           86.10 kB │ gzip:  21.32 kB
2026-03-13T13:51:18.6558361Z dist/runtime-DDXs_VgZ.js                                222.62 kB │ gzip:  69.20 kB
2026-03-13T13:51:18.6558843Z 
2026-03-13T13:51:18.6559109Z [32m✓ built in 1.05s[39m
2026-03-13T13:51:22.8739739Z 
2026-03-13T13:51:22.8742813Z added 333 packages, and audited 334 packages in 13s
2026-03-13T13:51:22.8745425Z 
2026-03-13T13:51:22.8745906Z 93 packages are looking for funding
2026-03-13T13:51:22.8746508Z   run `npm fund` for details
2026-03-13T13:51:22.8758042Z 
2026-03-13T13:51:22.8758619Z found 0 vulnerabilities
2026-03-13T13:51:22.9558554Z ##[group]Run npm run check
2026-03-13T13:51:22.9558836Z [36;1mnpm run check[0m
2026-03-13T13:51:22.9608477Z shell: /usr/bin/bash -e {0}
2026-03-13T13:51:22.9608732Z ##[endgroup]
2026-03-13T13:51:23.0646893Z 
2026-03-13T13:51:23.0647511Z > storage-service-frontend@0.0.0 check
2026-03-13T13:51:23.0648150Z > run-s lint type-check test build-only
2026-03-13T13:51:23.0648372Z 
2026-03-13T13:51:23.2303288Z 
2026-03-13T13:51:23.2306158Z > storage-service-frontend@0.0.0 lint
2026-03-13T13:51:23.2308988Z > eslint . --fix
2026-03-13T13:51:23.2310680Z 
2026-03-13T13:51:26.6006103Z 
2026-03-13T13:51:26.6007160Z > storage-service-frontend@0.0.0 type-check
2026-03-13T13:51:26.6007863Z > vue-tsc --build
2026-03-13T13:51:26.6008092Z 
2026-03-13T13:51:31.7660813Z 
2026-03-13T13:51:31.7661479Z > storage-service-frontend@0.0.0 test
2026-03-13T13:51:31.7662064Z > vitest run
2026-03-13T13:51:31.7662276Z 
2026-03-13T13:51:32.1654755Z 
2026-03-13T13:51:32.1659433Z [1m[46m RUN [49m[22m [36mv4.1.0 [39m[90m/home/runner/work/archivematica-storage-service/archivematica-storage-service/src/archivematica/storage_service/frontend[39m
2026-03-13T13:51:32.1660697Z 
2026-03-13T13:51:33.5073802Z  [32m✓[39m lib/location-directory-picker/locationFormModal.spec.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 103[2mms[22m[39m
2026-03-13T13:51:34.3845827Z  [32m✓[39m lib/tables/App.spec.ts [2m([22m[2m10 tests[22m[2m)[22m[33m 437[2mms[22m[39m
2026-03-13T13:51:34.5773964Z  [32m✓[39m lib/core/features/nav-collapse/index.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 68[2mms[22m[39m
2026-03-13T13:51:34.6022880Z  [32m✓[39m lib/shared/components/TreeView.spec.ts [2m([22m[2m19 tests[22m[2m)[22m[33m 378[2mms[22m[39m
2026-03-13T13:51:35.5695578Z  [32m✓[39m lib/shared/components/TreeNode.spec.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 116[2mms[22m[39m
2026-03-13T13:51:35.6478804Z  [32m✓[39m lib/core/features/clipboard-field/index.spec.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 103[2mms[22m[39m
2026-03-13T13:51:36.3889159Z  [32m✓[39m lib/location-directory-picker/App.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 100[2mms[22m[39m
2026-03-13T13:51:36.6095184Z  [32m✓[39m lib/shared/http/client.spec.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 25[2mms[22m[39m
2026-03-13T13:51:36.6990879Z  [32m✓[39m lib/tables/composables/useServerDatatable.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 43[2mms[22m[39m
2026-03-13T13:51:37.6212456Z  [32m✓[39m lib/core/features/package-request-delete/index.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 159[2mms[22m[39m
2026-03-13T13:51:37.7508039Z  [32m✓[39m lib/core/features/callback-headers/index.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 95[2mms[22m[39m
2026-03-13T13:51:37.7614305Z  [32m✓[39m lib/location-directory-picker/index.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 88[2mms[22m[39m
2026-03-13T13:51:38.7138801Z  [32m✓[39m lib/core/features/modal/index.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 74[2mms[22m[39m
2026-03-13T13:51:38.7399154Z  [31m❯[39m lib/core/features/clipboard-field/init.spec.ts [2m([22m[2m2 tests[22m[2m | [22m[31m1 failed[39m[2m)[22m[32m 56[2mms[22m[39m
2026-03-13T13:51:38.7480457Z      [32m✓[39m defines the element even if i18n init rejects[32m 20[2mms[22m[39m
2026-03-13T13:51:38.7481782Z [31m     [31m×[31m waits for i18n before defining and renders translated labels[39m[32m 34[2mms[22m[39m
2026-03-13T13:51:38.7728267Z  [32m✓[39m lib/tables/serverRowTransformers.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
2026-03-13T13:51:39.7436127Z  [32m✓[39m lib/core/features/space-protocol/index.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 87[2mms[22m[39m
2026-03-13T13:51:39.7760913Z  [32m✓[39m lib/core/features/location-replicators/index.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 42[2mms[22m[39m
2026-03-13T13:51:39.7936136Z  [32m✓[39m lib/tables/composables/useTableSearch.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 14[2mms[22m[39m
2026-03-13T13:51:40.6076438Z  [32m✓[39m lib/tables/utils/useDatatablesCompat.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
2026-03-13T13:51:40.8222184Z  [32m✓[39m lib/shared/http/space.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 9[2mms[22m[39m
2026-03-13T13:51:40.8336204Z  [32m✓[39m lib/shared/components/treeNodeKeys.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 8[2mms[22m[39m
2026-03-13T13:51:41.5910209Z  [32m✓[39m lib/location-directory-picker/utils/path.spec.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 9[2mms[22m[39m
2026-03-13T13:51:41.7136912Z  [32m✓[39m lib/shared/encoding/base64.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
2026-03-13T13:51:41.7850703Z  [32m✓[39m lib/location-directory-picker/composables/useSpaceBrowser.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
2026-03-13T13:51:41.7880485Z 
2026-03-13T13:51:41.7881569Z [31m⎯⎯⎯⎯⎯⎯⎯[39m[1m[41m Failed Tests 1 [49m[22m[31m⎯⎯⎯⎯⎯⎯⎯[39m
2026-03-13T13:51:41.7882068Z 
2026-03-13T13:51:41.7884358Z [41m[1m FAIL [22m[49m lib/core/features/clipboard-field/init.spec.ts[2m > [22mclipboard-field init[2m > [22mwaits for i18n before defining and renders translated labels
2026-03-13T13:51:41.7892863Z [31m[1mAssertionError[22m: expected undefined to be 'Copy' // Object.is equality[39m
2026-03-13T13:51:41.7893510Z 
2026-03-13T13:51:41.7893818Z [32m- Expected:[39m
2026-03-13T13:51:41.7894195Z "Copy"
2026-03-13T13:51:41.7894373Z 
2026-03-13T13:51:41.7894623Z [31m+ Received:[39m
2026-03-13T13:51:41.7894964Z undefined
2026-03-13T13:51:41.7895140Z 
2026-03-13T13:51:41.7895884Z [36m [2m❯[22m lib/core/features/clipboard-field/init.spec.ts:[2m98:48[22m[39m
2026-03-13T13:51:41.7928392Z     [90m 96|[39m     document.body.innerHTML = '<am-clipboard-field value="secret-key">…
2026-03-13T13:51:41.7930165Z     [90m 97|[39m     [35mconst[39m button [33m=[39m document[33m.[39m[34mquerySelector[39m([32m'button'[39m)
2026-03-13T13:51:41.7931939Z     [90m 98|[39m     [34mexpect[39m(button[33m?.[39m[34mgetAttribute[39m([32m'aria-label'[39m))[33m.[39m[34mtoBe[39m([32m'Copy'[39m)
2026-03-13T13:51:41.7933277Z     [90m   |[39m                                                [31m^[39m
2026-03-13T13:51:41.7934272Z     [90m 99|[39m     expect(button?.getAttribute('aria-label')).not.toBe('clipboardFiel…
2026-03-13T13:51:41.7934998Z     [90m100|[39m   })
2026-03-13T13:51:41.7935212Z 
2026-03-13T13:51:41.7935626Z [31m[2m⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯[22m[39m
2026-03-13T13:51:41.7935956Z 
2026-03-13T13:51:41.7936462Z [31m⎯⎯⎯⎯⎯⎯[39m[1m[41m Unhandled Errors [49m[22m[31m⎯⎯⎯⎯⎯⎯[39m
2026-03-13T13:51:41.7937263Z [31m[1m
2026-03-13T13:51:41.7937778Z Vitest caught 1 unhandled error during the test run.
2026-03-13T13:51:41.7939197Z This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.[22m[39m
2026-03-13T13:51:41.7940032Z 
2026-03-13T13:51:41.7940605Z [31m⎯⎯⎯⎯⎯[39m[1m[41m Uncaught Exception [49m[22m[31m⎯⎯⎯⎯⎯[39m
2026-03-13T13:51:41.7942046Z [31m[1mError[22m: [vitest] No "i18n" export is defined on the "@/shared/i18n" mock. Did you forget to return it from "vi.mock"?
2026-03-13T13:51:41.7943275Z If you need to partially mock a module, you can use "importOriginal" helper inside:
2026-03-13T13:51:41.7943687Z [39m
2026-03-13T13:51:41.7944003Z vi.mock(import("@/shared/i18n"), async (importOriginal) => {
2026-03-13T13:51:41.7944356Z   const actual = await importOriginal()
2026-03-13T13:51:41.7944602Z   return {
2026-03-13T13:51:41.7944765Z     ...actual,
2026-03-13T13:51:41.7945070Z     // your mocked methods
2026-03-13T13:51:41.7945460Z   }
2026-03-13T13:51:41.7945746Z })
2026-03-13T13:51:41.7945915Z 
2026-03-13T13:51:41.7947345Z [90m [2m❯[22m VitestMocker.createError node_modules/vitest/dist/chunks/startVitestModuleRunner.C3ZR-4J3.js:[2m62:17[22m[39m
2026-03-13T13:51:41.7950095Z [90m [2m❯[22m Object.get node_modules/vitest/dist/chunks/startVitestModuleRunner.C3ZR-4J3.js:[2m310:16[22m[39m
2026-03-13T13:51:41.7950923Z [36m [2m❯[22m translate lib/shared/i18n/plain.ts:[2m21:7[22m[39m
2026-03-13T13:51:41.7951531Z     [90m 19|[39m // - Falls back to a simple interpolated string when the key is missin…
2026-03-13T13:51:41.7952499Z     [90m 20|[39m [35mexport[39m [35mconst[39m translate [33m=[39m (key[33m:[39m string[33m,[39m params[33m?[39m[33m:[39m [33mParams[39m)[33m:[39m string [33m=>[39m {
2026-03-13T13:51:41.7953405Z     [90m 21|[39m   [35mif[39m (i18n[33m.[39mglobal[33m.[39m[34mte[39m(key)) {
2026-03-13T13:51:41.7954193Z     [90m   |[39m       [31m^[39m
2026-03-13T13:51:41.7954948Z     [90m 22|[39m     [35mconst[39m translated [33m=[39m i18n[33m.[39mglobal[33m.[39m[34mt[39m(key[33m,[39m params [33m??[39m {}) [35mas[39m string
2026-03-13T13:51:41.7955591Z     [90m 23|[39m     [35mreturn[39m translated
2026-03-13T13:51:41.7956194Z [90m [2m❯[22m getLabels lib/core/features/clipboard-field/index.ts:[2m15:9[22m[39m
2026-03-13T13:51:41.7957294Z [90m [2m❯[22m AmClipboardFieldElement.render lib/core/features/clipboard-field/index.ts:[2m67:20[22m[39m
2026-03-13T13:51:41.7958251Z [90m [2m❯[22m AmClipboardFieldElement.connectedCallback lib/core/features/clipboard-field/index.ts:[2m38:12[22m[39m
2026-03-13T13:51:41.7959938Z [90m [2m❯[22m AmClipboardFieldElement.invokeTheCallbackFunction node_modules/jsdom/lib/generated/idl/Function.js:[2m19:26[22m[39m
2026-03-13T13:51:41.7961956Z [90m [2m❯[22m invokeCEReactions node_modules/jsdom/lib/jsdom/living/helpers/custom-elements.js:[2m190:31[22m[39m
2026-03-13T13:51:41.7963808Z [90m [2m❯[22m ceReactionsPostSteps node_modules/jsdom/lib/jsdom/living/helpers/custom-elements.js:[2m54:3[22m[39m
2026-03-13T13:51:41.7964879Z [90m [2m❯[22m HTMLBodyElement.set innerHTML [as innerHTML] node_modules/jsdom/lib/generated/idl/Element.js:[2m1542:9[22m[39m
2026-03-13T13:51:41.7965345Z 
2026-03-13T13:51:41.7966213Z [31mThis error originated in "[1mlib/core/features/clipboard-field/init.spec.ts[22m" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.[39m
2026-03-13T13:51:41.7968811Z [31mThe latest test that might've caused the error is "[1mwaits for i18n before defining and renders translated labels[22m". It might mean one of the following:
2026-03-13T13:51:41.7969654Z - The error was thrown, while Vitest was running this test.
2026-03-13T13:51:41.7970418Z - If the error occurred after the test had been completed, this was the last documented test before it was thrown.[39m
2026-03-13T13:51:41.7971024Z [31m⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[39m
2026-03-13T13:51:41.7971199Z 
2026-03-13T13:51:41.7971250Z 
2026-03-13T13:51:41.7971899Z [2m Test Files [22m [1m[31m1 failed[39m[22m[2m | [22m[1m[32m23 passed[39m[22m[90m (24)[39m
2026-03-13T13:51:41.7973318Z [2m      Tests [22m [1m[31m1 failed[39m[22m[2m | [22m[1m[32m129 passed[39m[22m[90m (130)[39m
2026-03-13T13:51:41.7973877Z [2m     Errors [22m [1m[31m1 error[39m[22m
2026-03-13T13:51:41.7974222Z [2m   Start at [22m 13:51:32
2026-03-13T13:51:41.7974852Z [2m   Duration [22m 9.61s[2m (transform 1.10s, setup 0ms, import 3.90s, tests 2.03s, environment 17.91s)[22m
2026-03-13T13:51:41.7975218Z 
2026-03-13T13:51:41.7984438Z 
2026-03-13T13:51:41.8022172Z ##[error]Error: [vitest] No "i18n" export is defined on the "@/shared/i18n" mock. Did you forget to return it from "vi.mock"?
If you need to partially mock a module, you can use "importOriginal" helper inside:

vi.mock(import("@/shared/i18n"), async (importOriginal) => {
  const actual = await importOriginal()
  return {
    ...actual,
    // your mocked methods
  }
})

 ❯ translate lib/shared/i18n/plain.ts:21:7
 ❯ getLabels lib/core/features/clipboard-field/index.ts:15:9
 ❯ AmClipboardFieldElement.render lib/core/features/clipboard-field/index.ts:67:20
 ❯ AmClipboardFieldElement.connectedCallback lib/core/features/clipboard-field/index.ts:38:12
 ❯ AmClipboardFieldElement.invokeTheCallbackFunction node_modules/jsdom/lib/generated/idl/Function.js:19:26
 ❯ invokeCEReactions node_modules/jsdom/lib/jsdom/living/helpers/custom-elements.js:190:31
 ❯ ceReactionsPostSteps node_modules/jsdom/lib/jsdom/living/helpers/custom-elements.js:54:3
 ❯ HTMLBodyElement.set innerHTML [as innerHTML] node_modules/jsdom/lib/generated/idl/Element.js:1542:9

This error originated in "lib/core/features/clipboard-field/init.spec.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
The latest test that might've caused the error is "waits for i18n before defining and renders translated labels". It might mean one of the following:
- The error was thrown, while Vitest was running this test.
- If the error occurred after the test had been completed, this was the last documented test before it was thrown.

2026-03-13T13:51:41.8041905Z 
2026-03-13T13:51:41.8045767Z ##[error]AssertionError: expected undefined to be 'Copy' // Object.is equality

- Expected:
"Copy"

+ Received:
undefined

 ❯ lib/core/features/clipboard-field/init.spec.ts:98:48


2026-03-13T13:51:41.8491477Z ERROR: "test" exited with 1.
2026-03-13T13:51:41.8612276Z ##[error]Process completed with exit code 1.
2026-03-13T13:51:41.8725649Z Post job cleanup.
2026-03-13T13:51:41.9549512Z [command]/usr/bin/git version
2026-03-13T13:51:41.9587908Z git version 2.53.0
2026-03-13T13:51:41.9660402Z Temporarily overriding HOME='/home/runner/work/_temp/d0e0a898-027d-4c18-ac5e-9e39b838aefd' before making global git config changes
2026-03-13T13:51:41.9661751Z Adding repository directory to the temporary git global config as a safe directory
2026-03-13T13:51:41.9666764Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/archivematica-storage-service/archivematica-storage-service
2026-03-13T13:51:41.9701881Z Removing SSH command configuration
2026-03-13T13:51:41.9709434Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2026-03-13T13:51:41.9745811Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2026-03-13T13:51:42.0001610Z Removing HTTP extra header
2026-03-13T13:51:42.0003625Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2026-03-13T13:51:42.0045541Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2026-03-13T13:51:42.0313478Z Removing includeIf entries pointing to credentials config files
2026-03-13T13:51:42.0319564Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
2026-03-13T13:51:42.0351611Z includeif.gitdir:/home/runner/work/archivematica-storage-service/archivematica-storage-service/.git.path
2026-03-13T13:51:42.0353664Z includeif.gitdir:/home/runner/work/archivematica-storage-service/archivematica-storage-service/.git/worktrees/*.path
2026-03-13T13:51:42.0356342Z includeif.gitdir:/github/workspace/.git.path
2026-03-13T13:51:42.0357363Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
2026-03-13T13:51:42.0364308Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/archivematica-storage-service/archivematica-storage-service/.git.path
2026-03-13T13:51:42.0390988Z /home/runner/work/_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:42.0404515Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/archivematica-storage-service/archivematica-storage-service/.git.path /home/runner/work/_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:42.0448047Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/archivematica-storage-service/archivematica-storage-service/.git/worktrees/*.path
2026-03-13T13:51:42.0477357Z /home/runner/work/_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:42.0487879Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/archivematica-storage-service/archivematica-storage-service/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:42.0527076Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
2026-03-13T13:51:42.0554188Z /github/runner_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:42.0563509Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:42.0601040Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
2026-03-13T13:51:42.0627906Z /github/runner_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:42.0639627Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config
2026-03-13T13:51:42.0680132Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
2026-03-13T13:51:42.0952038Z Removing credentials config '/home/runner/work/_temp/git-credentials-b19e8d37-27e2-401e-be81-ec3f133fab2d.config'
2026-03-13T13:51:42.1105896Z Cleaning up orphan processes
```
</details>