### PR TITLE
Fix replica pointers for remote AIPs

### DIFF
--- a/src/archivematica/storage_service/locations/models/package.py
+++ b/src/archivematica/storage_service/locations/models/package.py
@@ -637,6 +637,8 @@ class Package(models.Model):
 
         replica_package = self._clone()
         replica_package.replicated_package = self
+        replica_package.pointer_file_location = None
+        replica_package.pointer_file_path = None
 
         # Remove the /uuid/path from the replica's current_path and replace the
         # old UUID in the basename with the new UUID.
@@ -692,7 +694,12 @@ class Package(models.Model):
             # Calculate the checksum of the replica while we have it locally,
             # compare it to the master's checksum and create a PREMIS validation
             # event out of the result.
-            replica_local_path = self.get_local_path()
+            #
+            # The main package may be in remote storage, but the replica has just
+            # been copied into the destination space's local staging path.
+            replica_local_path = os.path.join(
+                dest_space.staging_path, replica_package.current_path
+            )
             replica_checksum = utils.generate_checksum(
                 replica_local_path, master_checksum_algorithm
             ).hexdigest()
@@ -1167,10 +1174,18 @@ class Package(models.Model):
         uncompressed AIPs. See artefactual/archivematica-storage-service#324
         for further enhancements.
         """
-        if not self.should_have_pointer_file():
+        if not self.pointer_file_location or not self.pointer_file_path:
+            if self.should_have_pointer_file():
+                LOGGER.warning(
+                    "Package %s should have a pointer file, but no pointer file "
+                    "location/path is set.",
+                    self.uuid,
+                )
             return None
         ptr_path = self.full_pointer_file_path
-        if not ptr_path:
+        # Pointer files are stored in SS internal storage, so the XML must be
+        # locally present before metsrw can parse it.
+        if not ptr_path or not os.path.isfile(ptr_path):
             return None
         return metsrw.METSDocument.fromfile(ptr_path)
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -24,6 +24,7 @@ from collections.abc import Iterable
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Protocol
 from typing import TypedDict
 from typing import cast
@@ -45,6 +46,7 @@ from archivematica.storage_service.locations import package_request
 from archivematica.storage_service.locations.models import Event
 from archivematica.storage_service.locations.models import Location
 from archivematica.storage_service.locations.models import Package
+from archivematica.storage_service.locations.models import Pipeline
 from archivematica.storage_service.locations.models import Space
 
 if TYPE_CHECKING:
@@ -198,6 +200,15 @@ class Client:
     ) -> HttpResponse:
         return self.admin_client.post(
             f"/api/v2/file/{file_id}/delete_aip/",
+            json.dumps(data),
+            content_type="application/json",
+        )
+
+    def request_reingest(
+        self, file_id: uuid.UUID, data: dict[str, str]
+    ) -> HttpResponse:
+        return self.admin_client.post(
+            f"/api/v2/file/{file_id}/reingest/",
             json.dumps(data),
             content_type="application/json",
         )
@@ -860,6 +871,262 @@ class AIPRecoveryScenario(StorageScenario):
                 utils.generate_checksum(extracted_path / self.pkg_name).hexdigest()
                 == utils.generate_checksum(self.pkg).hexdigest()
             )
+
+
+class ReingestScenario(StorageScenario):
+    REINGEST_MARKER = "reingest-marker"
+
+    def request_reingest(self, reingest_type: str) -> dict[str, Any]:
+        resp = self.client.request_reingest(
+            self.PACKAGE_UUID,
+            {
+                "pipeline": str(self.PIPELINE_UUID),
+                "reingest_type": reingest_type,
+            },
+        )
+        assert resp.status_code == 202
+        return cast(dict[str, Any], json.loads(resp.text))
+
+    def get_currently_processing_location(self) -> LocationResponseResult:
+        resp = self.client.get_locations(
+            {
+                "pipeline_uuid": str(self.PIPELINE_UUID),
+                "purpose": Location.CURRENTLY_PROCESSING,
+            }
+        )
+        assert resp.status_code == 200
+        return cast(LocationResponseResult, json.loads(resp.text)["objects"][0])
+
+    def prepare_reingested_aip(
+        self, relative_path: str, source_path: Path | None = None
+    ) -> Path:
+        cp_location = self.get_currently_processing_location()
+        reingest_path = Path(cp_location["path"]) / "tmp" / relative_path
+        if self.compressed:
+            reingest_path.parent.mkdir(parents=True, exist_ok=True)
+            if source_path is None:
+                source_path = FIXTURES_DIR / self.pkg
+            shutil.copy2(source_path, reingest_path)
+            return reingest_path
+        assert reingest_path.is_dir()
+        self._create_reingest_mets(reingest_path)
+        return reingest_path
+
+    def _create_reingest_mets(self, reingest_root: Path) -> Path:
+        data_dir = reingest_root / "data"
+        mets_files = list(data_dir.glob("METS.*.xml"))
+        assert mets_files
+        reingest_mets = data_dir / f"METS.{self.PACKAGE_UUID}.xml"
+        shutil.copy2(mets_files[0], reingest_mets)
+        content = reingest_mets.read_text()
+        marker = f"<!-- {self.REINGEST_MARKER} -->"
+        if marker not in content:
+            if "</mets:mets>" not in content:
+                raise AssertionError("METS closing tag not found")
+            content = content.replace("</mets:mets>", f"{marker}\n</mets:mets>", 1)
+            reingest_mets.write_text(content)
+        return reingest_mets
+
+    def finish_reingest(
+        self,
+        *,
+        origin_location: str,
+        origin_path: str,
+        current_location: str,
+        current_path: str,
+    ) -> HttpResponse:
+        data: dict[str, str | int | list[PremisEvent] | list[PremisAgent]] = {
+            "uuid": str(self.PACKAGE_UUID),
+            "origin_location": origin_location,
+            "origin_path": origin_path,
+            "current_location": current_location,
+            "current_path": current_path,
+            "size": Package.objects.get(uuid=self.PACKAGE_UUID).size,
+            "package_type": Package.AIP,
+            "aip_subtype": "Archival Information Package",
+            "origin_pipeline": f"/api/v2/pipeline/{self.PIPELINE_UUID}/",
+            "events": [self.get_compression_event()],
+            "agents": [self.get_agent()],
+            "reingest": True,
+        }
+        return self.client.add_file(self.PACKAGE_UUID, data)
+
+
+@pytest.mark.parametrize(
+    ("pkg", "compressed"),
+    [
+        (COMPRESSED_PACKAGE, True),
+        (UNCOMPRESSED_PACKAGE, False),
+    ],
+    ids=["compressed", "uncompressed"],
+)
+@pytest.mark.parametrize(
+    ("storage_protocol", "replication_protocol"),
+    [
+        (Space.S3, Space.S3),
+        (Space.S3, Space.RCLONE),
+        (Space.S3, Space.NFS),
+        (Space.S3, Space.LOCAL_FILESYSTEM),
+        (Space.RCLONE, Space.S3),
+        (Space.RCLONE, Space.RCLONE),
+        (Space.RCLONE, Space.NFS),
+        (Space.RCLONE, Space.LOCAL_FILESYSTEM),
+        (Space.NFS, Space.S3),
+        (Space.NFS, Space.RCLONE),
+        (Space.NFS, Space.NFS),
+        (Space.NFS, Space.LOCAL_FILESYSTEM),
+        (Space.LOCAL_FILESYSTEM, Space.S3),
+        (Space.LOCAL_FILESYSTEM, Space.RCLONE),
+        (Space.LOCAL_FILESYSTEM, Space.NFS),
+        (Space.LOCAL_FILESYSTEM, Space.LOCAL_FILESYSTEM),
+    ],
+    ids=[
+        "s3_to_s3",
+        "s3_to_rclone",
+        "s3_to_nfs",
+        "s3_to_local_fs",
+        "rclone_to_s3",
+        "rclone_to_rclone",
+        "rclone_to_nfs",
+        "rclone_to_local_fs",
+        "nfs_to_s3",
+        "nfs_to_rclone",
+        "nfs_to_nfs",
+        "nfs_to_local_fs",
+        "local_fs_to_s3",
+        "local_fs_to_rclone",
+        "local_fs_to_nfs",
+        "local_fs_to_local_fs",
+    ],
+)
+@pytest.mark.django_db
+def test_reingest_with_replicas(
+    startup: None,
+    admin_client: DjangoTestClient,
+    working_directory_path: Path,
+    s3_browse_bucket: str,
+    s3_resource: S3ServiceResource,
+    monkeypatch: pytest.MonkeyPatch,
+    pkg: Path,
+    compressed: bool,
+    storage_protocol: str,
+    replication_protocol: str,
+) -> None:
+    scenario = ReingestScenario(
+        storage_protocol=storage_protocol,
+        replication_protocol=replication_protocol,
+        pkg=pkg,
+        compressed=compressed,
+    )
+    scenario.init(
+        admin_client,
+        working_directory_path,
+        s3_bucket=s3_browse_bucket,
+    )
+    scenario.store_aip()
+    scenario.assert_stored()
+
+    cp_location = Location.objects.get(
+        pipeline__uuid=scenario.PIPELINE_UUID,
+        purpose=Location.CURRENTLY_PROCESSING,
+    )
+    cp_staging_path = (
+        working_directory_path
+        / "var"
+        / "archivematica"
+        / "sharedDirectory"
+        / "tmp"
+        / "reingest_staging"
+    )
+    cp_staging_path.mkdir(parents=True, exist_ok=True)
+    cp_location.space.staging_path = str(cp_staging_path)
+    cp_location.space.save()
+
+    package = Package.objects.get(uuid=scenario.PACKAGE_UUID)
+    current_path = package.current_path
+    original_replicas = list(Package.objects.filter(replicated_package=package.uuid))
+    original_replica_uuids = {replica.uuid for replica in original_replicas}
+    assert len(original_replicas) == 1
+
+    reingest_path: str | None = None
+
+    def fake_reingest(
+        self: Pipeline, name: str, _uuid: uuid.UUID, _target: str = "transfer"
+    ) -> dict[str, str]:
+        nonlocal reingest_path
+        reingest_path = name
+        return {"reingest_uuid": str(uuid.uuid4())}
+
+    monkeypatch.setattr(Pipeline, "reingest", fake_reingest)
+
+    scenario.request_reingest(Package.FULL)
+    assert reingest_path is not None
+
+    relative_path = Path(current_path)
+    if scenario.compressed:
+        relative_path_str = relative_path.as_posix()
+    else:
+        relative_path_str = reingest_path
+    source_path = Path(package.full_path)
+    if scenario.compressed and not source_path.exists():
+        package_any = cast(Any, package)
+        source_path = Path(package_any.fetch_local_path())
+    scenario.prepare_reingested_aip(relative_path_str, source_path=source_path)
+    package_any = cast(Any, package)
+    package_any.clear_local_tempdirs()
+    if scenario.compressed:
+        origin_path = (Path("tmp") / relative_path).as_posix()
+    else:
+        origin_path = f"tmp/{relative_path_str.rstrip('/')}/"
+
+    assert scenario.aip_storage_location_attrs is not None
+    resp = scenario.finish_reingest(
+        origin_location=scenario.get_currently_processing_location()["resource_uri"],
+        origin_path=origin_path,
+        current_location=scenario.aip_storage_location_attrs["resource_uri"],
+        current_path=current_path,
+    )
+    assert resp.status_code in {200, 202}
+
+    package.refresh_from_db()
+    if scenario.compressed:
+        assert package.full_pointer_file_path
+        assert Path(package.full_pointer_file_path).is_file()
+    else:
+        assert package.full_pointer_file_path is None
+
+    resp = scenario.client.check_fixity(package.uuid)
+    assert resp.status_code == 200
+    assert json.loads(resp.text)["success"] is True
+
+    replicas = list(Package.objects.filter(replicated_package=package.uuid))
+    deleted_replicas = [
+        replica for replica in replicas if replica.status == Package.DELETED
+    ]
+    uploaded_replicas = [
+        replica for replica in replicas if replica.status == Package.UPLOADED
+    ]
+    assert {replica.uuid for replica in deleted_replicas} == original_replica_uuids
+    assert len(uploaded_replicas) == 1
+    assert uploaded_replicas[0].uuid not in original_replica_uuids
+    for replica in uploaded_replicas:
+        if scenario.compressed:
+            assert replica.full_pointer_file_path
+            assert Path(replica.full_pointer_file_path).is_file()
+        else:
+            assert replica.full_pointer_file_path is None
+
+    if scenario.replication_protocol in scenario.OBJECT_STORAGE_PROTOCOLS:
+        bucket_name = scenario._object_storage_bucket_name
+        assert bucket_name
+        replica = uploaded_replicas[0]
+        prefix = (
+            Path(replica.current_location.relative_path) / replica.current_path
+        ).as_posix()
+        if not scenario.compressed:
+            prefix = f"{prefix}/"
+        matches = list(s3_resource.Bucket(bucket_name).objects.filter(Prefix=prefix))
+        assert matches
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -214,6 +214,9 @@ class Client:
     def download_file(self, file_id: uuid.UUID) -> HttpResponse:
         return self.admin_client.get(f"/api/v2/file/{file_id}/download/")
 
+    def extract_file(self, file_id: uuid.UUID, data: dict[str, str]) -> HttpResponse:
+        return self.admin_client.get(f"/api/v2/file/{file_id}/extract_file/", data)
+
 
 @pytest.fixture(scope="session")
 def client(admin_client: DjangoTestClient) -> Client:
@@ -483,6 +486,18 @@ class StorageScenario:
         else:
             shutil.copy(FIXTURES_DIR / self.pkg, dst)
             assert dst.is_file()
+
+    def aip_mets_relative_path(self) -> str:
+        if self.compressed:
+            package_root = self.pkg.name.removesuffix("".join(self.pkg.suffixes))
+            mets_filename = f"METS.{self.PACKAGE_UUID}.xml"
+        else:
+            mets_files = list(self.pkg.glob("data/METS.*.xml"))
+            assert len(mets_files) == 1
+            package_root = self.pkg_name
+            mets_filename = mets_files[0].name
+
+        return f"{package_root}/data/{mets_filename}"
 
     def store_aip(self) -> None:
         resp = self.client.get_locations(
@@ -1266,19 +1281,22 @@ class AIPDeletionScenario(StorageScenario):
         return self.client.review_aip_deletion(file_uuid, data)
 
     def delete_aip(self) -> str:
+        return self.delete_package(self.PACKAGE_UUID, self.storage_protocol)
+
+    def delete_package(self, file_uuid: uuid.UUID, expected_protocol: str) -> str:
         data: dict[str, str | int] = {
             "event_reason": "Delete please!",
             "pipeline": str(self.PIPELINE_UUID),
             "user_id": 1,
             "user_email": "user@example.com",
         }
-        resp = self.request_aip_deletion(data)
+        resp = self.client.request_aip_deletion(file_uuid, data)
         assert resp.status_code == 202
 
         assert Event.objects.count() == 1
 
         event = Event.objects.get(
-            package=Package.objects.get(uuid=self.PACKAGE_UUID),
+            package=Package.objects.get(uuid=file_uuid),
             event_type=Event.DELETE,
             status=Event.SUBMITTED,
             event_reason=data["event_reason"],
@@ -1287,16 +1305,16 @@ class AIPDeletionScenario(StorageScenario):
             user_email=data["user_email"],
         )
 
-        package = Package.objects.get(uuid=self.PACKAGE_UUID)
-        assert package.current_location.space.access_protocol == self.storage_protocol
+        package = Package.objects.get(uuid=file_uuid)
+        assert package.current_location.space.access_protocol == expected_protocol
         package_full_path = str(package.full_path)
 
-        if self.storage_protocol not in self.OBJECT_STORAGE_PROTOCOLS:
+        if expected_protocol not in self.OBJECT_STORAGE_PROTOCOLS:
             assert Path(package_full_path).exists()
 
         reason = "Deleting!"
         resp = self.review_aip_deletion(
-            self.PACKAGE_UUID,
+            file_uuid,
             {
                 "reason": reason,
                 "decision": package_request.PackageRequestDecision.APPROVE,
@@ -1312,7 +1330,7 @@ class AIPDeletionScenario(StorageScenario):
         assert Event.objects.count() == 1
         assert (
             Event.objects.filter(
-                package=Package.objects.get(uuid=self.PACKAGE_UUID),
+                package=Package.objects.get(uuid=file_uuid),
                 event_type=Event.DELETE,
                 status=Event.APPROVED,
                 event_reason=data["event_reason"],
@@ -1415,6 +1433,166 @@ def test_aip_deletion(
         if scenario.storage_protocol in scenario.OBJECT_STORAGE_PROTOCOLS
         else None,
     )
+
+
+def assert_package_content_exists(
+    protocol: str,
+    package_full_path: str,
+    bucket_name: str,
+    s3_resource: S3ServiceResource,
+) -> None:
+    if protocol in StorageScenario.OBJECT_STORAGE_PROTOCOLS:
+        prefix = package_full_path.lstrip(os.sep)
+        bucket = s3_resource.Bucket(bucket_name)
+        assert list(bucket.objects.filter(Prefix=prefix))
+    else:
+        assert Path(package_full_path).exists()
+
+
+def assert_package_content_deleted(
+    protocol: str,
+    package_full_path: str,
+    bucket_name: str,
+    s3_resource: S3ServiceResource,
+) -> None:
+    if protocol in StorageScenario.OBJECT_STORAGE_PROTOCOLS:
+        prefix = package_full_path.lstrip(os.sep)
+        bucket = s3_resource.Bucket(bucket_name)
+        assert not list(bucket.objects.filter(Prefix=prefix))
+    else:
+        assert not Path(package_full_path).exists()
+
+
+@pytest.mark.parametrize(
+    ("pkg", "compressed"),
+    [
+        (COMPRESSED_PACKAGE, True),
+        (UNCOMPRESSED_PACKAGE, False),
+    ],
+    ids=["compressed", "uncompressed"],
+)
+@pytest.mark.parametrize(
+    ("storage_protocol", "replication_protocol"),
+    [
+        (Space.S3, Space.S3),
+        (Space.S3, Space.RCLONE),
+        (Space.S3, Space.NFS),
+        (Space.S3, Space.LOCAL_FILESYSTEM),
+        (Space.RCLONE, Space.S3),
+        (Space.RCLONE, Space.RCLONE),
+        (Space.RCLONE, Space.NFS),
+        (Space.RCLONE, Space.LOCAL_FILESYSTEM),
+        (Space.NFS, Space.S3),
+        (Space.NFS, Space.RCLONE),
+        (Space.NFS, Space.NFS),
+        (Space.NFS, Space.LOCAL_FILESYSTEM),
+        (Space.LOCAL_FILESYSTEM, Space.S3),
+        (Space.LOCAL_FILESYSTEM, Space.RCLONE),
+        (Space.LOCAL_FILESYSTEM, Space.NFS),
+        (Space.LOCAL_FILESYSTEM, Space.LOCAL_FILESYSTEM),
+    ],
+    ids=[
+        "s3_to_s3",
+        "s3_to_rclone",
+        "s3_to_nfs",
+        "s3_to_local_fs",
+        "rclone_to_s3",
+        "rclone_to_rclone",
+        "rclone_to_nfs",
+        "rclone_to_local_fs",
+        "nfs_to_s3",
+        "nfs_to_rclone",
+        "nfs_to_nfs",
+        "nfs_to_local_fs",
+        "local_fs_to_s3",
+        "local_fs_to_rclone",
+        "local_fs_to_nfs",
+        "local_fs_to_local_fs",
+    ],
+)
+@pytest.mark.django_db
+def test_deleting_replica_keeps_original_aip(
+    startup: None,
+    admin_client: DjangoTestClient,
+    working_directory_path: Path,
+    s3_browse_bucket: str,
+    s3_resource: S3ServiceResource,
+    pkg: Path,
+    compressed: bool,
+    storage_protocol: str,
+    replication_protocol: str,
+) -> None:
+    # Store the AIP through the shared scenario setup, creating its replica too.
+    scenario = AIPDeletionScenario(
+        storage_protocol=storage_protocol,
+        replication_protocol=replication_protocol,
+        pkg=pkg,
+        compressed=compressed,
+    )
+    scenario.init(
+        admin_client,
+        working_directory_path,
+        s3_bucket=s3_browse_bucket,
+    )
+    scenario.store_aip()
+    scenario.assert_stored()
+
+    aip = Package.objects.get(uuid=scenario.PACKAGE_UUID)
+    replica = Package.objects.get(replicated_package=aip.uuid)
+    aip_full_path = str(aip.full_path)
+    replica_full_path = str(replica.full_path)
+
+    # Confirm both packages exist, are uploaded, and are in the expected spaces.
+    assert aip.status == Package.UPLOADED
+    assert replica.status == Package.UPLOADED
+    assert aip.current_location.space.access_protocol == storage_protocol
+    assert replica.current_location.space.access_protocol == replication_protocol
+    assert_package_content_exists(
+        storage_protocol, aip_full_path, s3_browse_bucket, s3_resource
+    )
+    assert_package_content_exists(
+        replication_protocol, replica_full_path, s3_browse_bucket, s3_resource
+    )
+
+    # Compressed replicas create their own pointer file.
+    if compressed:
+        assert replica.pointer_file_location is not None
+        assert replica.pointer_file_path is not None
+        assert str(replica.uuid) in replica.pointer_file_path
+        assert replica.full_pointer_file_path != aip.full_pointer_file_path
+        assert Path(replica.full_pointer_file_path).exists()
+
+    # Delete only the replica through the package deletion request/review flow.
+    scenario.delete_package(replica.uuid, replication_protocol)
+
+    # The replica is gone, while the original AIP remains uploaded and readable.
+    aip.refresh_from_db()
+    replica.refresh_from_db()
+    assert aip.status == Package.UPLOADED
+    assert replica.status == Package.DELETED
+    assert_package_content_exists(
+        storage_protocol, aip_full_path, s3_browse_bucket, s3_resource
+    )
+    assert_package_content_deleted(
+        replication_protocol, replica_full_path, s3_browse_bucket, s3_resource
+    )
+
+    # Only the original remains uploaded; no uploaded replica points at it.
+    assert Package.objects.filter(status=Package.UPLOADED).count() == 1
+    assert (
+        Package.objects.filter(
+            replicated_package=aip.uuid, status=Package.UPLOADED
+        ).count()
+        == 0
+    )
+
+    # Extract the original AIP's METS file through the API after replica deletion.
+    resp = scenario.client.extract_file(
+        aip.uuid, {"relative_path_to_file": scenario.aip_mets_relative_path()}
+    )
+    assert resp.status_code == 200
+    assert isinstance(resp, StreamingHttpResponse)
+    assert b"<mets:mets" in b"".join(resp.streaming_content)
 
 
 @pytest.fixture


### PR DESCRIPTION
During replication, the `Package` model calculates the replica
validation checksum through `self.get_local_path()`. That only works
when the main package is locally accessible; for remote storage, the
replica package content is already available in the destination
space's staging path instead.

This change uses the staged replica path for checksum validation, and
makes pointer lookup depend on the package's saved pointer location
and path. This avoids treating a remote AIP object key as a missing
local file when reading an existing internal pointer XML.

Connected to https://github.com/archivematica/Issues/issues/1796
Connected to https://github.com/archivematica/Issues/issues/1342