### PR TITLE
Wait for Keycloak before running the integration tests

### DIFF
--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -81,10 +81,8 @@ services:
         condition: service_healthy
       seaweedfs-setup:
         condition: service_completed_successfully
-    links:
-      - "seaweedfs"
-      - "mysql"
-      - "keycloak"
+      keycloak:
+        condition: service_healthy
 
   seaweedfs:
     image: "chrislusf/seaweedfs:4.45"
@@ -166,3 +164,19 @@ services:
       - 8080:8080
     volumes:
       - "./etc/keycloak/realm.json:/opt/keycloak/data/import/realm.json:ro"
+    healthcheck:
+      # The Keycloak image ships no curl/wget, so use bash's /dev/tcp. Gate on
+      # the OIDC discovery document of every realm the tests log in to, which
+      # is only served once `--import-realm` has finished.
+      test:
+        - "CMD-SHELL"
+        - >-
+          for realm in demo secondary; do
+          exec 3<>/dev/tcp/127.0.0.1/8080 &&
+          printf 'GET /realms/%s/.well-known/openid-configuration HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' "$$realm" >&3 &&
+          head -n 1 <&3 | grep -q ' 200 ' || exit 1;
+          done
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,6 +1,40 @@
 ---
 name: ss-integration
 
+configs:
+
+  seaweedfs-setup:
+    content: |
+      set -eu
+      while :; do
+        output=$(
+          weed shell -master=seaweedfs:9333 -filer=seaweedfs:8888 2>&1 <<'EOF' || true
+      s3.iam.import -file=/config/iam.json -apply
+      s3.policy -put -name=AdminAccess -file=/config/policies/admin-access.json
+      s3.policy -put -name=BrowseBuckets -file=/config/policies/browse-buckets.json
+      s3.config.show
+      EOF
+        )
+        printf '%s\n' "$$output"
+
+        if ! printf '%s\n' "$$output" | grep -qi '^error:'; then
+          break
+        fi
+
+        sleep 1
+      done
+
+  keycloak-healthcheck:
+    # The Keycloak image ships no curl/wget, so use bash's /dev/tcp. Gate on
+    # the OIDC discovery document of every realm the tests log in to, which
+    # is only served once `--import-realm` has finished.
+    content: |
+      for realm in demo secondary; do
+        exec 3<>/dev/tcp/127.0.0.1/8080 &&
+        printf 'GET /realms/%s/.well-known/openid-configuration HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' "$$realm" >&3 &&
+        head -n 1 <&3 | grep -q ' 200 ' || exit 1
+      done
+
 services:
 
   archivematica-storage-service:
@@ -108,28 +142,10 @@ services:
   seaweedfs-setup:
     image: "chrislusf/seaweedfs:4.45"
     entrypoint: []
-    command:
-      - "/bin/sh"
-      - "-c"
-      - |
-        set -eu
-        while :; do
-          output=$(
-            weed shell -master=seaweedfs:9333 -filer=seaweedfs:8888 2>&1 <<'EOF' || true
-        s3.iam.import -file=/config/iam.json -apply
-        s3.policy -put -name=AdminAccess -file=/config/policies/admin-access.json
-        s3.policy -put -name=BrowseBuckets -file=/config/policies/browse-buckets.json
-        s3.config.show
-        EOF
-          )
-          printf '%s\n' "$$output"
-
-          if ! printf '%s\n' "$$output" | grep -qi '^error:'; then
-            break
-          fi
-
-          sleep 1
-        done
+    command: ["/bin/sh", "/setup.sh"]
+    configs:
+      - source: "seaweedfs-setup"
+        target: "/setup.sh"
     depends_on:
       seaweedfs:
         condition: service_started
@@ -164,18 +180,11 @@ services:
       - 8080:8080
     volumes:
       - "./etc/keycloak/realm.json:/opt/keycloak/data/import/realm.json:ro"
+    configs:
+      - source: "keycloak-healthcheck"
+        target: "/healthcheck.sh"
     healthcheck:
-      # The Keycloak image ships no curl/wget, so use bash's /dev/tcp. Gate on
-      # the OIDC discovery document of every realm the tests log in to, which
-      # is only served once `--import-realm` has finished.
-      test:
-        - "CMD-SHELL"
-        - >-
-          for realm in demo secondary; do
-          exec 3<>/dev/tcp/127.0.0.1/8080 &&
-          printf 'GET /realms/%s/.well-known/openid-configuration HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' "$$realm" >&3 &&
-          head -n 1 <&3 | grep -q ' 200 ' || exit 1;
-          done
+      test: ["CMD", "bash", "/healthcheck.sh"]
       interval: 5s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
The test container was gated on mysql and seaweedfs being healthy, but keycloak was only listed under `links`, which merely means the container has started. Keycloak (start-dev --import-realm) opens its HTTP listener only after the realm import has finished, so any test that reaches the OIDC login page early enough in the run finds nothing listening and times out. Because pytest-randomly shuffles the test order, this made the OIDC integration tests fail intermittently.

Add a healthcheck to the keycloak service that requests the OIDC discovery document of both realms the tests log in to, and make the test container depend on it being healthy. The Keycloak image ships no curl or wget, so the check uses bash's /dev/tcp. Drop the redundant `links` block now that all dependencies are declared with `depends_on`.