### PR TITLE
Fix Browse button for spaces with empty roots

### DIFF
--- a/src/archivematica/storage_service/frontend/lib/location-directory-picker/App.spec.ts
+++ b/src/archivematica/storage_service/frontend/lib/location-directory-picker/App.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18nMock } from '@/shared/i18n'
+import TreeView from '@/shared/components/TreeView.vue'
 import App from './App.vue'
 
 const mockBrowseSpaceDirectory = vi.fn()
@@ -84,6 +85,100 @@ describe('LocationDirectoryPickerApp', () => {
     expect(wrapper.text()).toContain('child_2')
   })
 
+  it('loads and labels object storage roots when root path is empty', async () => {
+    mockBrowseSpaceDirectory.mockResolvedValueOnce({
+      entries: ['dHJhbnNmZXJz'],
+      directories: ['dHJhbnNmZXJz'],
+    })
+
+    const wrapper = mount(App, {
+      props: {
+        spaceUuid: '7d20c992-bc92-4f92-a794-7161ff2cc08b',
+        rootPath: '',
+      },
+      global: {
+        plugins: [createI18nMock()],
+        stubs: {
+          TreeView: TreeViewStub,
+        },
+      },
+    })
+
+    await flushPromises()
+
+    const tree = wrapper.findComponent(TreeViewStub)
+
+    expect(mockBrowseSpaceDirectory).toHaveBeenCalledWith(
+      '7d20c992-bc92-4f92-a794-7161ff2cc08b',
+      '',
+      undefined,
+    )
+    expect(tree.props('expanded')).toEqual([])
+    expect(wrapper.text()).toContain('Space root')
+    expect(wrapper.text()).toContain('transfers')
+  })
+
+  it('reveals empty-root children after expanding the synthetic root', async () => {
+    mockBrowseSpaceDirectory.mockResolvedValueOnce({
+      entries: ['c3BhY2Utcm9vdA=='],
+      directories: ['c3BhY2Utcm9vdA=='],
+    })
+
+    const wrapper = mount(App, {
+      props: {
+        spaceUuid: '7d20c992-bc92-4f92-a794-7161ff2cc08b',
+        rootPath: '',
+      },
+      global: {
+        plugins: [createI18nMock()],
+      },
+    })
+
+    await flushPromises()
+
+    const tree = wrapper.findComponent(TreeView)
+    const [rootNode] = tree.props('items') as Array<Record<string, unknown>>
+
+    expect(wrapper.findAll('.tree-node-label').map(node => node.text())).toEqual(['Space root'])
+    expect(rootNode?.id).toBe('root:')
+
+    const rootTreeNode = wrapper.findComponent({ name: 'TreeNode' })
+    rootTreeNode.vm.$emit('toggle', rootNode)
+    await flushPromises()
+
+    expect(wrapper.findAll('.tree-node-label').map(node => node.text())).toEqual([
+      'Space root',
+      'space-root',
+    ])
+    expect((tree.props('expanded') as string[])).toContain('root:')
+    expect(mockBrowseSpaceDirectory).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps filesystem root labels for non-empty root paths', async () => {
+    mockBrowseSpaceDirectory.mockResolvedValueOnce({
+      entries: ['Y2hpbGRfMQ=='],
+      directories: ['Y2hpbGRfMQ=='],
+    })
+
+    const wrapper = mount(App, {
+      props: {
+        spaceUuid: '7d20c992-bc92-4f92-a794-7161ff2cc08b',
+        rootPath: '/',
+      },
+      global: {
+        plugins: [createI18nMock()],
+        stubs: {
+          TreeView: TreeViewStub,
+        },
+      },
+    })
+
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('"label":"/"')
+    expect(wrapper.text()).not.toContain('Space root')
+  })
+
   it('loads children when a directory is toggled', async () => {
     mockBrowseSpaceDirectory
       .mockResolvedValueOnce({
@@ -112,7 +207,7 @@ describe('LocationDirectoryPickerApp', () => {
 
     const tree = wrapper.findComponent(TreeViewStub)
     tree.vm.$emit('toggle', {
-      id: '/var/storage/child_1',
+      id: 'path:/var/storage/child_1',
       path: '/var/storage/child_1',
       label: 'child_1',
       children: [],
@@ -182,7 +277,7 @@ describe('LocationDirectoryPickerApp', () => {
 
     const tree = wrapper.findComponent(TreeViewStub)
     tree.vm.$emit('update:modelValue', {
-      id: '/var/storage/child_1',
+      id: 'path:/var/storage/child_1',
       path: '/var/storage/child_1',
       label: 'child_1',
       children: [],

--- a/src/archivematica/storage_service/frontend/lib/location-directory-picker/App.vue
+++ b/src/archivematica/storage_service/frontend/lib/location-directory-picker/App.vue
@@ -19,11 +19,14 @@ const emit = defineEmits<{
 const selectedNode = ref<DirectoryNode | undefined>()
 const committedSelectedPath = ref(props.selectedPath ?? '')
 const expandedPaths = ref<string[]>([])
-const { items, loading, error, loadRoot, expandNode, clearError } = useSpaceBrowser()
 const { t } = useI18n()
+const { items, loading, error, loadRoot, expandNode, clearError } = useSpaceBrowser(
+  t('locationDirectoryPicker.spaceRoot'),
+)
 
 const refresh = async () => {
   await loadRoot(props.spaceUuid, props.rootPath)
+
   if (props.selectedPath) {
     const node = findNodeByPath(items.value, props.selectedPath)
     if (node) {
@@ -33,12 +36,12 @@ const refresh = async () => {
 }
 
 const handleToggle = async (node: DirectoryNode) => {
-  const path = node.path
-  const index = expandedPaths.value.indexOf(path)
+  const key = node.id
+  const index = expandedPaths.value.indexOf(key)
   if (index === -1) {
-    expandedPaths.value = [...expandedPaths.value, path]
+    expandedPaths.value = [...expandedPaths.value, key]
   } else {
-    expandedPaths.value = expandedPaths.value.filter(entry => entry !== path)
+    expandedPaths.value = expandedPaths.value.filter(entry => entry !== key)
   }
 
   await expandNode(props.spaceUuid, node)
@@ -150,7 +153,7 @@ function findNodeByPath(nodes: DirectoryNode[], path: string): DirectoryNode | u
         :variant="'compact'"
         :auto-focus-on-items-change="true"
         :auto-focus-target="'first'"
-        :get-key="node => (node as DirectoryNode).path"
+        :get-key="node => (node as DirectoryNode).id"
         :get-children="node => (node as DirectoryNode).children"
         :right-toggles="true"
         :enter-toggles="false"

--- a/src/archivematica/storage_service/frontend/lib/location-directory-picker/composables/useSpaceBrowser.spec.ts
+++ b/src/archivematica/storage_service/frontend/lib/location-directory-picker/composables/useSpaceBrowser.spec.ts
@@ -4,6 +4,7 @@ import {
   decodeBrowseResponse,
   joinPath,
   mapBrowseResponseToDirectoryNodes,
+  toTreeKey,
 } from '@/location-directory-picker/composables/useSpaceBrowser'
 
 describe('useSpaceBrowser helpers', () => {
@@ -34,7 +35,7 @@ describe('useSpaceBrowser helpers', () => {
 
     expect(nodes).toEqual([
       {
-        id: '/var/storage/child_1',
+        id: 'path:/var/storage/child_1',
         label: 'child_1',
         path: '/var/storage/child_1',
         children: [],
@@ -43,7 +44,7 @@ describe('useSpaceBrowser helpers', () => {
         loadError: null,
       },
       {
-        id: '/var/storage/child_2',
+        id: 'path:/var/storage/child_2',
         label: 'child_2',
         path: '/var/storage/child_2',
         children: [],
@@ -52,5 +53,12 @@ describe('useSpaceBrowser helpers', () => {
         loadError: null,
       },
     ])
+  })
+
+  it('namespaces tree keys for roots and paths separately', () => {
+    expect(toTreeKey('', true)).toBe('root:')
+    expect(toTreeKey('space-root')).toBe('path:space-root')
+    expect(toTreeKey('/')).toBe('path:/')
+    expect(toTreeKey('/', true)).toBe('root:/')
   })
 })

--- a/src/archivematica/storage_service/frontend/lib/location-directory-picker/composables/useSpaceBrowser.ts
+++ b/src/archivematica/storage_service/frontend/lib/location-directory-picker/composables/useSpaceBrowser.ts
@@ -38,6 +38,10 @@ const decodeBrowseResponse = (response: SpaceBrowseResponse): DecodedBrowseRespo
   }
 }
 
+const toTreeKey = (path: string, isRoot = false): string => {
+  return `${isRoot ? 'root' : 'path'}:${path}`
+}
+
 const mapBrowseResponseToDirectoryNodes = (
   response: DecodedBrowseResponse,
   currentPath: string,
@@ -49,7 +53,7 @@ const mapBrowseResponseToDirectoryNodes = (
     .map((entry) => {
       const path = joinPath(currentPath, entry)
       return {
-        id: path,
+        id: toTreeKey(path),
         label: entry,
         path,
         children: [],
@@ -60,9 +64,17 @@ const mapBrowseResponseToDirectoryNodes = (
     })
 }
 
-const createRootNode = (path: string): DirectoryNode => ({
-  id: path,
-  label: path.split('/').filter(Boolean).pop() ?? path,
+const getRootLabel = (path: string, spaceRootLabel: string): string => {
+  if (path === '') {
+    return spaceRootLabel
+  }
+
+  return path.split('/').filter(Boolean).pop() ?? path
+}
+
+const createRootNode = (path: string, spaceRootLabel: string): DirectoryNode => ({
+  id: toTreeKey(path, true),
+  label: getRootLabel(path, spaceRootLabel),
   path,
   children: [],
   loaded: false,
@@ -70,7 +82,7 @@ const createRootNode = (path: string): DirectoryNode => ({
   loadError: null,
 })
 
-export function useSpaceBrowser() {
+export function useSpaceBrowser(spaceRootLabel: string) {
   const items: Ref<DirectoryNode[]> = ref([])
   const loading: Ref<boolean> = ref(false)
   const error: Ref<string | null> = ref(null)
@@ -85,14 +97,14 @@ export function useSpaceBrowser() {
     items.value = []
     error.value = null
 
-    if (!spaceUuid || !rootPath) {
-      error.value = 'A valid space UUID and root path are required.'
+    if (!spaceUuid) {
+      error.value = 'A valid space UUID is required.'
       return
     }
 
     loading.value = true
 
-    const root = createRootNode(rootPath)
+    const root = createRootNode(rootPath, spaceRootLabel)
     root.loading = true
     items.value = [root]
 
@@ -151,4 +163,5 @@ export {
   decodeBrowseResponse,
   mapBrowseResponseToDirectoryNodes,
   joinPath,
+  toTreeKey,
 }

--- a/src/archivematica/storage_service/frontend/lib/location-directory-picker/index.spec.ts
+++ b/src/archivematica/storage_service/frontend/lib/location-directory-picker/index.spec.ts
@@ -30,6 +30,11 @@ vi.mock('./App.vue', () => ({
           'type': 'button',
           'onClick': () => emit('select', '/var/storage/home/selected'),
         }),
+        h('button', {
+          'data-testid': 'emit-current-select',
+          'type': 'button',
+          'onClick': () => emit('select', props.selectedPath),
+        }),
       ])
     },
   }),
@@ -75,6 +80,14 @@ describe('location-directory-picker bootstrap', () => {
     button.click()
   }
 
+  const triggerCurrentSelect = (mountEl: HTMLElement) => {
+    const button = mountEl.querySelector<HTMLButtonElement>('[data-testid="emit-current-select"]')
+    if (!button) {
+      throw new Error('Current select button not found in test DOM.')
+    }
+    button.click()
+  }
+
   it('dispatches selected-path once per directory selection', async () => {
     await import('./index')
     await Promise.resolve()
@@ -106,6 +119,30 @@ describe('location-directory-picker bootstrap', () => {
     await Promise.resolve()
 
     expect(getSelectedPathText(mountEl)).toBe('/var/storage/home/new')
+  })
+
+  it('keeps selected paths relative for object storage roots', async () => {
+    document.body.innerHTML = `
+      <div
+        id="location-directory-picker"
+        data-space-uuid="2e008d73-33d0-4aa6-917b-9fd6f4031915"
+        data-root-path=""
+        data-selected-relative-path="/transfers/foo"
+      ></div>
+    `
+
+    await import('./index')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const mountEl = getMountEl()
+    expect(getSelectedPathText(mountEl)).toBe('transfers/foo')
+
+    triggerCurrentSelect(mountEl)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mountEl.getAttribute('data-selected-relative-path')).toBe('transfers/foo')
   })
 
   it('uses latest manual relative path after a prior selection', async () => {

--- a/src/archivematica/storage_service/frontend/lib/location-directory-picker/utils/path.spec.ts
+++ b/src/archivematica/storage_service/frontend/lib/location-directory-picker/utils/path.spec.ts
@@ -18,7 +18,12 @@ describe('toAbsolutePath', () => {
 
   it('joins from root slash', () => {
     expect(toAbsolutePath('/', 'child/path')).toBe('/child/path')
-    expect(toAbsolutePath('', 'child/path')).toBe('/child/path')
+  })
+
+  it('keeps object storage paths relative when root path is empty', () => {
+    expect(toAbsolutePath('', 'child/path')).toBe('child/path')
+    expect(toAbsolutePath('', '/transfers/foo')).toBe('transfers/foo')
+    expect(toAbsolutePath('', '///transfers/foo')).toBe('transfers/foo')
   })
 
   it('treats paths starting with slash as already absolute', () => {
@@ -48,5 +53,10 @@ describe('toRelativePath', () => {
 
   it('handles root slash as base path', () => {
     expect(toRelativePath('/', '/home/archivematica')).toBe('home/archivematica')
+  })
+
+  it('keeps object storage paths relative when root path is empty', () => {
+    expect(toRelativePath('', 'child/path')).toBe('child/path')
+    expect(toRelativePath('', '/child/path')).toBe('child/path')
   })
 })

--- a/src/archivematica/storage_service/frontend/lib/location-directory-picker/utils/path.ts
+++ b/src/archivematica/storage_service/frontend/lib/location-directory-picker/utils/path.ts
@@ -4,11 +4,15 @@ export const toAbsolutePath = (rootPath: string, relativePath: string): string =
     return ''
   }
 
+  const normalizedRootPath = rootPath.trim()
+  if (!normalizedRootPath) {
+    return trimmedRelativePath.replace(/^\/+/, '')
+  }
+
   if (trimmedRelativePath.startsWith('/')) {
     return trimmedRelativePath
   }
 
-  const normalizedRootPath = rootPath.trim() || '/'
   const normalizedRelativePath = trimmedRelativePath.replace(/^\/+/, '')
   if (normalizedRootPath === '/') {
     return `/${normalizedRelativePath}`
@@ -22,7 +26,11 @@ export const toRelativePath = (rootPath: string, selectedPath: string): string =
     return ''
   }
 
-  const normalizedRootPath = (rootPath.trim() || '/').replace(/\/$/, '')
+  const normalizedRootPath = rootPath.trim().replace(/\/$/, '')
+  if (!normalizedRootPath) {
+    return trimmedPath.replace(/^\/+/, '')
+  }
+
   if (normalizedRootPath && normalizedRootPath !== '/' && trimmedPath.startsWith(`${normalizedRootPath}/`)) {
     return trimmedPath.slice(normalizedRootPath.length + 1)
   }

--- a/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/en.json
+++ b/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/en.json
@@ -4,7 +4,8 @@
     "loadingDirectories": "Loading...",
     "loadFailed": "Unable to load directory",
     "retry": "Retry",
-    "select": "Select"
+    "select": "Select",
+    "spaceRoot": "Space root"
   },
   "clipboardField": {
     "copy": "Copy",

--- a/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/es.json
+++ b/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/es.json
@@ -4,7 +4,8 @@
     "loadingDirectories": "Cargando...",
     "loadFailed": "No se pudo cargar el directorio",
     "retry": "Reintentar",
-    "select": "Seleccionar"
+    "select": "Seleccionar",
+    "spaceRoot": "Raíz del espacio"
   },
   "clipboardField": {
     "copy": "Copiar",

--- a/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/fr.json
+++ b/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/fr.json
@@ -4,7 +4,8 @@
     "loadingDirectories": "Chargement...",
     "loadFailed": "Impossible de charger le répertoire",
     "retry": "Réessayer",
-    "select": "Sélectionner"
+    "select": "Sélectionner",
+    "spaceRoot": "Racine de l’espace"
   },
   "clipboardField": {
     "copy": "Copier",

--- a/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/ja.json
+++ b/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/ja.json
@@ -4,7 +4,8 @@
     "loadingDirectories": "読み込み中...",
     "loadFailed": "ディレクトリーを読み込めません",
     "retry": "再試行",
-    "select": "選択"
+    "select": "選択",
+    "spaceRoot": "スペースのルート"
   },
   "clipboardField": {
     "copy": "コピー",

--- a/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/no.json
+++ b/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/no.json
@@ -4,7 +4,8 @@
     "loadingDirectories": "Laster inn...",
     "loadFailed": "Kunne ikke laste inn katalogen",
     "retry": "Prøv igjen",
-    "select": "Velg"
+    "select": "Velg",
+    "spaceRoot": "Lagringsområdets rot"
   },
   "clipboardField": {
     "copy": "Kopier",

--- a/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/pt-br.json
+++ b/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/pt-br.json
@@ -4,7 +4,8 @@
     "loadingDirectories": "Carregando...",
     "loadFailed": "Não foi possível carregar o diretório",
     "retry": "Tentar novamente",
-    "select": "Selecionar"
+    "select": "Selecionar",
+    "spaceRoot": "Raiz do espaço"
   },
   "clipboardField": {
     "copy": "Copiar",

--- a/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/pt.json
+++ b/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/pt.json
@@ -4,7 +4,8 @@
     "loadingDirectories": "A carregar...",
     "loadFailed": "Não foi possível carregar o diretório",
     "retry": "Tentar novamente",
-    "select": "Selecionar"
+    "select": "Selecionar",
+    "spaceRoot": "Raiz do espaço"
   },
   "clipboardField": {
     "copy": "Copiar",

--- a/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/sv.json
+++ b/src/archivematica/storage_service/frontend/lib/shared/i18n/locales/sv.json
@@ -4,7 +4,8 @@
     "loadingDirectories": "Läser in...",
     "loadFailed": "Det gick inte att läsa in katalogen",
     "retry": "Försök igen",
-    "select": "Välj"
+    "select": "Välj",
+    "spaceRoot": "Utrymmets rot"
   },
   "clipboardField": {
     "copy": "Kopiera",


### PR DESCRIPTION
This prevents the Browse button in location forms from failing when a space has no root path, as with remote storage backends such as S3.