### PR TITLE
Set UTC as default timezone

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -90,7 +90,7 @@ of these settings or provide values to mandatory fields.
 - **`TIME_ZONE`**:
   - **Description:** application time zone. See [TIME_ZONE] for more details.
   - **Type:** `string`
-  - **Default:** `"America/Los_Angeles"`
+  - **Default:** `"UTC"`
 
 - **`SECRET_KEY`**:
   - **Description:** a secret key used for cryptographic signing. See [SECRET_KEY]

--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -74,7 +74,7 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # ######## GENERAL CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#time-zone
-TIME_ZONE = environ.get("TIME_ZONE", "America/Los_Angeles")
+TIME_ZONE = environ.get("TIME_ZONE", "UTC")
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#language-code
 LANGUAGE_CODE = "en-us"


### PR DESCRIPTION
The current value of `America/Los_Angeles` is a historical artifact[1] from old Django versions, and new templates default to UTC.

Keeping the current default is causing the storage service to display times in the web UI and in log messages using a timezone that is different from the other AM components (they are already using UTC by default) and also different from the system's timezone, which is very confusing for users (and sysadmins!)

Since the `USE_TZ` setting is set to `True` by default, all the datetime objects are timezone-aware and so this change should not cause any issues with existing data.

[1]: https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-TIME_ZONE