### PR TITLE
Limit rsync execution time

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -217,6 +217,18 @@ of these settings or provide values to mandatory fields.
   - **Type:** `boolean`
   - **Default:** `false`
 
+- **`SS_RSYNC_IO_TIMEOUT_SECONDS`**:
+  - **Description:** maximum number of seconds rsync may observe no I/O before
+    failing a transfer. This does not limit total transfer duration.
+  - **Type:** `integer`
+  - **Default:** `300`
+
+- **`SS_RSYNC_PROCESS_TIMEOUT_SECONDS`**:
+  - **Description:** maximum wall-clock runtime for an rsync process before
+    Storage Service terminates it.
+  - **Type:** `integer`
+  - **Default:** `86400`
+
 - **`SS_S3_TIMEOUTS`**:
   - **Description:** read and connect timeouts for S3 matching your
     implementation's recommended defaults.

--- a/src/archivematica/storage_service/common/rsync.py
+++ b/src/archivematica/storage_service/common/rsync.py
@@ -1,0 +1,174 @@
+"""Run rsync commands with Storage Service failure boundaries.
+
+The storage models build the rsync command line because they know the source,
+destination, transport style, and permission flags needed for each move. This
+module owns the process-running policy shared by those callers: bound captured
+output, enforce a maximum wall-clock runtime, and clean up the whole process
+group when rsync does not exit on its own.
+
+Rsync also receives ``--timeout`` from callers using
+``settings.RSYNC_IO_TIMEOUT_SECONDS``. That is rsync's idle I/O timeout, not a
+total runtime limit. The runner's wall-clock timeout is a separate safety net
+so a transfer that keeps producing some output cannot keep an API request or
+worker alive forever.
+"""
+
+import logging
+import os
+import selectors
+import signal
+import subprocess
+import time
+from collections.abc import Mapping
+from collections.abc import Sequence
+from typing import IO
+from typing import cast
+
+from django.conf import settings
+
+LOGGER = logging.getLogger(__name__)
+
+__all__ = ("RsyncError", "run_rsync")
+
+# Keep enough stderr/stdout for diagnosis without holding unbounded output.
+RSYNC_OUTPUT_LIMIT_BYTES = 65536
+
+# Give rsync a short window to handle SIGTERM before forcing SIGKILL.
+RSYNC_TERMINATE_GRACE_SECONDS = 10
+
+
+class RsyncError(Exception):
+    """Raised when rsync exits unsuccessfully or exceeds runtime limits."""
+
+
+class _BoundedOutput:
+    """Collect only the tail of process output for failure diagnostics."""
+
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        self.output = bytearray()
+        self.truncated = False
+
+    def append(self, chunk: bytes) -> None:
+        """Append output while keeping the buffer within its byte limit."""
+        self.output.extend(chunk)
+        if len(self.output) > self.limit:
+            del self.output[: len(self.output) - self.limit]
+            self.truncated = True
+
+    def text(self) -> str:
+        """Return decoded buffered output, noting when earlier output was cut."""
+        result = self.output.decode(errors="replace")
+        if self.truncated:
+            return f"[output truncated to last {self.limit} bytes]\n{result}"
+        return result
+
+
+def _kill_process_group(process: subprocess.Popen[bytes]) -> None:
+    """Terminate an rsync process group, escalating to SIGKILL if needed."""
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=RSYNC_TERMINATE_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        process.wait()
+
+
+def _drain_output(fileobj: IO[bytes], output: _BoundedOutput) -> bool:
+    """Read currently available output and report whether EOF was reached."""
+    while True:
+        try:
+            chunk = os.read(fileobj.fileno(), 8192)
+        except BlockingIOError:
+            return False
+        if not chunk:
+            return True
+        output.append(chunk)
+
+
+def _communicate_with_timeout(
+    process: subprocess.Popen[bytes], timeout: float
+) -> tuple[str, float]:
+    """Collect process output while enforcing a wall-clock timeout."""
+    output = _BoundedOutput(RSYNC_OUTPUT_LIMIT_BYTES)
+    started = time.monotonic()
+
+    if process.stdout is None:
+        process.wait(timeout=timeout)
+        return "", time.monotonic() - started
+
+    os.set_blocking(process.stdout.fileno(), False)
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ)
+
+    try:
+        while process.poll() is None:
+            elapsed = time.monotonic() - started
+            if elapsed >= timeout:
+                _kill_process_group(process)
+                _drain_output(process.stdout, output)
+                raise TimeoutError(output.text())
+
+            for key, _ in selector.select(timeout=min(1.0, timeout - elapsed)):
+                fileobj = cast(IO[bytes], key.fileobj)
+                if _drain_output(fileobj, output):
+                    selector.unregister(fileobj)
+                    remaining = timeout - (time.monotonic() - started)
+                    try:
+                        process.wait(timeout=max(0, remaining))
+                    except subprocess.TimeoutExpired:
+                        _kill_process_group(process)
+                        raise TimeoutError(output.text())
+                    return output.text(), time.monotonic() - started
+
+        _drain_output(process.stdout, output)
+        return output.text(), time.monotonic() - started
+    finally:
+        selector.close()
+
+
+def run_rsync(
+    command: Sequence[str],
+    env: Mapping[str, str] | None = None,
+    source: str | None = None,
+    destination: str | None = None,
+) -> None:
+    """Run rsync with bounded output capture and process-group cleanup."""
+    LOGGER.debug("rsync command: %s", command)
+    source_label = source or "<unknown source>"
+    destination_label = destination or "<unknown destination>"
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        env=env,
+    )
+
+    process_timeout = settings.RSYNC_PROCESS_TIMEOUT_SECONDS
+    try:
+        stdout, _ = _communicate_with_timeout(process, process_timeout)
+    except TimeoutError as err:
+        message = (
+            "Rsync exceeded maximum runtime of "
+            f"{process_timeout} seconds while copying "
+            f"{source_label} to {destination_label}. "
+            f"Last output: {err}"
+        )
+        LOGGER.warning(message)
+        raise RsyncError(message) from err
+
+    if process.returncode != 0:
+        message = (
+            f"Rsync failed with status {process.returncode} while copying "
+            f"{source_label} to {destination_label}. "
+            f"Last output: {stdout}"
+        )
+        LOGGER.warning(message)
+        raise RsyncError(message)

--- a/src/archivematica/storage_service/locations/models/space.py
+++ b/src/archivematica/storage_service/locations/models/space.py
@@ -9,12 +9,15 @@ import subprocess
 import tempfile
 import uuid
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from archivematica.storage_service.common import fields
 from archivematica.storage_service.common import utils
+from archivematica.storage_service.common.rsync import RsyncError
+from archivematica.storage_service.common.rsync import run_rsync
 from archivematica.storage_service.locations.models import StorageException
 
 LOGGER = logging.getLogger(__name__)
@@ -546,8 +549,8 @@ class Space(models.Model):
                     dest_norm,
                 )
 
-        # Rsync file over
-        # TODO Do this asyncronously, with restarting failed attempts
+        # Rsync file over. Keep this call bounded so API users get a terminal
+        # success or failure instead of waiting indefinitely.
         command = [
             "rsync",
             "-t",
@@ -556,19 +559,17 @@ class Space(models.Model):
             "-vv",
             "--chmod=Fug+rw,o-rwx,Dug+rwx,o-rwx",
             "-r",
+            f"--timeout={settings.RSYNC_IO_TIMEOUT_SECONDS}",
             source,
             destination,
         ]
-        LOGGER.info("rsync command: %s", command)
-        kwargs = {"stdout": subprocess.PIPE, "stderr": subprocess.STDOUT}
+        env = None
         if assume_rsync_daemon:
-            kwargs["env"] = {"RSYNC_PASSWORD": rsync_password}
-        p = subprocess.Popen(command, **kwargs)
-        stdout, _ = p.communicate()
-        if p.returncode != 0:
-            s = f"Rsync failed with status {p.returncode}: {stdout}"
-            LOGGER.warning(s)
-            raise StorageException(s)
+            env = {"RSYNC_PASSWORD": rsync_password}
+        try:
+            run_rsync(command, env=env, source=source, destination=destination)
+        except RsyncError as err:
+            raise StorageException(str(err)) from err
 
     def create_local_directory(self, path, mode=None):
         """

--- a/src/archivematica/storage_service/storage_service/settings/base.py
+++ b/src/archivematica/storage_service/storage_service/settings/base.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _
 
 from archivematica.storage_service.common.helpers import get_oidc_secondary_providers
 from archivematica.storage_service.common.helpers import is_true
+from archivematica.storage_service.storage_service.settings.components.rsync import *
 from archivematica.storage_service.storage_service.settings.components.s3 import *
 
 try:

--- a/src/archivematica/storage_service/storage_service/settings/components/rsync.py
+++ b/src/archivematica/storage_service/storage_service/settings/components/rsync.py
@@ -1,0 +1,30 @@
+"""Configure rsync subprocess boundaries."""
+
+from os import environ
+
+from django.core.exceptions import ImproperlyConfigured
+
+# Fail rsync when it observes no I/O for this many seconds. This does not limit
+# total transfer duration; large copies can run longer while making progress.
+RSYNC_IO_TIMEOUT_SECONDS = 300
+try:
+    RSYNC_IO_TIMEOUT_SECONDS = int(
+        environ.get("SS_RSYNC_IO_TIMEOUT_SECONDS", RSYNC_IO_TIMEOUT_SECONDS)
+    )
+except ValueError:
+    raise ImproperlyConfigured(
+        "Rsync I/O timeout configured incorrectly in the environment - "
+        "please check the 'SS_RSYNC_IO_TIMEOUT_SECONDS' variable"
+    )
+
+# Safety net for rsync processes that keep doing some I/O but never finish.
+RSYNC_PROCESS_TIMEOUT_SECONDS = 86400
+try:
+    RSYNC_PROCESS_TIMEOUT_SECONDS = int(
+        environ.get("SS_RSYNC_PROCESS_TIMEOUT_SECONDS", RSYNC_PROCESS_TIMEOUT_SECONDS)
+    )
+except ValueError:
+    raise ImproperlyConfigured(
+        "Rsync process timeout configured incorrectly in the environment - "
+        "please check the 'SS_RSYNC_PROCESS_TIMEOUT_SECONDS' variable"
+    )

--- a/tests/common/test_rsync.py
+++ b/tests/common/test_rsync.py
@@ -1,0 +1,69 @@
+import os
+from unittest import mock
+
+import pytest
+
+from archivematica.storage_service.common import rsync as rsync_module
+
+
+class FakeProcess:
+    def __init__(self, stdout, returncode=None):
+        self.stdout = stdout
+        self.returncode = returncode
+        self.pid = 999999
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        self.returncode = -15
+        return self.returncode
+
+
+def _pipe_with_output(output=b"", keep_writer_open=False):
+    read_fd, write_fd = os.pipe()
+    if output:
+        os.write(write_fd, output)
+    if not keep_writer_open:
+        os.close(write_fd)
+        write_fd = None
+    return os.fdopen(read_fd, "rb", buffering=0), write_fd
+
+
+@mock.patch("subprocess.Popen")
+def test_run_rsync_raises_rsync_error_on_nonzero_exit(popen):
+    stdout, _ = _pipe_with_output(b"rsync error")
+    popen.return_value = FakeProcess(stdout, returncode=23)
+
+    with pytest.raises(rsync_module.RsyncError, match="Rsync failed with status 23"):
+        rsync_module.run_rsync(["rsync"], source="source", destination="destination")
+
+
+@mock.patch("subprocess.Popen")
+def test_run_rsync_keeps_bounded_error_output(popen, monkeypatch):
+    monkeypatch.setattr(rsync_module, "RSYNC_OUTPUT_LIMIT_BYTES", 10)
+    stdout, _ = _pipe_with_output(b"0123456789abcdef")
+    popen.return_value = FakeProcess(stdout, returncode=23)
+
+    with pytest.raises(rsync_module.RsyncError) as exc:
+        rsync_module.run_rsync(["rsync"], source="source", destination="destination")
+
+    message = str(exc.value)
+    assert "output truncated to last 10 bytes" in message
+    assert "6789abcdef" in message
+    assert "012345" not in message
+
+
+@mock.patch("archivematica.storage_service.common.rsync._kill_process_group")
+@mock.patch("subprocess.Popen")
+def test_run_rsync_times_out_and_kills_process(popen, kill_process_group, settings):
+    settings.RSYNC_PROCESS_TIMEOUT_SECONDS = 0.01
+    stdout, write_fd = _pipe_with_output(keep_writer_open=True)
+    process = FakeProcess(stdout, returncode=None)
+    popen.return_value = process
+
+    with pytest.raises(rsync_module.RsyncError, match="exceeded maximum runtime"):
+        rsync_module.run_rsync(["rsync"], source="source", destination="destination")
+
+    kill_process_group.assert_called_once_with(process)
+    os.close(write_fd)

--- a/tests/locations/test_space.py
+++ b/tests/locations/test_space.py
@@ -1,14 +1,15 @@
 import os.path
 import shutil
-import subprocess
 from os import makedirs
 from os import scandir
 from unittest import mock
 
 import pytest
 
+from archivematica.storage_service.common.rsync import RsyncError
 from archivematica.storage_service.locations.models import LocalFilesystem
 from archivematica.storage_service.locations.models import Space
+from archivematica.storage_service.locations.models import StorageException
 from archivematica.storage_service.locations.models.space import path2browse_dict
 
 
@@ -521,17 +522,13 @@ def test_delete_non_existant_path_local(tmpdir, aipstore_uncompressed):
         assert os.path.exists(remaining_aip)
 
 
-@mock.patch(
-    "subprocess.Popen",
-    return_value=mock.Mock(
-        **{"communicate.return_value": ("command output", None), "returncode": 0}
-    ),
-)
-def test_move_rsync_command_decodes_paths(popen):
+@mock.patch("archivematica.storage_service.locations.models.space.run_rsync")
+def test_move_rsync_command_decodes_paths(run_rsync, settings):
+    settings.RSYNC_IO_TIMEOUT_SECONDS = 42
     space = Space()
     space.move_rsync("source_dir", "destination_dir")
 
-    popen.assert_called_once_with(
+    run_rsync.assert_called_once_with(
         [
             "rsync",
             "-t",
@@ -540,12 +537,38 @@ def test_move_rsync_command_decodes_paths(popen):
             "-vv",
             "--chmod=Fug+rw,o-rwx,Dug+rwx,o-rwx",
             "-r",
+            "--timeout=42",
             "source_dir",
             "destination_dir",
         ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        env=None,
+        source="source_dir",
+        destination="destination_dir",
     )
+
+
+@mock.patch("archivematica.storage_service.locations.models.space.run_rsync")
+def test_move_rsync_maps_rsync_error_to_storage_exception(run_rsync):
+    run_rsync.side_effect = RsyncError("rsync failed")
+
+    with pytest.raises(StorageException, match="rsync failed"):
+        Space().move_rsync("source_dir", "destination_dir")
+
+
+@mock.patch("archivematica.storage_service.locations.models.space.run_rsync")
+@mock.patch("subprocess.call")
+@mock.patch("os.rename")
+def test_move_rsync_try_mv_local_returns_after_successful_rename(
+    rename, subprocess_call, run_rsync
+):
+    space = Space()
+    space.move_rsync("source_dir", "destination_dir", try_mv_local=True)
+
+    rename.assert_called_once_with("source_dir", "destination_dir")
+    subprocess_call.assert_called_once_with(
+        ["chmod", "--recursive", "ug+rw,o+r", "destination_dir"]
+    )
+    run_rsync.assert_not_called()
 
 
 @mock.patch("tempfile.mkdtemp")


### PR DESCRIPTION
Move rsync subprocess handling into a top-level Storage Service module. This keeps Space.move_rsync focused on building the command and passing copy context to the runner.

Add an rsync I/O timeout of 300 seconds. This makes stalled transfers fail when rsync observes no input or output activity, while still allowing large transfers to continue as long as they keep making progress.

Keep a 24 hour wall-clock timeout as a final cleanup guard for rsync processes that continue producing output but never finish. Run rsync in its own process group so timeout handling can terminate rsync and child processes together.

Capture stdout and stderr through a bounded buffer and include the retained output in StorageException messages. This gives synchronous API callers a terminal failure and lets asynchronous callers record the task as errored.

Add focused unit tests for command construction, non-zero rsync exits, bounded output capture, and timeout cleanup.

Fixes https://github.com/archivematica/Issues/issues/1800.