### PR TITLE
Preserve API key on blank pipeline form submission

### DIFF
--- a/src/archivematica/storage_service/locations/api/resources.py
+++ b/src/archivematica/storage_service/locations/api/resources.py
@@ -250,6 +250,10 @@ class PipelineResource(ModelResource):
         return bundle
 
     def obj_create(self, bundle, **kwargs):
+        if bundle.data.get("api_key") is None:
+            # Normalize omitted/null API keys to the canonical empty string so
+            # API and form-created pipelines behave the same way.
+            bundle.data["api_key"] = ""
         bundle = super().obj_create(bundle, **kwargs)
         bundle.obj.enabled = not utils.get_setting("pipelines_disabled", False)
         create_default_locations = bundle.data.get("create_default_locations", False)

--- a/src/archivematica/storage_service/locations/forms.py
+++ b/src/archivematica/storage_service/locations/forms.py
@@ -74,11 +74,20 @@ class PipelineForm(forms.ModelForm):
             "enabled",
         )
 
+    def clean_api_key(self):
+        api_key = self.cleaned_data["api_key"]
+        if self.instance.pk and api_key == "":
+            # PasswordInput does not render the stored key on edit, so a blank
+            # submission means "leave the existing value alone" rather than
+            # "clear it".
+            return self.instance.api_key
+        return api_key
+
     def save(self, *args, **kwargs):
-        if not self.cleaned_data["api_key"]:
-            # If the API key was not provided, remove it from the cleaned data
-            # to avoid overwriting its existing stored value.
-            del self.cleaned_data["api_key"]
+        if not self.instance.pk and self.instance.api_key is None:
+            # Normalize create-time empty API keys to the canonical empty string
+            # so form and API-created pipelines behave the same way.
+            self.instance.api_key = ""
         return super().save(*args, **kwargs)
 
 

--- a/tests/locations/test_api.py
+++ b/tests/locations/test_api.py
@@ -1098,6 +1098,23 @@ class TestPipelineAPI(TestCase):
             "http://192.168.0.10"
         )
 
+    def test_pipeline_create_without_api_key_stores_empty_string(self):
+        pipeline_uuid = str(uuid.uuid4())
+        data = {
+            "uuid": pipeline_uuid,
+            "description": "My pipeline without api key",
+            "remote_name": "https://archivematica-dashboard:8080",
+            "api_username": "test",
+        }
+
+        response = self.client.post(
+            "/api/v2/pipeline/", data=json.dumps(data), content_type="application/json"
+        )
+        assert response.status_code == 201
+
+        pipeline = models.Pipeline.objects.get(uuid=pipeline_uuid)
+        assert pipeline.api_key == ""
+
 
 @pytest.fixture
 def internal_processing_location(db, tmp_path):

--- a/tests/locations/test_pipeline.py
+++ b/tests/locations/test_pipeline.py
@@ -152,15 +152,41 @@ def test_view_create_pipeline_invalid_post(admin_client: Client) -> None:
 
 def test_view_create_pipeline_post(admin_client: Client) -> None:
     url = reverse("locations:pipeline_create")
+    pipeline_uuid = str(uuid.uuid4())
+
+    resp = admin_client.post(url, follow=True, data={"uuid": pipeline_uuid})
+    messages = list(resp.context["messages"])
+
+    pipeline = models.Pipeline.objects.get(uuid=pipeline_uuid)
+    assert pipeline.api_key == ""
+    assert str(messages[0]) == "Pipeline saved."
+
+
+def test_view_create_pipeline_post_with_blank_api_key(admin_client: Client) -> None:
+    url = reverse("locations:pipeline_create")
+    pipeline_uuid = str(uuid.uuid4())
+    description = "Pipeline without API key"
+    remote_name = "http://example.com"
+    api_username = "myuser"
 
     resp = admin_client.post(
-        url, follow=True, data={"uuid": "0d9d6be9-2751-4e81-b85f-fe4e51a1f789"}
+        url,
+        follow=True,
+        data={
+            "uuid": pipeline_uuid,
+            "description": description,
+            "remote_name": remote_name,
+            "api_username": api_username,
+            "api_key": "",
+        },
     )
     messages = list(resp.context["messages"])
 
-    assert models.Pipeline.objects.filter(
-        uuid="0d9d6be9-2751-4e81-b85f-fe4e51a1f789"
-    ).exists()
+    pipeline = models.Pipeline.objects.get(uuid=pipeline_uuid)
+    assert pipeline.description == description
+    assert pipeline.remote_name == remote_name
+    assert pipeline.api_username == api_username
+    assert pipeline.api_key == ""
     assert str(messages[0]) == "Pipeline saved."
 
 
@@ -221,11 +247,43 @@ def test_view_edit_pipeline_post(
     assert str(messages[0]) == "Pipeline saved."
 
 
-def test_view_edit_pipeline_post_updates_fields_when_api_key_is_not_set(
+def test_view_edit_pipeline_post_preserves_existing_api_key_when_blank_string_is_submitted(
     admin_client: Client, pipeline: models.Pipeline
 ) -> None:
     url = reverse("locations:pipeline_edit", args=[pipeline.uuid])
     description = "Pipeline 3ebf"
+    remote_name = "localhost"
+    api_username = "newapiusername"
+    old_api_key = pipeline.api_key
+
+    resp = admin_client.post(
+        url,
+        follow=True,
+        data={
+            "uuid": str(pipeline.uuid),
+            "description": description,
+            "remote_name": remote_name,
+            "api_username": api_username,
+            "api_key": "",
+        },
+    )
+    messages = list(resp.context["messages"])
+
+    pipeline.refresh_from_db()
+    assert pipeline.description == description
+    assert pipeline.remote_name == remote_name
+    assert pipeline.api_username == api_username
+    assert str(messages[0]) == "Pipeline saved."
+
+    # The existing API key value was not modified.
+    assert pipeline.api_key == old_api_key
+
+
+def test_view_edit_pipeline_post_preserves_existing_api_key_when_api_key_is_omitted(
+    admin_client: Client, pipeline: models.Pipeline
+) -> None:
+    url = reverse("locations:pipeline_edit", args=[pipeline.uuid])
+    description = "Pipeline with omitted api_key"
     remote_name = "localhost"
     api_username = "newapiusername"
     old_api_key = pipeline.api_key
@@ -248,7 +306,7 @@ def test_view_edit_pipeline_post_updates_fields_when_api_key_is_not_set(
     assert pipeline.api_username == api_username
     assert str(messages[0]) == "Pipeline saved."
 
-    # The existing API key value was not modified.
+    # Omitting the field entirely should preserve the existing key too.
     assert pipeline.api_key == old_api_key
 
 


### PR DESCRIPTION
This change makes pipeline API key handling consistent across the UI and API.

Creating a pipeline without an API key now stores the canonical empty value "" regardless of whether the request comes from the form or the API, and editing an existing pipeline with a blank API key form field preserves the currently stored key instead of replacing it.

Connected to https://github.com/archivematica/Issues/issues/1789