### PR TITLE
Add OIDC auto-create-user toggle

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -592,6 +592,9 @@ These variables specify the behaviour of CAS authentication. If
 These variables specify the behaviour of OpenID Connect (OIDC) authentication.
 If `SS_OIDC_AUTHENTICATION` is false, none of the other ones are used.
 
+Automatic local user creation for OIDC logins is controlled by
+`SS_OIDC_AUTO_CREATE_USER`.
+
 - **`SS_OIDC_AUTHENTICATION`**:
   - **Description:** Enables user authentication via OIDC.
   - **Type:** `boolean`
@@ -599,6 +602,12 @@ If `SS_OIDC_AUTHENTICATION` is false, none of the other ones are used.
 
 - **`SS_OIDC_ALLOW_LOCAL_AUTHENTICATION`**:
   - **Description:** Allows local authentication and authentication via OIDC.
+  - **Type:** `boolean`
+  - **Default:** `true`
+
+- **`SS_OIDC_AUTO_CREATE_USER`**:
+  - **Description:** enables automatic local user creation for successful OIDC
+    logins when no matching Storage Service user already exists.
   - **Type:** `boolean`
   - **Default:** `true`
 

--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -629,6 +629,7 @@ if OIDC_AUTHENTICATION:
     OIDC_ALLOW_LOCAL_AUTHENTICATION = is_true(
         environ.get("SS_OIDC_ALLOW_LOCAL_AUTHENTICATION", "true")
     )
+    OIDC_CREATE_USER = is_true(environ.get("SS_OIDC_AUTO_CREATE_USER", "true"))
 
     if not OIDC_ALLOW_LOCAL_AUTHENTICATION:
         LOGIN_URL = "/oidc/authenticate/"

--- a/tests/storage_service/test_oidc.py
+++ b/tests/storage_service/test_oidc.py
@@ -301,8 +301,7 @@ def test_get_userinfo(settings: pytest_django.Settings) -> None:
 
 @pytest.mark.django_db
 def test_get_or_create_user_does_not_create_user_when_disabled(
-    settings: pytest_django.fixtures.SettingsWrapper,
-    monkeypatch: pytest.MonkeyPatch,
+    settings: pytest_django.Settings, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     settings.OIDC_CREATE_USER = False
     backend = CustomOIDCBackend()
@@ -324,8 +323,7 @@ def test_get_or_create_user_does_not_create_user_when_disabled(
 
 @pytest.mark.django_db
 def test_get_or_create_user_returns_existing_user_when_creation_disabled(
-    settings: pytest_django.fixtures.SettingsWrapper,
-    monkeypatch: pytest.MonkeyPatch,
+    settings: pytest_django.Settings, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     settings.OIDC_CREATE_USER = False
     existing_user = User.objects.create_user(

--- a/tests/storage_service/test_oidc.py
+++ b/tests/storage_service/test_oidc.py
@@ -21,6 +21,7 @@ def settings(settings: pytest_django.Settings) -> pytest_django.Settings:
         "family_name": "last_name",
     }
     settings.OIDC_OP_SET_ROLES_FROM_CLAIMS = False
+    settings.OIDC_CREATE_USER = True
     settings.OIDC_OP_ROLE_CLAIM_PATH = "realm_access.roles"
     settings.OIDC_ID_ATTRIBUTE_MAP = {"email": "email"}
     settings.OIDC_USERNAME_ALGO = lambda email: email
@@ -296,6 +297,54 @@ def test_get_userinfo(settings: pytest_django.Settings) -> None:
     assert info["email"] == "test@example.com"
     assert info["first_name"] == "Test"
     assert info["last_name"] == "User"
+
+
+@pytest.mark.django_db
+def test_get_or_create_user_does_not_create_user_when_disabled(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings.OIDC_CREATE_USER = False
+    backend = CustomOIDCBackend()
+    monkeypatch.setattr(
+        backend,
+        "get_userinfo",
+        lambda access_token, id_token, payload: {"email": "new@example.com"},
+    )
+
+    user = backend.get_or_create_user(
+        access_token="access-token",
+        id_token="id-token",
+        payload={"sub": "test"},
+    )
+
+    assert user is None
+    assert User.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_get_or_create_user_returns_existing_user_when_creation_disabled(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings.OIDC_CREATE_USER = False
+    existing_user = User.objects.create_user(
+        username="existing@example.com", email="existing@example.com"
+    )
+    backend = CustomOIDCBackend()
+    monkeypatch.setattr(
+        backend,
+        "get_userinfo",
+        lambda access_token, id_token, payload: {"email": "existing@example.com"},
+    )
+
+    user = backend.get_or_create_user(
+        access_token="access-token",
+        id_token="id-token",
+        payload={"sub": "test"},
+    )
+
+    assert user == existing_user
 
 
 @pytest.mark.django_db

--- a/tests/storage_service/test_oidc.py
+++ b/tests/storage_service/test_oidc.py
@@ -345,6 +345,7 @@ def test_get_or_create_user_returns_existing_user_when_creation_disabled(
     )
 
     assert user == existing_user
+    assert User.objects.count() == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Add a config option to control whether OIDC logins can automatically create a local user when no matching account exists.

This keeps the current default behavior enabled and exposes it through the new environment variable `SS_OIDC_AUTO_CREATE_USER`.

Connects to https://github.com/archivematica/Issues/issues/1783