### PR TITLE
Avoid cookie name collisions with Archivematica

### DIFF
--- a/src/archivematica/storage_service/frontend/lib/shared/http/client.spec.ts
+++ b/src/archivematica/storage_service/frontend/lib/shared/http/client.spec.ts
@@ -3,16 +3,23 @@ import { HttpError, toHttpErrorInfo } from '@/shared/http'
 import { createHttpClient } from '@/shared/http/client'
 
 const mockFetch = vi.fn()
+const clearCookie = (name: string): void => {
+  document.cookie = `${name}=; Max-Age=0; path=/`
+}
 
 describe('shared http client', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', mockFetch)
     mockFetch.mockReset()
+    clearCookie('storageapi_csrfid')
+    clearCookie('csrftoken')
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.clearAllMocks()
+    clearCookie('storageapi_csrfid')
+    clearCookie('csrftoken')
   })
 
   it('appends query params and cache buster', async () => {
@@ -54,6 +61,26 @@ describe('shared http client', () => {
     expect(init?.body).toBe(JSON.stringify({ a: 1 }))
     expect(headers.get('Content-Type')).toBe('application/json')
     expect(headers.get('X-Requested-With')).toBe('XMLHttpRequest')
+  })
+
+  it('uses the Storage Service CSRF cookie for unsafe requests', async () => {
+    document.cookie = 'storageapi_csrfid=csrf-token; path=/'
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => JSON.stringify({ ok: true }),
+    })
+
+    const client = createHttpClient()
+    await client.requestJson('/api/test/', {
+      method: 'POST',
+      json: { a: 1 },
+    })
+
+    expect(mockFetch).toHaveBeenCalled()
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit?]
+    const headers = new Headers(init?.headers as HeadersInit)
+
+    expect(headers.get('X-CSRFToken')).toBe('csrf-token')
   })
 
   it('throws HttpError for non-ok responses', async () => {

--- a/src/archivematica/storage_service/frontend/lib/shared/http/client.ts
+++ b/src/archivematica/storage_service/frontend/lib/shared/http/client.ts
@@ -116,7 +116,7 @@ const getCookie = (name: string): string => {
 }
 
 const getCsrfToken = (): string => {
-  return getCookie('csrftoken')
+  return getCookie('storageapi_csrfid')
 }
 
 const needsCsrf = (method?: string) =>

--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -333,10 +333,12 @@ else:
 # ######## END LOGGING CONFIGURATION
 
 
-# ######## SESSION CONFIGURATION
+# ######## COOKIE NAME CONFIGURATION
 # So the cookies don't conflict with archivematica cookies
 SESSION_COOKIE_NAME = "storageapi_sessionid"
-# ######## END SESSION CONFIGURATION
+CSRF_COOKIE_NAME = "storageapi_csrfid"
+LANGUAGE_COOKIE_NAME = "storageapi_languageid"
+# ######## END COOKIE NAME CONFIGURATION
 
 
 # ######## WSGI CONFIGURATION


### PR DESCRIPTION
This change adds Storage Service-specific names for the CSRF and language cookies so they do not collide with Archivematica's Django cookie defaults when both apps share a host.