### PR TITLE
Replace MinIO with SeaweedFS in integration tests

### DIFF
--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -32,11 +32,11 @@ services:
       SESSION_COOKIE_SAMESITE: "Lax"
       CSRF_COOKIE_SECURE: "false"
       RCLONE_CONFIG_MYS3_TYPE: "s3"
-      RCLONE_CONFIG_MYS3_PROVIDER: "Minio"
-      RCLONE_CONFIG_MYS3_ENDPOINT: "http://minio:9000"
-      RCLONE_CONFIG_MYS3_ACCESS_KEY_ID: "minio"
-      RCLONE_CONFIG_MYS3_SECRET_ACCESS_KEY: "minio123"
-      RCLONE_CONFIG_MYS3_REGION: "planet-earth"
+      RCLONE_CONFIG_MYS3_PROVIDER: "SeaweedFS"
+      RCLONE_CONFIG_MYS3_ENDPOINT: "http://seaweedfs:8333"
+      RCLONE_CONFIG_MYS3_ACCESS_KEY_ID: "ss"
+      RCLONE_CONFIG_MYS3_SECRET_ACCESS_KEY: "ss123"
+      RCLONE_CONFIG_MYS3_REGION: "us-east-1"
       SS_OIDC_AUTHENTICATION: "true"
       OIDC_USE_PKCE: "true"
       OIDC_PKCE_CODE_CHALLENGE_METHOD: "S256"
@@ -77,55 +77,66 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-      minio-setup:
+      seaweedfs:
+        condition: service_healthy
+      seaweedfs-setup:
         condition: service_completed_successfully
     links:
-      - "minio"
+      - "seaweedfs"
       - "mysql"
       - "keycloak"
 
-  minio:
-    image: "minio/minio:RELEASE.2025-09-07T16-13-09Z"
-    command: "server /data"
+  seaweedfs:
+    image: "chrislusf/seaweedfs:4.38"
+    command: ["mini", "-dir=/data"]
     environment:
-      MINIO_ROOT_USER: "minio"
-      MINIO_ROOT_PASSWORD: "minio123"
-      MINIO_REGION_NAME: "planet-earth"
-      MINIO_BROWSER: "off"
+      WEED_ADMIN_USER: "admin"
+      WEED_ADMIN_PASSWORD: "admin123"
     expose:
-      - "9000"
+      - "8333"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:9000/minio/health/ready"]
+      test:
+        [
+          "CMD-SHELL",
+          "test \"$$(curl -sS --max-time 2 -o /dev/null -w '%{http_code}' http://localhost:8333/ || true)\" = \"403\"",
+        ]
       interval: 5s
       timeout: 5s
       retries: 5
       start_period: 5s
+    volumes:
+      - "./etc/seaweedfs:/config:ro"
 
-  minio-setup:
-    image: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+  seaweedfs-setup:
+    image: "chrislusf/seaweedfs:4.38"
     entrypoint: []
     command:
       - "/bin/sh"
       - "-c"
       - |
-        set -e
-        until mc alias set minio http://minio:9000 minio minio123 >/dev/null 2>&1; do
+        set -eu
+        while :; do
+          output=$(
+            weed shell -master=seaweedfs:9333 -filer=seaweedfs:8888 2>&1 <<'EOF' || true
+        s3.iam.import -file=/config/iam.json -apply
+        s3.policy -put -name=AdminAccess -file=/config/policies/admin-access.json
+        s3.policy -put -name=BrowseBuckets -file=/config/policies/browse-buckets.json
+        s3.config.show
+        EOF
+          )
+          printf '%s\n' "$$output"
+
+          if ! printf '%s\n' "$$output" | grep -qi '^error:'; then
+            break
+          fi
+
           sleep 1
         done
-        #
-        # The resource name used in the statement of this policy file
-        # matches the bucket naming convention of the s3_browse_bucket fixture.
-        #
-        mc admin policy info minio ss-user >/dev/null 2>&1 || mc admin policy create minio ss-user /config/policies/user.json
-        if ! mc admin user info minio minio-user >/dev/null 2>&1; then
-          mc admin user add minio minio-user minio-password
-        fi
-        mc admin policy attach minio ss-user --user minio-user
     depends_on:
-      minio:
-        condition: service_healthy
+      seaweedfs:
+        condition: service_started
     volumes:
-      - "./etc/minio:/config:ro"
+      - "./etc/seaweedfs:/config:ro"
 
   mysql:
     image: "percona/percona-server:8.4.10-10"

--- a/tests/integration/etc/seaweedfs/iam.json
+++ b/tests/integration/etc/seaweedfs/iam.json
@@ -1,0 +1,30 @@
+{
+  "identities": [
+    {
+      "name": "ss",
+      "credentials": [
+        {
+          "accessKey": "ss",
+          "secretKey": "ss123",
+          "status": "Active"
+        }
+      ],
+      "policyNames": [
+        "AdminAccess"
+      ]
+    },
+    {
+      "name": "limited",
+      "credentials": [
+        {
+          "accessKey": "limited",
+          "secretKey": "limited123",
+          "status": "Active"
+        }
+      ],
+      "policyNames": [
+        "BrowseBuckets"
+      ]
+    }
+  ]
+}

--- a/tests/integration/etc/seaweedfs/policies/admin-access.json
+++ b/tests/integration/etc/seaweedfs/policies/admin-access.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AdminAccess",
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::*",
+        "arn:aws:s3:::*/*"
+      ]
+    }
+  ]
+}

--- a/tests/integration/etc/seaweedfs/policies/browse-buckets.json
+++ b/tests/integration/etc/seaweedfs/policies/browse-buckets.json
@@ -9,7 +9,8 @@
         "s3:ListBucket"
       ],
       "Resource": [
-        "arn:aws:s3:::storage-service-browse-*"
+        "arn:aws:s3:::storage-service-browse-*",
+        "arn:aws:s3:::storage-service-browse-*/*"
       ]
     }
   ]

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -294,10 +294,10 @@ class StorageScenario:
             "access_protocol": Space.S3,
             "path": "",
             "staging_path": "/var/archivematica/sharedDirectory/tmp/s3_staging_path",
-            "endpoint_url": "http://minio:9000",
-            "access_key_id": "minio",
-            "secret_access_key": "minio123",
-            "region": "planet-earth",
+            "endpoint_url": "http://seaweedfs:8333",
+            "access_key_id": "ss",
+            "secret_access_key": "ss123",
+            "region": "us-east-1",
             "bucket": "aip-storage",
         },
         Space.RCLONE: {
@@ -1240,14 +1240,14 @@ def test_aip_recovery_handles_recovery_copy_setup_error(
 
 @pytest.fixture
 def s3_resource(s3_recorded_keys: list[str]) -> S3ServiceResource:
-    """Return a boto3 resource connected to the test MinIO instance."""
+    """Return a boto3 resource connected to the S3-compatible test service."""
     del s3_recorded_keys  # Ensure tracking fixture executes before resource creation.
     return boto3.resource(
         "s3",
-        endpoint_url="http://minio:9000",
-        aws_access_key_id="minio",
-        aws_secret_access_key="minio123",
-        region_name="planet-earth",
+        endpoint_url="http://seaweedfs:8333",
+        aws_access_key_id="ss",
+        aws_secret_access_key="ss123",
+        region_name="us-east-1",
     )
 
 
@@ -1265,7 +1265,6 @@ def _provision_s3_bucket(
         else:
             s3_resource.create_bucket(
                 Bucket=bucket_name,
-                # MinIO accepts non-AWS region names; boto3 stubs restrict this to AWS literals.
                 CreateBucketConfiguration=cast(
                     "CreateBucketConfigurationTypeDef",
                     {"LocationConstraint": region},
@@ -1287,11 +1286,11 @@ def _provision_s3_bucket(
 def s3_browse_bucket(
     request: pytest.FixtureRequest, s3_resource: S3ServiceResource
 ) -> Iterator[str]:
-    """Provision a bucket backed by the MinIO test service."""
+    """Provision a bucket backed by the S3-compatible test service."""
     object_keys = getattr(request, "param", None)
     bucket_name = _provision_s3_bucket(
         s3_resource,
-        region="planet-earth",
+        region="us-east-1",
         name_prefix="storage-service-browse-",
         object_keys=object_keys,
     )
@@ -1352,10 +1351,10 @@ def test_browsing_a_s3_transfer_source_location_loads_path_level_results_only(
             "access_protocol": Space.S3,
             "path": "/",
             "staging_path": "/var/archivematica/storage_service",
-            "endpoint_url": "http://minio:9000",
-            "access_key_id": "minio-user",
-            "secret_access_key": "minio-password",
-            "region": "planet-earth",
+            "endpoint_url": "http://seaweedfs:8333",
+            "access_key_id": "limited",
+            "secret_access_key": "limited123",
+            "region": "us-east-1",
             "bucket": s3_browse_bucket,
         }
     )
@@ -1407,8 +1406,8 @@ def test_browsing_an_rclone_transfer_source_location_works_with_limited_permissi
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("RCLONE_CONFIG_MYS3_ACCESS_KEY_ID", "minio-user")
-    monkeypatch.setenv("RCLONE_CONFIG_MYS3_SECRET_ACCESS_KEY", "minio-password")
+    monkeypatch.setenv("RCLONE_CONFIG_MYS3_ACCESS_KEY_ID", "limited")
+    monkeypatch.setenv("RCLONE_CONFIG_MYS3_SECRET_ACCESS_KEY", "limited123")
 
     client = Client(admin_client)
     shared_directory = tmp_path / "var" / "archivematica" / "sharedDirectory"


### PR DESCRIPTION
Use SeaweedFS as the S3-compatible object store in the integration Compose environment, provisioning IAM-style users and AWS-like S3 policies through the setup service while keeping the existing rclone remote name.