### PR TITLE
Preserve interrupted async operation results

### DIFF
--- a/src/archivematica/storage_service/locations/api/resources.py
+++ b/src/archivematica/storage_service/locations/api/resources.py
@@ -56,6 +56,9 @@ from archivematica.storage_service.locations.models import PosixMoveUnsupportedE
 from archivematica.storage_service.locations.models import Space
 from archivematica.storage_service.locations.models import StorageException
 from archivematica.storage_service.locations.models.async_manager import AsyncManager
+from archivematica.storage_service.locations.models.async_manager import (
+    get_async_error_code,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -2168,6 +2171,7 @@ class AsyncResource(ModelResource):
         if bundle.obj.completed:
             if bundle.obj.was_error:
                 bundle.data["error"] = bundle.obj.error
+                bundle.data["error_code"] = get_async_error_code(bundle.obj._error)
             else:
                 bundle.data["result"] = bundle.obj.result
 

--- a/src/archivematica/storage_service/locations/metrics.py
+++ b/src/archivematica/storage_service/locations/metrics.py
@@ -14,6 +14,11 @@ async_manager_watchdog_time_counter = Counter(
     ("Total time taken by a watchdog loop iteration in seconds"),
 )
 
+async_manager_interrupted_tasks_counter = Counter(
+    "async_manager_interrupted_tasks",
+    "Number of tasks marked as interrupted after their heartbeat expired",
+)
+
 
 @contextmanager
 def watchdog_loop_timer():

--- a/src/archivematica/storage_service/locations/models/async_manager.py
+++ b/src/archivematica/storage_service/locations/models/async_manager.py
@@ -15,6 +15,7 @@ import threading
 import time
 import traceback
 
+from django.db import transaction
 from django.utils import timezone
 
 from archivematica.storage_service.locations import metrics
@@ -86,35 +87,6 @@ class AsyncManager:
         with AsyncManager.lock:
             now = timezone.now()
 
-            # Mark any tasks that have expired before finishing as interrupted
-            # (i.e. interrupted due to a server restart)
-            Async.objects.filter(
-                completed=False,
-                updated_time__lte=(now - TASK_TIMEOUT_SECONDS),
-            ).update(
-                completed=True,
-                was_error=True,
-                completed_time=now,
-                updated_time=now,
-                _error=INTERRUPTED_TASK_ERROR,
-            )
-
-            # Delete any tasks whose results have expired
-            Async.objects.filter(
-                completed=True,
-                completed_time__lte=(now - MAX_TASK_AGE_SECONDS),
-            ).delete()
-
-            # Touch the update time of any running task.  If we crash/restart then these will expire.
-            running_task_ids = [
-                task.async_id
-                for task in AsyncManager.running_tasks
-                if task.thread.is_alive()
-            ]
-            Async.objects.filter(id__in=running_task_ids).update(
-                updated_time=timezone.now()
-            )
-
             # Find any tasks that have completed since we last looked
             completed_tasks = [
                 task
@@ -127,17 +99,23 @@ class AsyncManager:
                 metrics.async_manager_running_tasks.dec()
 
                 try:
-                    async_task = Async.objects.get(id=task.async_id)
-                    async_task.completed = True
-                    async_task.completed_time = timezone.now()
-                    async_task.was_error = task.was_error
+                    with transaction.atomic():
+                        async_task = Async.objects.select_for_update().get(
+                            id=task.async_id
+                        )
+                        if async_task.completed:
+                            continue
 
-                    if task.was_error:
-                        async_task.error = task.error
-                    else:
-                        async_task.result = task.result
+                        async_task.completed = True
+                        async_task.completed_time = now
+                        async_task.was_error = task.was_error
 
-                    async_task.save()
+                        if task.was_error:
+                            async_task.error = task.error
+                        else:
+                            async_task.result = task.result
+
+                        async_task.save()
                 except Async.DoesNotExist:
                     # This generally shouldn't happen, but if it does that
                     # would suggest that the watchdog had failed to update
@@ -146,6 +124,33 @@ class AsyncManager:
                         "Watchdog attempted to update Async object %d but couldn't find it!"
                         % (task.async_id)
                     )
+
+            # Touch the update time of any running task. If we crash or restart,
+            # these tasks will expire.
+            running_task_ids = [task.async_id for task in AsyncManager.running_tasks]
+            Async.objects.filter(
+                id__in=running_task_ids,
+                completed=False,
+            ).update(updated_time=now)
+
+            # Mark any tasks that have expired before finishing as interrupted
+            # (i.e. interrupted due to a server restart).
+            Async.objects.filter(
+                completed=False,
+                updated_time__lte=(now - TASK_TIMEOUT_SECONDS),
+            ).update(
+                completed=True,
+                was_error=True,
+                completed_time=now,
+                updated_time=now,
+                _error=INTERRUPTED_TASK_ERROR,
+            )
+
+            # Delete any tasks whose results have expired.
+            Async.objects.filter(
+                completed=True,
+                completed_time__lte=(now - MAX_TASK_AGE_SECONDS),
+            ).delete()
 
     @staticmethod
     def _wrap_task(task, task_fn):

--- a/src/archivematica/storage_service/locations/models/async_manager.py
+++ b/src/archivematica/storage_service/locations/models/async_manager.py
@@ -135,16 +135,35 @@ class AsyncManager:
 
             # Mark any tasks that have expired before finishing as interrupted
             # (i.e. interrupted due to a server restart).
-            Async.objects.filter(
+            expired_tasks = Async.objects.filter(
                 completed=False,
                 updated_time__lte=(now - TASK_TIMEOUT_SECONDS),
-            ).update(
-                completed=True,
-                was_error=True,
-                completed_time=now,
-                updated_time=now,
-                _error=INTERRUPTED_TASK_ERROR,
             )
+            expired_task_ids = list(expired_tasks.values_list("id", flat=True))
+            if expired_task_ids:
+                interrupted_count = expired_tasks.update(
+                    completed=True,
+                    was_error=True,
+                    completed_time=now,
+                    updated_time=now,
+                    _error=INTERRUPTED_TASK_ERROR,
+                )
+                if interrupted_count:
+                    interrupted_task_ids = Async.objects.filter(
+                        id__in=expired_task_ids,
+                        completed=True,
+                        was_error=True,
+                        completed_time=now,
+                    ).values_list("id", flat=True)
+                    metrics.async_manager_interrupted_tasks_counter.inc(
+                        interrupted_count
+                    )
+                    LOGGER.warning(
+                        "Marked %d asynchronous task(s) as interrupted after their "
+                        "heartbeat expired: %s",
+                        interrupted_count,
+                        ", ".join(str(task_id) for task_id in interrupted_task_ids),
+                    )
 
             # Delete any tasks whose results have expired.
             Async.objects.filter(

--- a/src/archivematica/storage_service/locations/models/async_manager.py
+++ b/src/archivematica/storage_service/locations/models/async_manager.py
@@ -19,6 +19,7 @@ from django.utils import timezone
 
 from archivematica.storage_service.locations import metrics
 from archivematica.storage_service.locations.models.asynchronous import Async
+from archivematica.storage_service.locations.models.asynchronous import serialize_error
 
 LOGGER = logging.getLogger(__name__)
 
@@ -35,6 +36,23 @@ MAX_TASK_AGE_SECONDS = datetime.timedelta(seconds=86400)
 # Must be less than TASK_TIMEOUT_SECONDS!  Controls how often we wake up to
 # check the status of our tasks.
 WATCHDOG_POLL_SECONDS = 5
+
+INTERRUPTED_TASK_ERROR_CODE = "async_operation_interrupted"
+INTERRUPTED_TASK_ERROR = serialize_error(
+    RuntimeError(
+        "The asynchronous operation was interrupted after its heartbeat expired. "
+        "Its final outcome is unknown; do not retry it automatically."
+    )
+)
+
+
+def get_async_error_code(error: bytes | memoryview | None) -> str | None:
+    """Return the stable API code for a recognized asynchronous error."""
+    if isinstance(error, memoryview):
+        error = error.tobytes()
+    if error == INTERRUPTED_TASK_ERROR:
+        return INTERRUPTED_TASK_ERROR_CODE
+    return None
 
 
 class RunningTask:
@@ -66,17 +84,25 @@ class AsyncManager:
         """Wake up, expire old tasks, report completed tasks and give a sign of
         life for everything that's still running"""
         with AsyncManager.lock:
-            # Delete any tasks that have expired before finishing
+            now = timezone.now()
+
+            # Mark any tasks that have expired before finishing as interrupted
             # (i.e. interrupted due to a server restart)
             Async.objects.filter(
                 completed=False,
-                updated_time__lte=(timezone.now() - TASK_TIMEOUT_SECONDS),
-            ).delete()
+                updated_time__lte=(now - TASK_TIMEOUT_SECONDS),
+            ).update(
+                completed=True,
+                was_error=True,
+                completed_time=now,
+                updated_time=now,
+                _error=INTERRUPTED_TASK_ERROR,
+            )
 
             # Delete any tasks whose results have expired
             Async.objects.filter(
                 completed=True,
-                completed_time__lte=(timezone.now() - MAX_TASK_AGE_SECONDS),
+                completed_time__lte=(now - MAX_TASK_AGE_SECONDS),
             ).delete()
 
             # Touch the update time of any running task.  If we crash/restart then these will expire.

--- a/src/archivematica/storage_service/locations/models/asynchronous.py
+++ b/src/archivematica/storage_service/locations/models/asynchronous.py
@@ -9,6 +9,10 @@ __all__ = ("Async",)
 LOGGER = logging.getLogger(__name__)
 
 
+def serialize_error(value):
+    return pickle.dumps(str(type(value)) + ": " + str(value))
+
+
 class Async(models.Model):
     """Stores information about currently running asynchronous tasks."""
 
@@ -52,7 +56,7 @@ class Async(models.Model):
 
     @error.setter
     def error(self, value):
-        self._error = pickle.dumps(str(type(value)) + ": " + str(value))
+        self._error = serialize_error(value)
 
     class Meta:
         verbose_name = _("Async")

--- a/tests/locations/test_async_manager.py
+++ b/tests/locations/test_async_manager.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import pickle
 from unittest import mock
 
@@ -8,9 +9,6 @@ from django.urls import reverse
 from django.utils import timezone
 
 from archivematica.storage_service.locations import metrics
-from archivematica.storage_service.locations.models.asynchronous import Async
-from archivematica.storage_service.locations.models.asynchronous import serialize_error
-from archivematica.storage_service.locations.models.async_manager import AsyncManager
 from archivematica.storage_service.locations.models.async_manager import (
     INTERRUPTED_TASK_ERROR_CODE,
 )
@@ -20,7 +18,10 @@ from archivematica.storage_service.locations.models.async_manager import (
 from archivematica.storage_service.locations.models.async_manager import (
     TASK_TIMEOUT_SECONDS,
 )
+from archivematica.storage_service.locations.models.async_manager import AsyncManager
 from archivematica.storage_service.locations.models.async_manager import RunningTask
+from archivematica.storage_service.locations.models.asynchronous import Async
+from archivematica.storage_service.locations.models.asynchronous import serialize_error
 
 
 @pytest.fixture(autouse=True)
@@ -152,11 +153,7 @@ def test_watchdog_records_local_completion_before_expiring() -> None:
 @pytest.mark.django_db
 def test_watchdog_heartbeats_local_task_before_expiring() -> None:
     async_task = Async.objects.create()
-    expired_time = (
-        timezone.now()
-        - TASK_TIMEOUT_SECONDS
-        - datetime.timedelta(seconds=1)
-    )
+    expired_time = timezone.now() - TASK_TIMEOUT_SECONDS - datetime.timedelta(seconds=1)
     Async.objects.filter(pk=async_task.pk).update(updated_time=expired_time)
     running_task = RunningTask()
     running_task.async_id = async_task.pk
@@ -223,3 +220,27 @@ def test_watchdog_does_not_overwrite_terminal_result() -> None:
     assert async_task.was_error is True
     assert async_task.error == "<class 'RuntimeError'>: Interrupted"
     assert async_task._result is None
+
+
+@pytest.mark.django_db
+def test_watchdog_reports_interrupted_tasks(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    expired_time = timezone.now() - TASK_TIMEOUT_SECONDS - datetime.timedelta(seconds=1)
+    async_tasks = [Async.objects.create(), Async.objects.create()]
+    Async.objects.filter(pk__in=[task.pk for task in async_tasks]).update(
+        updated_time=expired_time
+    )
+
+    with (
+        mock.patch.object(
+            metrics.async_manager_interrupted_tasks_counter, "inc"
+        ) as increment,
+        caplog.at_level(logging.WARNING),
+    ):
+        AsyncManager._watchdog_loop()
+
+    increment.assert_called_once_with(2)
+    assert "Marked 2 asynchronous task(s) as interrupted" in caplog.text
+    for async_task in async_tasks:
+        assert str(async_task.pk) in caplog.text

--- a/tests/locations/test_async_manager.py
+++ b/tests/locations/test_async_manager.py
@@ -1,11 +1,13 @@
 import datetime
 import pickle
+from unittest import mock
 
 import pytest
 from django.test import Client
 from django.urls import reverse
 from django.utils import timezone
 
+from archivematica.storage_service.locations import metrics
 from archivematica.storage_service.locations.models.asynchronous import Async
 from archivematica.storage_service.locations.models.asynchronous import serialize_error
 from archivematica.storage_service.locations.models.async_manager import AsyncManager
@@ -18,6 +20,7 @@ from archivematica.storage_service.locations.models.async_manager import (
 from archivematica.storage_service.locations.models.async_manager import (
     TASK_TIMEOUT_SECONDS,
 )
+from archivematica.storage_service.locations.models.async_manager import RunningTask
 
 
 @pytest.fixture(autouse=True)
@@ -120,3 +123,103 @@ def test_watchdog_deletes_expired_terminal_result() -> None:
     AsyncManager._watchdog_loop()
 
     assert not Async.objects.filter(pk=async_task.pk).exists()
+
+
+@pytest.mark.django_db
+def test_watchdog_records_local_completion_before_expiring() -> None:
+    async_task = Async.objects.create()
+    Async.objects.filter(pk=async_task.pk).update(
+        updated_time=timezone.now()
+        - TASK_TIMEOUT_SECONDS
+        - datetime.timedelta(seconds=1)
+    )
+    running_task = RunningTask()
+    running_task.async_id = async_task.pk
+    running_task.thread = mock.Mock()
+    running_task.thread.is_alive.return_value = False
+    running_task.result = "Done"
+    AsyncManager.running_tasks = [running_task]
+
+    with mock.patch.object(metrics.async_manager_running_tasks, "dec"):
+        AsyncManager._watchdog_loop()
+
+    async_task.refresh_from_db()
+    assert async_task.completed is True
+    assert async_task.was_error is False
+    assert async_task.result == "Done"
+
+
+@pytest.mark.django_db
+def test_watchdog_heartbeats_local_task_before_expiring() -> None:
+    async_task = Async.objects.create()
+    expired_time = (
+        timezone.now()
+        - TASK_TIMEOUT_SECONDS
+        - datetime.timedelta(seconds=1)
+    )
+    Async.objects.filter(pk=async_task.pk).update(updated_time=expired_time)
+    running_task = RunningTask()
+    running_task.async_id = async_task.pk
+    running_task.thread = mock.Mock()
+    running_task.thread.is_alive.return_value = True
+    AsyncManager.running_tasks = [running_task]
+
+    AsyncManager._watchdog_loop()
+
+    async_task.refresh_from_db()
+    assert async_task.completed is False
+    assert async_task.updated_time > expired_time
+
+
+@pytest.mark.django_db
+def test_watchdog_heartbeats_task_that_finishes_after_liveness_check() -> None:
+    async_task = Async.objects.create()
+    expired_time = timezone.now() - TASK_TIMEOUT_SECONDS - datetime.timedelta(seconds=1)
+    Async.objects.filter(pk=async_task.pk).update(updated_time=expired_time)
+    running_task = RunningTask()
+    running_task.async_id = async_task.pk
+    running_task.thread = mock.Mock()
+    running_task.thread.is_alive.side_effect = [True, False]
+    running_task.result = "Done"
+    AsyncManager.running_tasks = [running_task]
+
+    AsyncManager._watchdog_loop()
+
+    async_task.refresh_from_db()
+    assert running_task.thread.is_alive.call_count == 1
+    assert async_task.completed is False
+    assert async_task.updated_time > expired_time
+
+    with mock.patch.object(metrics.async_manager_running_tasks, "dec"):
+        AsyncManager._watchdog_loop()
+
+    async_task.refresh_from_db()
+    assert async_task.completed is True
+    assert async_task.was_error is False
+    assert async_task.result == "Done"
+
+
+@pytest.mark.django_db
+def test_watchdog_does_not_overwrite_terminal_result() -> None:
+    async_task = Async.objects.create(
+        completed=True,
+        was_error=True,
+        completed_time=timezone.now(),
+    )
+    async_task.error = RuntimeError("Interrupted")
+    async_task.save()
+    running_task = RunningTask()
+    running_task.async_id = async_task.pk
+    running_task.thread = mock.Mock()
+    running_task.thread.is_alive.return_value = False
+    running_task.result = "Late result"
+    AsyncManager.running_tasks = [running_task]
+
+    with mock.patch.object(metrics.async_manager_running_tasks, "dec"):
+        AsyncManager._watchdog_loop()
+
+    async_task.refresh_from_db()
+    assert async_task.completed is True
+    assert async_task.was_error is True
+    assert async_task.error == "<class 'RuntimeError'>: Interrupted"
+    assert async_task._result is None

--- a/tests/locations/test_async_manager.py
+++ b/tests/locations/test_async_manager.py
@@ -1,14 +1,25 @@
 import datetime
 import logging
 import pickle
+import threading
+from collections.abc import Callable
+from collections.abc import Iterator
 from unittest import mock
 
 import pytest
+from django.db import close_old_connections
+from django.db import connection
+from django.db import transaction
+from django.db.backends.utils import CursorWrapper
+from django.db.models.query import QuerySet
 from django.test import Client
 from django.urls import reverse
 from django.utils import timezone
 
 from archivematica.storage_service.locations import metrics
+from archivematica.storage_service.locations.models.async_manager import (
+    INTERRUPTED_TASK_ERROR,
+)
 from archivematica.storage_service.locations.models.async_manager import (
     INTERRUPTED_TASK_ERROR_CODE,
 )
@@ -20,6 +31,9 @@ from archivematica.storage_service.locations.models.async_manager import (
 )
 from archivematica.storage_service.locations.models.async_manager import AsyncManager
 from archivematica.storage_service.locations.models.async_manager import RunningTask
+from archivematica.storage_service.locations.models.async_manager import (
+    get_async_error_code,
+)
 from archivematica.storage_service.locations.models.asynchronous import Async
 from archivematica.storage_service.locations.models.asynchronous import serialize_error
 
@@ -27,6 +41,66 @@ from archivematica.storage_service.locations.models.asynchronous import serializ
 @pytest.fixture(autouse=True)
 def reset_running_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(AsyncManager, "running_tasks", [])
+
+
+def _run_database_thread(
+    function: Callable[[], None],
+    errors: list[BaseException],
+    done: threading.Event,
+) -> None:
+    close_old_connections()
+    try:
+        function()
+    except BaseException as error:
+        errors.append(error)
+    finally:
+        close_old_connections()
+        done.set()
+
+
+def _run_database_operation(function: Callable[[], None]) -> None:
+    errors: list[BaseException] = []
+    done = threading.Event()
+    thread = threading.Thread(
+        target=_run_database_thread,
+        args=(function, errors, done),
+    )
+
+    thread.start()
+    assert done.wait(timeout=10)
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    if errors:
+        raise errors[0]
+
+
+@pytest.fixture
+def committed_expired_async_task() -> Iterator[tuple[int, datetime.datetime]]:
+    """Create committed state visible to independent database connections.
+
+    Avoid ``transaction=True`` so these tests do not flush data migrations when
+    pytest reuses its test database.
+    """
+    if not connection.features.has_select_for_update:
+        pytest.skip("The database backend does not support row-level locks")
+
+    expired_time = timezone.now() - TASK_TIMEOUT_SECONDS - datetime.timedelta(seconds=1)
+    async_task_ids: list[int] = []
+
+    def create_task() -> None:
+        async_task = Async.objects.create()
+        Async.objects.filter(pk=async_task.pk).update(updated_time=expired_time)
+        async_task_ids.append(async_task.pk)
+
+    _run_database_operation(create_task)
+    async_task_id = async_task_ids[0]
+
+    yield async_task_id, expired_time
+
+    def delete_task() -> None:
+        Async.objects.filter(pk=async_task_id).delete()
+
+    _run_database_operation(delete_task)
 
 
 def test_serialize_error_preserves_async_error_format() -> None:
@@ -40,6 +114,17 @@ def test_serialize_error_preserves_async_error_format() -> None:
     async_task.error = error
     assert async_task._error == serialized
     assert async_task.error == "<class 'RuntimeError'>: Something went wrong"
+
+
+@pytest.mark.parametrize(
+    "error",
+    [INTERRUPTED_TASK_ERROR, memoryview(INTERRUPTED_TASK_ERROR)],
+    ids=["bytes", "memoryview"],
+)
+def test_get_async_error_code_recognizes_interrupted_task(
+    error: bytes | memoryview,
+) -> None:
+    assert get_async_error_code(error) == INTERRUPTED_TASK_ERROR_CODE
 
 
 @pytest.mark.django_db
@@ -151,6 +236,32 @@ def test_watchdog_records_local_completion_before_expiring() -> None:
 
 
 @pytest.mark.django_db
+def test_watchdog_records_local_error_before_expiring() -> None:
+    async_task = Async.objects.create()
+    Async.objects.filter(pk=async_task.pk).update(
+        updated_time=timezone.now()
+        - TASK_TIMEOUT_SECONDS
+        - datetime.timedelta(seconds=1)
+    )
+    running_task = RunningTask()
+    running_task.async_id = async_task.pk
+    running_task.thread = mock.Mock()
+    running_task.thread.is_alive.return_value = False
+    running_task.was_error = True
+    running_task.error = RuntimeError("Task failed")
+    AsyncManager.running_tasks = [running_task]
+
+    with mock.patch.object(metrics.async_manager_running_tasks, "dec"):
+        AsyncManager._watchdog_loop()
+
+    async_task.refresh_from_db()
+    assert async_task.completed is True
+    assert async_task.was_error is True
+    assert async_task.error == "<class 'RuntimeError'>: Task failed"
+    assert async_task._result is None
+
+
+@pytest.mark.django_db
 def test_watchdog_heartbeats_local_task_before_expiring() -> None:
     async_task = Async.objects.create()
     expired_time = timezone.now() - TASK_TIMEOUT_SECONDS - datetime.timedelta(seconds=1)
@@ -197,6 +308,41 @@ def test_watchdog_heartbeats_task_that_finishes_after_liveness_check() -> None:
 
 
 @pytest.mark.django_db
+def test_watchdog_does_not_interrupt_task_heartbeated_after_candidate_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_task = Async.objects.create()
+    expired_time = timezone.now() - TASK_TIMEOUT_SECONDS - datetime.timedelta(seconds=1)
+    Async.objects.filter(pk=async_task.pk).update(updated_time=expired_time)
+    original_update = QuerySet.update
+    interruption_attempted = False
+
+    def heartbeat_before_interruption(
+        queryset: QuerySet[Async], **kwargs: object
+    ) -> int:
+        nonlocal interruption_attempted
+        if kwargs.get("_error") == INTERRUPTED_TASK_ERROR:
+            interruption_attempted = True
+            original_update(
+                Async.objects.filter(pk=async_task.pk), updated_time=timezone.now()
+            )
+        return original_update(queryset, **kwargs)
+
+    monkeypatch.setattr(QuerySet, "update", heartbeat_before_interruption)
+
+    with mock.patch.object(
+        metrics.async_manager_interrupted_tasks_counter, "inc"
+    ) as increment:
+        AsyncManager._watchdog_loop()
+
+    async_task.refresh_from_db()
+    assert interruption_attempted is True
+    assert async_task.completed is False
+    assert async_task.updated_time > expired_time
+    increment.assert_not_called()
+
+
+@pytest.mark.django_db
 def test_watchdog_does_not_overwrite_terminal_result() -> None:
     async_task = Async.objects.create(
         completed=True,
@@ -205,6 +351,11 @@ def test_watchdog_does_not_overwrite_terminal_result() -> None:
     )
     async_task.error = RuntimeError("Interrupted")
     async_task.save()
+    Async.objects.filter(pk=async_task.pk).update(
+        updated_time=timezone.now()
+        - TASK_TIMEOUT_SECONDS
+        - datetime.timedelta(seconds=1)
+    )
     running_task = RunningTask()
     running_task.async_id = async_task.pk
     running_task.thread = mock.Mock()
@@ -239,8 +390,197 @@ def test_watchdog_reports_interrupted_tasks(
         caplog.at_level(logging.WARNING),
     ):
         AsyncManager._watchdog_loop()
+        AsyncManager._watchdog_loop()
 
     increment.assert_called_once_with(2)
-    assert "Marked 2 asynchronous task(s) as interrupted" in caplog.text
+    assert caplog.text.count("Marked 2 asynchronous task(s) as interrupted") == 1
     for async_task in async_tasks:
         assert str(async_task.pk) in caplog.text
+
+
+@pytest.mark.django_db
+def test_concurrent_interruption_is_not_replaced_by_late_completion(
+    monkeypatch: pytest.MonkeyPatch,
+    committed_expired_async_task: tuple[int, datetime.datetime],
+) -> None:
+    """An interruption committed first remains the terminal state."""
+    async_task_id, expired_time = committed_expired_async_task
+    running_task = RunningTask()
+    running_task.async_id = async_task_id
+    running_task.thread = mock.Mock()
+    running_task.thread.is_alive.return_value = False
+    running_task.result = "Late result"
+    AsyncManager.running_tasks = [running_task]
+
+    interruption_ready = threading.Event()
+    allow_interruption_commit = threading.Event()
+    completion_select_started = threading.Event()
+    interruption_done = threading.Event()
+    completion_done = threading.Event()
+    errors: list[BaseException] = []
+
+    def interrupt_task() -> None:
+        with transaction.atomic():
+            interrupted_count = Async.objects.filter(
+                pk=async_task_id,
+                completed=False,
+                updated_time__lte=expired_time,
+            ).update(
+                completed=True,
+                was_error=True,
+                completed_time=timezone.now(),
+                updated_time=timezone.now(),
+                _error=INTERRUPTED_TASK_ERROR,
+            )
+            assert interrupted_count == 1
+            interruption_ready.set()
+            assert allow_interruption_commit.wait(timeout=10)
+
+    def complete_task() -> None:
+        AsyncManager._watchdog_loop()
+
+    interruption_thread = threading.Thread(
+        target=_run_database_thread,
+        args=(interrupt_task, errors, interruption_done),
+    )
+    completion_thread = threading.Thread(
+        target=_run_database_thread,
+        args=(complete_task, errors, completion_done),
+    )
+    original_execute = CursorWrapper.execute
+
+    def observe_completion_select(
+        cursor: CursorWrapper, sql: str, params: object = None
+    ) -> object:
+        if (
+            threading.current_thread() is completion_thread
+            and "FOR UPDATE" in sql.upper()
+        ):
+            completion_select_started.set()
+        return original_execute(cursor, sql, params)
+
+    monkeypatch.setattr(CursorWrapper, "execute", observe_completion_select)
+
+    interruption_thread.start()
+    assert interruption_ready.wait(timeout=10)
+    with mock.patch.object(metrics.async_manager_running_tasks, "dec"):
+        completion_thread.start()
+        try:
+            # The completion read must wait for the interruption's row lock.
+            assert completion_select_started.wait(timeout=10)
+            assert not completion_done.wait(timeout=0.1)
+        finally:
+            allow_interruption_commit.set()
+        interruption_thread.join(timeout=10)
+        completion_thread.join(timeout=10)
+
+    assert not interruption_thread.is_alive()
+    assert not completion_thread.is_alive()
+    assert errors == []
+    async_task = Async.objects.get(pk=async_task_id)
+    assert async_task.completed is True
+    assert async_task.was_error is True
+    assert async_task.error == pickle.loads(INTERRUPTED_TASK_ERROR)
+    assert async_task._result is None
+
+
+@pytest.mark.django_db
+def test_concurrent_completion_is_not_replaced_by_interruption(
+    monkeypatch: pytest.MonkeyPatch,
+    committed_expired_async_task: tuple[int, datetime.datetime],
+) -> None:
+    """A completion committed first remains the terminal state."""
+    async_task_id, expired_time = committed_expired_async_task
+    running_task = RunningTask()
+    running_task.async_id = async_task_id
+    running_task.thread = mock.Mock()
+    running_task.thread.is_alive.return_value = False
+    running_task.result = "Completed result"
+    AsyncManager.running_tasks = [running_task]
+
+    completion_saved = threading.Event()
+    allow_completion_commit = threading.Event()
+    interruption_update_started = threading.Event()
+    completion_done = threading.Event()
+    interruption_done = threading.Event()
+    errors: list[BaseException] = []
+    interrupted_counts: list[int] = []
+    original_save = Async.save
+
+    def save_completion_before_commit(
+        instance: Async, *args: object, **kwargs: object
+    ) -> None:
+        original_save(instance, *args, **kwargs)
+        if (
+            threading.current_thread() is completion_thread
+            and instance.pk == async_task_id
+            and instance.completed
+        ):
+            assert connection.in_atomic_block
+            completion_saved.set()
+            assert allow_completion_commit.wait(timeout=10)
+
+    monkeypatch.setattr(Async, "save", save_completion_before_commit)
+
+    def complete_task() -> None:
+        AsyncManager._watchdog_loop()
+
+    def interrupt_task() -> None:
+        interrupted_counts.append(
+            Async.objects.filter(
+                pk=async_task_id,
+                completed=False,
+                updated_time__lte=expired_time,
+            ).update(
+                completed=True,
+                was_error=True,
+                completed_time=timezone.now(),
+                updated_time=timezone.now(),
+                _error=INTERRUPTED_TASK_ERROR,
+            )
+        )
+
+    completion_thread = threading.Thread(
+        target=_run_database_thread,
+        args=(complete_task, errors, completion_done),
+    )
+    interruption_thread = threading.Thread(
+        target=_run_database_thread,
+        args=(interrupt_task, errors, interruption_done),
+    )
+    original_execute = CursorWrapper.execute
+
+    def observe_interruption_update(
+        cursor: CursorWrapper, sql: str, params: object = None
+    ) -> object:
+        if (
+            threading.current_thread() is interruption_thread
+            and sql.lstrip().upper().startswith("UPDATE")
+        ):
+            interruption_update_started.set()
+        return original_execute(cursor, sql, params)
+
+    monkeypatch.setattr(CursorWrapper, "execute", observe_interruption_update)
+
+    with mock.patch.object(metrics.async_manager_running_tasks, "dec"):
+        completion_thread.start()
+        assert completion_saved.wait(timeout=10)
+        interruption_thread.start()
+        try:
+            # The interruption update must wait for the completion's row lock.
+            assert interruption_update_started.wait(timeout=10)
+            assert not interruption_done.wait(timeout=0.1)
+        finally:
+            allow_completion_commit.set()
+        completion_thread.join(timeout=10)
+        interruption_thread.join(timeout=10)
+
+    assert not completion_thread.is_alive()
+    assert not interruption_thread.is_alive()
+    assert errors == []
+    assert interrupted_counts == [0]
+    async_task = Async.objects.get(pk=async_task_id)
+    assert async_task.completed is True
+    assert async_task.was_error is False
+    assert async_task.result == "Completed result"
+    assert async_task._error is None

--- a/tests/locations/test_async_manager.py
+++ b/tests/locations/test_async_manager.py
@@ -1,0 +1,122 @@
+import datetime
+import pickle
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+
+from archivematica.storage_service.locations.models.asynchronous import Async
+from archivematica.storage_service.locations.models.asynchronous import serialize_error
+from archivematica.storage_service.locations.models.async_manager import AsyncManager
+from archivematica.storage_service.locations.models.async_manager import (
+    INTERRUPTED_TASK_ERROR_CODE,
+)
+from archivematica.storage_service.locations.models.async_manager import (
+    MAX_TASK_AGE_SECONDS,
+)
+from archivematica.storage_service.locations.models.async_manager import (
+    TASK_TIMEOUT_SECONDS,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_running_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(AsyncManager, "running_tasks", [])
+
+
+def test_serialize_error_preserves_async_error_format() -> None:
+    error = RuntimeError("Something went wrong")
+
+    serialized = serialize_error(error)
+
+    assert pickle.loads(serialized) == "<class 'RuntimeError'>: Something went wrong"
+
+    async_task = Async()
+    async_task.error = error
+    assert async_task._error == serialized
+    assert async_task.error == "<class 'RuntimeError'>: Something went wrong"
+
+
+@pytest.mark.django_db
+def test_watchdog_marks_expired_task_as_interrupted(admin_client: Client) -> None:
+    async_task = Async.objects.create()
+    Async.objects.filter(pk=async_task.pk).update(
+        updated_time=timezone.now()
+        - TASK_TIMEOUT_SECONDS
+        - datetime.timedelta(seconds=1)
+    )
+
+    AsyncManager._watchdog_loop()
+
+    async_task.refresh_from_db()
+    assert async_task.completed is True
+    assert async_task.was_error is True
+    assert async_task.completed_time is not None
+    assert "heartbeat expired" in async_task.error
+    assert "final outcome is unknown" in async_task.error
+
+    response = admin_client.get(
+        reverse(
+            "api_dispatch_detail",
+            kwargs={"api_name": "v2", "resource_name": "async", "id": async_task.pk},
+        )
+    )
+    assert response.status_code == 200
+    assert response.json()["completed"] is True
+    assert response.json()["was_error"] is True
+    assert response.json()["error_code"] == INTERRUPTED_TASK_ERROR_CODE
+    assert response.json()["error"] == async_task.error
+
+
+@pytest.mark.django_db
+def test_async_resource_does_not_classify_task_error(admin_client: Client) -> None:
+    async_task = Async.objects.create(
+        completed=True,
+        was_error=True,
+        completed_time=timezone.now(),
+    )
+    async_task.error = RuntimeError("Something went wrong")
+    async_task.save()
+
+    response = admin_client.get(
+        reverse(
+            "api_dispatch_detail",
+            kwargs={"api_name": "v2", "resource_name": "async", "id": async_task.pk},
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.json()["error_code"] is None
+    assert response.json()["error"] == async_task.error
+
+
+@pytest.mark.django_db
+def test_watchdog_leaves_fresh_incomplete_task_running() -> None:
+    async_task = Async.objects.create()
+
+    AsyncManager._watchdog_loop()
+
+    async_task.refresh_from_db()
+    assert async_task.completed is False
+    assert async_task.was_error is False
+    assert async_task.completed_time is None
+
+
+@pytest.mark.django_db
+def test_watchdog_deletes_expired_terminal_result() -> None:
+    async_task = Async.objects.create(
+        completed=True,
+        completed_time=timezone.now(),
+    )
+    async_task.result = "Done"
+    async_task.save()
+    Async.objects.filter(pk=async_task.pk).update(
+        completed_time=timezone.now()
+        - MAX_TASK_AGE_SECONDS
+        - datetime.timedelta(seconds=1)
+    )
+
+    AsyncManager._watchdog_loop()
+
+    assert not Async.objects.filter(pk=async_task.pk).exists()


### PR DESCRIPTION
This change prevents interrupted asynchronous operations from disappearing.
When an operation stops heartbeating, Storage Service now keeps its status
record and reports a terminal error with an unknown final outcome.

## How asynchronous operations work

Some Storage Service requests start work in a background thread. Storage
Service records the operation and gives the caller an identifier. The caller
uses that identifier to poll the operation until it finishes:

| Poll result | Meaning |
| --- | --- |
| `completed=false` | Work is still running; poll again |
| `completed=true` | Work ended; read its result or error |
| `404` | No status record exists for that identifier |

A watchdog refreshes the heartbeat of each running operation. If the process
that owns the operation disappears, its heartbeat stops. Storage Service can
then tell that it lost the operation, but not how far the work progressed.

The operation may have produced an external side effect before it stopped.
Retrying it without knowing the outcome could therefore duplicate work.

## The problem

The failure that motivated this change exposed two related gaps:

| Failure mode | Effect | Fixed here? |
| --- | --- | --- |
| A live operation never completes | Caller polls forever | No |
| An operation stops heartbeating | Record deleted; poll returns `404` | Yes |

The first gap tied up the workers handling the polling calls. It requires an
overall observation deadline in the caller.

This PR fixes the second gap. The watchdog previously deleted the status record
after its heartbeat expired. The caller could not tell whether the identifier
was invalid, the result had aged out, or the operation had been interrupted.
The watchdog now retains the record as a terminal interruption.

## Observable behaviour

| State | Before | After |
| --- | --- | --- |
| Running or normal result | Existing `200` | Unchanged |
| Task exception | `200`; terminal error | Unchanged |
| Heartbeat expires | Row deleted; `404` | Retained; `200` terminal error |
| Result retention expires | Row deleted; `404` | Unchanged |

With the repository defaults, heartbeat expiry happens after 120 seconds. The
interrupted result is then retained for approximately 24 hours through the
existing completed-result cleanup path.

The error tells clients that the operation was interrupted, its final outcome
is unknown, and it must not be retried automatically.

## What changed

- Expired incomplete rows become completed errors using the existing async
  error format. No schema or migration change is required.
- The watchdog records local completion and live heartbeats before checking for
  expiry. Row locking and terminal-state checks ensure that a late result cannot
  replace an already recorded terminal state.
- Interrupted operations produce a warning containing their IDs and increment
  the Prometheus counter `async_manager_interrupted_tasks_total`.

## Compatibility and downstream work

The response schema is unchanged, but the behaviour is not fully backward
compatible: an interrupted operation now returns `200` instead of `404`, and
`was_error=true` can now describe a synthetic interruption as well as an
exception raised by the task. Interrupted rows also live until the normal
result-retention deadline, and a late result no longer overwrites them.
